### PR TITLE
New encoder

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -133,7 +133,9 @@ class DataSource(Dataset):
             encoder_class = config['encoder_class']
 
         encoder_attrs = config['encoder_attrs'] if 'encoder_attrs' in config else {}
-
+        print(encoder_attrs)
+        exit()
+        
         encoder_instance = encoder_class()
 
         for attr in encoder_attrs:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -133,9 +133,7 @@ class DataSource(Dataset):
             encoder_class = config['encoder_class']
 
         encoder_attrs = config['encoder_attrs'] if 'encoder_attrs' in config else {}
-        print(encoder_attrs)
-        exit()
-        
+
         encoder_instance = encoder_class()
 
         for attr in encoder_attrs:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -127,12 +127,12 @@ class DataSource(Dataset):
             module = importlib.import_module(path)
             if hasattr(module, 'default'):
                 encoder_class = importlib.import_module(path).default
-                encoder_attrs = {}
             else:
                 raise ValueError('No default encoder for {type}'.format(type=config['type']))
         else:
             encoder_class = config['encoder_class']
-            encoder_attrs = config['encoder_attrs'] if 'encoder_attrs' in config else {}
+
+        encoder_attrs = config['encoder_attrs'] if 'encoder_attrs' in config else {}
 
         encoder_instance = encoder_class()
 

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -39,7 +39,8 @@ class Img2Vec():
         if self.model_name == 'alexnet':
             my_embedding = torch.zeros(1, self.layer_output_size)
         else:
-            my_embedding = torch.zeros(1, self.layer_output_size, 1, 1)
+            #my_embedding = torch.zeros(1, self.layer_output_size, 1, 1)
+            my_embedding = torch.zeros(1, self.layer_output_size)
 
         def copy_data(m, i, o):
             my_embedding.copy_(o.data)
@@ -54,7 +55,8 @@ class Img2Vec():
             if self.model_name == 'alexnet':
                 return my_embedding.numpy()[0, :]
             else:
-                return my_embedding.numpy()[0, :, 0, 0]
+                #return my_embedding.numpy()[0, :, 0, 0]
+                return my_embedding.numpy()[0, :]
 
     def _get_model_and_layer(self, model_name, layer):
         """ Internal method for getting layer from model
@@ -64,16 +66,16 @@ class Img2Vec():
         """
 
         # DEBUGING
-        model = models.resnext50_32x4d(pretrained=True)
+        model = models.mobilenet_v2(pretrained=True)
         if layer == 'default':
-            layer = model._modules.get('avgpool')
-            self.layer_output_size = 2048
+            layer = model._modules.get('classifier')
+            self.layer_output_size = 1000
         else:
             layer = model._modules.get(layer)
 
         return model, layer
-
         # DEBUGING
+
         if model_name == 'resnet-18':
             model = models.resnet18(pretrained=True)
             if layer == 'default':

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -3,11 +3,6 @@ import torch.nn as nn
 import torchvision.models as models
 import torchvision.transforms as transforms
 
-
-class Flatten(nn.Module):
-    def forward(self, input):
-        return input.view(input.size(0), -1)
-
 class ChannelPoolAdaptiveAvg1d(torch.nn.AdaptiveAvgPool1d):
     def forward(self, input):
         n, c = input.size()

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -4,6 +4,19 @@ import torchvision.models as models
 import torchvision.transforms as transforms
 
 
+class Flatten(nn.Module):
+    def forward(self, input):
+        return input.view(input.size(0), -1)
+
+class ChannelPoolAdaptiveAvg1d(torch.nn.AdaptiveAvgPool1d):
+    def forward(self, input):
+        n, c = input.size()
+        input = input.view(n,c,1).permute(0,2,1)
+        pooled =  torch.nn.functional.adaptive_avg_pool1d(input, self.output_size)
+        _, _, c = pooled.size()
+        pooled = pooled.permute(0,2,1)
+        return pooled.view(n,c)
+
 class Img2Vec():
 
     def __init__(self, cuda=False, model='resnet-18', layer='default', layer_output_size=512):
@@ -36,10 +49,10 @@ class Img2Vec():
         """
         image = self.normalize(self.to_tensor(self.scaler(img))).unsqueeze(0).to(self.device)
 
-        if self.model_name in ('alexnet', 'mobilenet'):
+        if self.model_name in ('alexnet', 'mobilenet', 'resnext-50-small'):
             my_embedding = torch.zeros(1, self.layer_output_size)
         elif self.model_name in ('resnet-18', 'resnext-50'):
-            my_embedding = torch.zeros(1, self.layer_output_size, 1, 1)
+            my_embedding = torch.zeros(1, self.layer_output_size)
 
         def copy_data(m, i, o):
             my_embedding.copy_(o.data)
@@ -51,7 +64,7 @@ class Img2Vec():
         if tensor:
             return my_embedding
         else:
-            if self.model_name in ('alexnet', 'mobilenet'):
+            if self.model_name in ('alexnet', 'mobilenet', 'resnext-50-small'):
                 return my_embedding.numpy()[0, :]
             elif self.model_name in ('resnet-18', 'resnext-50'):
                 return my_embedding.numpy()[0, :, 0, 0]
@@ -63,13 +76,17 @@ class Img2Vec():
         :returns: pytorch model, selected layer
         """
 
