### PR TITLE
New MLP mixer

### DIFF
--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -58,7 +58,7 @@ class Predictor:
 
         self.train_accuracy = None
 
-    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 100):
+    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20):
         """
         Train and save a model (you can use this to retrain model from data)
 
@@ -144,7 +144,6 @@ class Predictor:
 
             # see if it needs to be evaluated
             if epoch >= eval_next_on_epoch and test_data_ds:
-
                 tmp_next = eval_next_on_epoch + eval_every_x_epochs
                 eval_next_on_epoch = tmp_next
 
@@ -195,6 +194,10 @@ class Predictor:
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break
+                print('\n\n-------------------\n\n')
+                print(delta_mean)
+                print(len(error_delta_buffer))
+                print(test_error)
 
 
         # make sure that we update the encoders, we do this, so that the predictor or parent object can pickle the mixers

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -199,11 +199,6 @@ class Predictor:
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break
-                    
-                print('\n\n-------------------\n\n')
-                print(delta_mean)
-                print(len(error_delta_buffer))
-                print(test_error)
 
 
         # make sure that we update the encoders, we do this, so that the predictor or parent object can pickle the mixers

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -59,7 +59,7 @@ class Predictor:
 
         self.train_accuracy = None
 
-    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20, stop_training_after_seconds=800):
+    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20, stop_training_after_seconds=3600 * 24 * 5):
         """
         Train and save a model (you can use this to retrain model from data)
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -132,6 +132,7 @@ class Predictor:
         delta_mean = 0
         last_test_error = None
         lowest_error = None
+        lowest_error_epoch = None
         last_good_model = None
 
         #iterate over the iter_fit and see what the epoch and mixer error is
@@ -152,12 +153,14 @@ class Predictor:
                 # initialize lowest_error_variable if not initialized yet
                 if lowest_error is None:
                     lowest_error = test_error
+                    lowest_error_epoch = epoch
                     is_lowest_error = True
 
                 else:
                     # define if this is the lowest test error we have had thus far
                     if test_error < lowest_error:
                         lowest_error = test_error
+                        lowest_error_epoch = epoch
                         is_lowest_error = True
                     else:
                         is_lowest_error = False
@@ -190,7 +193,7 @@ class Predictor:
                     callback_on_iter(epoch, mix_error, test_error, delta_mean)
 
                 # if the model is overfitting that is, that the the test error is becoming greater than the train error
-                if delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1:
+                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0005) or (lowest_error_epoch + round(max(eval_every_x_epochs+2,epoch*1.2)) < epoch):
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -24,11 +24,8 @@ class DefaultNet(nn.Module):
                 nn.Linear(2*input_size, output_size)
             )
         else:
-            print('HERE 2')
-            #deep_layer_in = round(min(input_size/2, max(output_size*16,input_size/16)))
-            #deep_layer_out = round(min(deep_layer_in,output_size*2))
-            deep_layer_in = 20
-            deep_layer_out = 10
+            deep_layer_in = round(min(128, max(output_size*4,input_size/4)))
+            deep_layer_out = round(min(deep_layer_in,output_size*2))
             self.net = nn.Sequential(
                 nn.Linear(input_size, deep_layer_in),
                 nn.SELU(),

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -16,14 +16,14 @@ class DefaultNet(nn.Module):
         input_size = len(input_sample)
         output_size = len(output_sample)
 
-        if input_size <= output_size or input_size < 3 * pow(10,3):
+        if input_size < 3 * pow(10,3):
             self.net = nn.Sequential(
                 nn.Linear(input_size, 2*input_size),
                 nn.ReLU(),
                 nn.Linear(2*input_size, output_size)
             )
         else:
-            deep_layer_in = round(min(128, max(output_size*4,input_size/4)))
+            deep_layer_in = 128
             deep_layer_out = round(min(deep_layer_in,output_size*2))
             self.net = nn.Sequential(
                 nn.Linear(input_size, deep_layer_in),

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -16,14 +16,24 @@ class DefaultNet(nn.Module):
         input_size = len(input_sample)
         output_size = len(output_sample)
 
-        self.net = nn.Sequential(
-
-            nn.Linear(input_size, 2*input_size),
-            nn.ReLU(),
-            nn.Linear(2*input_size, output_size)
-
-        )
-
+        if input_size <= output_size or input_size < 3 * pow(10,1):
+            print('HERE 1')
+            self.net = nn.Sequential(
+                nn.Linear(input_size, 2*input_size),
+                nn.ReLU(),
+                nn.Linear(2*input_size, output_size)
+            )
+        else:
+            print('HERE 2')
+            deep_layer_in = round(min(input_size/2, max(output_size*16,input_size/16)))
+            deep_layer_out = round(min(deep_layer_in,output_size*2))
+            self.net = nn.Sequential(
+                nn.Linear(input_size, deep_layer_in),
+                nn.SELU(),
+                nn.Linear(deep_layer_in, deep_layer_out),
+                nn.SELU(),
+                nn.Linear(deep_layer_out, output_size)
+            )
 
 
         if CONFIG.USE_CUDA:
@@ -40,6 +50,6 @@ class DefaultNet(nn.Module):
 
         if CONFIG.USE_CUDA:
             input.cuda()
-        
+
         output = self.net(input)
         return output

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -25,8 +25,10 @@ class DefaultNet(nn.Module):
             )
         else:
             print('HERE 2')
-            deep_layer_in = round(min(input_size/2, max(output_size*16,input_size/16)))
-            deep_layer_out = round(min(deep_layer_in,output_size*2))
+            #deep_layer_in = round(min(input_size/2, max(output_size*16,input_size/16)))
+            #deep_layer_out = round(min(deep_layer_in,output_size*2))
+            deep_layer_in = 20
+            deep_layer_out = 10
             self.net = nn.Sequential(
                 nn.Linear(input_size, deep_layer_in),
                 nn.SELU(),

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -16,8 +16,7 @@ class DefaultNet(nn.Module):
         input_size = len(input_sample)
         output_size = len(output_sample)
 
-        if input_size <= output_size or input_size < 3 * pow(10,1):
-            print('HERE 1')
+        if input_size <= output_size or input_size < 3 * pow(10,3):
             self.net = nn.Sequential(
                 nn.Linear(input_size, 2*input_size),
                 nn.ReLU(),

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -102,7 +102,6 @@ class NnMixer:
             # forward + backward + optimize
             outputs = self.net(inputs)
             loss = self.criterion(outputs, labels)
-            loss.backward()
 
             # print statistics
             running_loss += loss.item()
@@ -132,7 +131,6 @@ class NnMixer:
         :param ds:
         :return:
         """
-
         self.input_column_names = self.input_column_names if self.input_column_names is not None else ds.get_feature_names(
             'input_features')
         self.output_column_names = self.output_column_names if self.output_column_names is not None else ds.get_feature_names(


### PR DESCRIPTION
* Added a new MLP mixer which seems to yield better or similar performance on existing datasets and is currently used when the input is > 3000 values. The purpose of this is to allow running datasets where input features are encoded into very long input tensors. This reduced training for the non-public dataset we were concerned about (see slack) from 2+ days and counting to ~20 minutes.

* Added an argument to `.learn` that allows us to stop training after a given number of second (the argument is `stop_training_after_seconds` and defaults to 5 days)

* Added a condition that allows the model to stop training in the edge case where it happens to get close to 100% performance on both the train and test datasets.

* Added a condition that allows the model to stop training if no new lowest error is found after a relatively large number of epochs. Arguable if this is the approach we want to take in the long run, it might be worth trying a new mixer, reseting training with different initial weights or changing hyperparams instead. However, it is a quick fix to the issue of models that can't either converge nor get biased to the training set.
 