-        # DEBUGING
-
-        if model_name == 'mobilenet':
-            model = models.mobilenet_v2(pretrained=True)
+        if model_name == 'resnext-50-small':
+            model = models.resnext50_32x4d(pretrained=True)
             if layer == 'default':
-                layer = model._modules.get('classifier')
-                self.layer_output_size = 1000
+                #b = torch.nn.AvgPool2d(kernel_size=(8,8),stride=(4,4))
+                #a = torch.nn.AvgPool2d(kernel_size=(2,2),stride=2)
+                #model.avgpool = b
+                #model.fc = nn.Identity()
+                #layer = model.avgpool
+                model.fc = ChannelPoolAdaptiveAvg1d(output_size=512)
+                layer = model.fc
+                self.layer_output_size = 512
             else:
                 layer = model._modules.get(layer)
 
@@ -95,13 +112,25 @@ class Img2Vec():
 
             return model, layer
 
-        elif model_name == 'alexnet':
+        # @TODO: Fix or remove, this is both slow and inaccurate, not sure where we'd use it
+        if model_name == 'alexnet':
             model = models.alexnet(pretrained=True)
             if layer == 'default':
                 layer = model.classifier[-2]
                 self.layer_output_size = 4096
             else:
                 layer = model.classifier[-layer]
+
+            return model, layer
+
+        # @TODO: Fix or remove, this is slow and not quite as accurate as resnet18, it's a failed experiment trying to end the encoder with the output from an FC rather than output from the pooling layer, might work on it later, if 1 month from now it stays the same, just remove it
+        if model_name == 'mobilenet':
+            model = models.mobilenet_v2(pretrained=True)
+            if layer == 'default':
+                layer = model._modules.get('classifier')
+                self.layer_output_size = 1000
+            else:
+                layer = model._modules.get(layer)
 
             return model, layer
 

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -6,7 +6,7 @@ import torchvision.transforms as transforms
 
 class Img2Vec():
 
-    def __init__(self, cuda=False, model='resnet-18', layer='default', layer_output_size=512):
+    def __init__(self, cuda=False, model='resnet-18', layer='default', layer_output_size=2048):
         """ Img2Vec
         :param cuda: If set to True, will run forward pass on GPU
         :param model: String name of requested model
@@ -16,7 +16,7 @@ class Img2Vec():
         self.device = torch.device("cuda" if cuda else "cpu")
         self.layer_output_size = layer_output_size
         self.model_name = model
-        
+
         self.model, self.extraction_layer = self._get_model_and_layer(model, layer)
 
         self.model = self.model.to(self.device)
@@ -62,11 +62,23 @@ class Img2Vec():
         :param layer: layer as a string for resnet-18 or int for alexnet
         :returns: pytorch model, selected layer
         """
+
+        # DEBUGING
+        model = models.resnext50_32x4d(pretrained=True)
+        if layer == 'default':
+            layer = model._modules.get('avgpool')
+            self.layer_output_size = 2048
+        else:
+            layer = model._modules.get(layer)
+
+        return model, layer
+
+        # DEBUGING
         if model_name == 'resnet-18':
             model = models.resnet18(pretrained=True)
             if layer == 'default':
                 layer = model._modules.get('avgpool')
-                self.layer_output_size = 512
+                self.layer_output_size = 2048
             else:
                 layer = model._modules.get(layer)
 

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -65,7 +65,7 @@ class Img2Vec():
 
         # DEBUGING
 
-        if model_name = 'mobilenet':
+        if model_name == 'mobilenet':
             model = models.mobilenet_v2(pretrained=True)
             if layer == 'default':
                 layer = model._modules.get('classifier')
@@ -96,6 +96,8 @@ class Img2Vec():
             return model, layer
 
         elif model_name == 'alexnet':
+            print('USING ALEXNET !')
+            exit()
             model = models.alexnet(pretrained=True)
             if layer == 'default':
                 layer = model.classifier[-2]

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -96,8 +96,6 @@ class Img2Vec():
             return model, layer
 
         elif model_name == 'alexnet':
-            print('USING ALEXNET !')
-            exit()
             model = models.alexnet(pretrained=True)
             if layer == 'default':
                 layer = model.classifier[-2]

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -21,9 +21,9 @@ class Img2VecEncoder:
         """
         if self._model is None:
             if self.aim == 'speed':
-                self._model = Img2Vec(model='alexnet')
+                self._model = Img2Vec(model='resnet18')
             elif self.aim == 'balance':
-                self._model = Img2Vec(model='resnet-18')
+                self._model = Img2Vec(model='resnext-50-small')#(model='resnet-18')
             elif self.aim == 'accuracy':
                 self._model = Img2Vec(model='resnext-50')
             else:

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -8,8 +8,8 @@ class Img2VecEncoder:
 
     def __init__(self):
         self._model = None
-        # I think we should make this an enum, something like: fast, balanced, accurate
-        self.encoding_aim = 'balanced'
+        # I think we should make this an enum, something like: speed, balance, accuracy
+        self.aim = 'balance'
         self._pytorch_wrapper = torch.FloatTensor
 
     def encode(self, images):
@@ -20,11 +20,11 @@ class Img2VecEncoder:
             :return: a torch.floatTensor
         """
         if self._model is None:
-            if self.encoding_aim == 'fast':
+            if self.aim == 'speed':
                 self._model = Img2Vec(model='alexnet')
-            elif self.encoding_aim == 'balanced':
+            elif self.aim == 'balance':
                 self._model = Img2Vec(model='resnet-18')
-            elif self.encoding_aim == 'accurate':
+            elif self.aim == 'accuracy':
                 self._model = Img2Vec(model='resnext-50')
             else:
                 self._model = Img2Vec()

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -22,7 +22,7 @@ class Img2VecEncoder:
         if self._model is None:
             if self.speed == 'fast':
                 self._model = Img2Vec(model='alexnet')
-            elif self.speed == 'balacned':
+            elif self.speed == 'balanced':
                 self._model = Img2Vec(model='resnet-18')
             elif self.speed == 'accurate':
                 self._model = Img2Vec(model='resnext-50')

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -9,7 +9,7 @@ class Img2VecEncoder:
     def __init__(self):
         self._model = None
         # I think we should make this an enum, something like: fast, balanced, accurate
-        self.speed = 'balanced'
+        self.encoding_aim = 'balanced'
         self._pytorch_wrapper = torch.FloatTensor
 
     def encode(self, images):
@@ -20,11 +20,11 @@ class Img2VecEncoder:
             :return: a torch.floatTensor
         """
         if self._model is None:
-            if self.speed == 'fast':
+            if self.encoding_aim == 'fast':
                 self._model = Img2Vec(model='alexnet')
-            elif self.speed == 'balanced':
+            elif self.encoding_aim == 'balanced':
                 self._model = Img2Vec(model='resnet-18')
-            elif self.speed == 'accurate':
+            elif self.encoding_aim == 'accurate':
                 self._model = Img2Vec(model='resnext-50')
             else:
                 self._model = Img2Vec()

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -6,8 +6,10 @@ from lightwood.encoders.image.helpers.img_to_vec import Img2Vec
 
 class Img2VecEncoder:
 
-    def __init__(self, is_target = False):
+    def __init__(self):
         self._model = None
+        # I think we should make this an enum, something like: fast, balanced, accurate
+        self.speed = 'balanced'
         self._pytorch_wrapper = torch.FloatTensor
 
     def encode(self, images):
@@ -18,7 +20,14 @@ class Img2VecEncoder:
             :return: a torch.floatTensor
         """
         if self._model is None:
-            self._model = Img2Vec()
+            if self.speed == 'fast':
+                self._model = Img2Vec(model='alexnet')
+            elif self.speed == 'balacned':
+                self._model = Img2Vec(model='resnet-18')
+            elif self.speed == 'accurate':
+                self._model = Img2Vec(model='resnext-50')
+            else:
+                self._model = Img2Vec()
 
         pics = []
         for image in images:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ numpy >= 1.16.2
 pandas >= 0.23.4
 schema >= 0.6.8
 sklearn >= 0.0
-torch == 1.0.1
-torchvision == 0.2.1
+torch == 1.1.0
+torchvision == 0.3
 xlrd >= 1.0.0


### PR DESCRIPTION
* Fixed a bug where `encoder_attrs` weren't passed correctly
* Added an `aim` element (can be passed as part of `encoder_attrs`) for image_to_vec that can be specified as `speed`, `balance` or `accuracy` based on which we can pick an underlying encoder (maybe factoring in additional info about the user's GPU, RAM and CPU in cases where GPU is missing or disabled)
* Added two new pre-trained models to serve as encoders/backbone for images, resnext50 and mobilenet v2. The laters performance is surprisingly poor (slightly slower and slightly less accurate than resnet18, the former yields amazing performance, at least on a sample of the cifrar 100 dataset, but makes training take forever).

In the future I will experiment with different resnext models or maybe increasing the window size of the final pooling layer for resnext to yield 512 features (same as resnet18), and see if that helps bring up with training speed.