### PR TITLE
CI tests & Install fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ cache: pip
 install:
   - pip3 install --upgrade pip
   #- travis_wait pip3 install -e .
-  - travis_wait if [ "$TRAVIS_OS_NAME" = "windows" ]; then python setup.py install; fi
-  - travis_wait if [ "$TRAVIS_OS_NAME" != "windows" ]; then python3 setup.py install; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python setup.py install; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 setup.py install; fi
   - travis_wait pip3 install pytest
 
 before_script: cd tests/ci_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ cache: pip
 install:
   - travis_wait pip3 install -e .
   - travis_wait pip3 install pytest
+
+before_script: cd tests/ci_tests
 # run tests
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - travis_wait if [ "$TRAVIS_OS_NAME" = "windows" ]; then python full_test.py; fi
-  - travis_wait if [ "$TRAVIS_OS_NAME" != "windows" ]; then python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; travis_wait then python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; travis_wait then python full_test.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 matrix:
   include:
-    - name: "Python 3.7.3 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.7.3
-      dist: xenial
-      sudo: true
+#    - name: "Python 3.7.3 on Ubuntu 16.0.4"
+#      os: linux
+#      python: 3.7.3
+#      dist: xenial
+#      sudo: true
 
-    - name: "Python 3.7.2 on OSX"
-      os: osx
-      language: shell
-      dist: xcode10.2
-      sudo: true
+#    - name: "Python 3.7.2 on OSX"
+#      os: osx
+#      language: shell
+#      dist: xcode10.2
+#      sudo: true
 
     - name: "Python 3.7.3 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ matrix:
   include:
     - name: "Python 3.7.3 on Ubuntu 16.0.4"
       os: linux
-      - python: 3.7.3
-      - python: 3.6
+      python: 3.7.3
+      dist: xenial
+      sudo: true
+
+    - name: "Python 3.6 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.6
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - pytest
+  - python3 full_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ cache: pip
 # install dependencies
 install:
   - pip3 install --upgrade pip
-  - travis_wait pip3 install -e .
+  #- travis_wait pip3 install -e .
+  - travis_wait python3 setup.py install
   - travis_wait pip3 install pytest
 
 before_script: cd tests/ci_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
 cache: pip
 # install dependencies
 install:
-  - travis_wait pip install lightwood
+  - travis_wait pip3 install -e .
+  - travis_wait pip3 install pytest
 # run tests
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: python
 matrix:
   include:
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
+    - name: "Python 3.7.3 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.7.3
       dist: xenial
-      sudo: true 
+      sudo: true
+
+    - name: "Python 3.7.2 on OSX"
+      os: osx
+      language: shell
+      dist: xcode10.2
+
+    - name: "Python 3.7.3 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+
 cache: pip
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 matrix:
   include:
-#    - name: "Python 3.7.3 on Ubuntu 16.0.4"
-#      os: linux
-#      python: 3.7.3
-#      dist: xenial
-#      sudo: true
+    - name: "Python 3.7.3 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.7.3
+      dist: xenial
+      sudo: true
 
-#    - name: "Python 3.7.2 on OSX"
-#      os: osx
-#      language: shell
-#      dist: xcode10.2
-#      sudo: true
+    - name: "Python 3.7.2 on OSX"
+      os: osx
+      language: shell
+      dist: xcode10.2
+      sudo: true
 
     - name: "Python 3.7.3 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 matrix:
   include:
-    - name: "Python 3.7.3 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.7.3
-      dist: xenial
-      sudo: true
+    #- name: "Python 3.7.3 on Ubuntu 16.0.4"
+    #  os: linux
+    #  python: 3.7.3
+    #  dist: xenial
+    #  sudo: true
 
     - name: "Python 3.7.2 on OSX"
       os: osx
@@ -13,23 +13,25 @@ matrix:
       dist: xcode10.2
       sudo: true
 
-    - name: "Python 3.7.3 on Windows"
-      os: windows           # Windows 10.0.17134 N/A Build 17134
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      before_install:
-        - choco install python
-        - python -m pip install --upgrade pip
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    #- name: "Python 3.7.3 on Windows"
+    #  os: windows           # Windows 10.0.17134 N/A Build 17134
+    #  language: shell       # 'language: python' is an error on Travis CI Windows
+    #  before_install:
+    #    - choco install python
+    #    - python -m pip install --upgrade pip
+    #  env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 cache: pip
 # install dependencies
 install:
   - pip3 install --upgrade pip
   #- travis_wait pip3 install -e .
-  - travis_wait python setup.py install
+  - travis_wait if [ "$TRAVIS_OS_NAME" = "windows" ]; then python setup.py install; fi
+  - travis_wait if [ "$TRAVIS_OS_NAME" != "windows" ]; then python3 setup.py install; fi
   - travis_wait pip3 install pytest
 
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - python full_test.py
+  - travis_wait if [ "$TRAVIS_OS_NAME" = "windows" ]; then python full_test.py; fi
+  - travis_wait if [ "$TRAVIS_OS_NAME" != "windows" ]; then python full_test.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; travis_wait then python full_test.py; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; travis_wait then python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python full_test.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ before_script: cd tests/ci_tests
 # run tests
 script:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache: pip
 install:
   - pip3 install --upgrade pip
   #- travis_wait pip3 install -e .
-  - travis_wait python3 setup.py install
+  - travis_wait python setup.py install
   - travis_wait pip3 install pytest
 
 before_script: cd tests/ci_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ matrix:
   include:
     - name: "Python 3.7.3 on Ubuntu 16.0.4"
       os: linux
-      python: 3.7.3
+      - python: 3.7.3
+      - python: 3.6
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - python3 full_test.py
+  - python full_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       os: osx
       language: shell
       dist: xcode10.2
+      sudo: true
 
     - name: "Python 3.7.3 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
@@ -23,6 +24,7 @@ matrix:
 cache: pip
 # install dependencies
 install:
+  - pip3 install --upgrade pip
   - travis_wait pip3 install -e .
   - travis_wait pip3 install pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 matrix:
   include:
-    #- name: "Python 3.7.3 on Ubuntu 16.0.4"
-    #  os: linux
-    #  python: 3.7.3
-    #  dist: xenial
-    #  sudo: true
+    - name: "Python 3.7.3 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.7.3
+      dist: xenial
+      sudo: true
 
     - name: "Python 3.7.2 on OSX"
       os: osx
@@ -13,13 +13,13 @@ matrix:
       dist: xcode10.2
       sudo: true
 
-    #- name: "Python 3.7.3 on Windows"
-    #  os: windows           # Windows 10.0.17134 N/A Build 17134
-    #  language: shell       # 'language: python' is an error on Travis CI Windows
-    #  before_install:
-    #    - choco install python
-    #    - python -m pip install --upgrade pip
-    #  env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    - name: "Python 3.7.3 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 cache: pip
 # install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
-![Lightwood](https://mindsdb.github.io/lightwood/assets/logo.png) 
+![Lightwood](https://mindsdb.github.io/lightwood/assets/logo.png)
+#
 
+[![Build Status](https://travis-ci.org/mindsdb/lightwood.svg?branch=master)](https://travis-ci.org/mindsdb/lightwood)
+[![PyPI version](https://badge.fury.io/py/lightwood.svg)](https://badge.fury.io/py/lightwood)
 
 Lightwood has two objectives:
 
@@ -27,7 +30,7 @@ sensor3_predictor = Predictor(output=['sensor3']).learn(from_data=pandas.read_cs
 
 ```
 
-### Predict 
+### Predict
 
 You can now given new readings from *sensor1* and *sensor2* predict what *sensor3* will be.
 
@@ -36,4 +39,3 @@ You can now given new readings from *sensor1* and *sensor2* predict what *sensor
 prediction = sensor3_predictor.predict(when={'sensor1':1, 'sensor2':-1})
 
 ```
-

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,0 +1,10 @@
+__title__ = 'lightwood'
+__package_name__ = 'mindsdb'
+__version__ = '0.7.1'
+__description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
+__email__ = "jorge@mindsdb.com"
+__author__ = 'MindsDB Inc'
+__github__ = 'https://github.com/mindsdb/lightwood'
+__pypi__ = 'https://pypi.org/project/lightwood'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2019- mindsdb'

--- a/lightwood/__init__.py
+++ b/lightwood/__init__.py
@@ -1,4 +1,6 @@
 import sys
+
+
 if sys.version_info < (3,3):
     sys.exit('Sorry, For Lightwood Python < 3.3 is not supported')
 
@@ -8,5 +10,3 @@ from lightwood.api.predictor import Predictor
 from lightwood.mixers import BUILTIN_MIXERS
 
 COLUMN_DATA_TYPES = CONST.COLUMN_DATA_TYPES
-
-

--- a/lightwood/version.py
+++ b/lightwood/version.py
@@ -1,1 +1,0 @@
-lightwood_version = '0.6.9'

--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,15 @@ if os == 'Darwin':
 
 # Windows specific requirements
 if os == 'Windows':
-    print('HERE !')
     requirements = remove_requirement(requirements,'torch')
     requirements = remove_requirement(requirements,'torchvision')
-    requirements.append('torch == 1.1.0')
-    requirements.append('torchvision == 0.3')
+    requirements.append('torch == 1.1.0.0')
+    requirements.append('torchvision == 0.3.0.0')
 
-    dependency_links.append('https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-win_amd64.whl#egg=torch-1.1.0')
-    dependency_links.append('https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp37-cp37m-win_amd64.whl#egg=torchvision-0.3')
-
+    #dependency_links.append('https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-win_amd64.whl#egg=torch-1.1.0.0')
+    #dependency_links.append('https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp37-cp37m-win_amd64.whl#egg=torchvision-0.3.0.0')
+    dependency_links.append('https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl#egg=torch-1.1.0.0')
+    dependency_links.append('https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl#egg=torchvision-0.3.0.0')
 
 setuptools.setup(
     name="lightwood",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if os == 'Darwin':
 
 # Windows specific requirements
 if os == 'Windows':
+    print('HERE !')
     requirements = remove_requirement(requirements,'torch')
     requirements = remove_requirement(requirements,'torchvision')
     requirements.append('torch == 1.1.0')

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,13 @@ if os == 'Darwin':
 # Windows specific requirements
 if os == 'Windows':
     requirements = remove_requirement(requirements,'torch')
+    requirements = remove_requirement(requirements,'torchvision')
     requirements.append('torch == 1.1.0')
+    requirements.append('torchvision == 0.3')
+
+    dependency_links.append('https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-win_amd64.whl#egg=torch-1.1.0')
+    dependency_links.append('https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp37-cp37m-win_amd64.whl#egg=torchvision-0.3')
+
 
 setuptools.setup(
     name="lightwood",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ import platform
 import setuptools
 
 
+about = {}
+with open("mindsdb/__about__.py") as fp:
+    exec(fp.read(), about)
+
+
 def remove_requirement(requirements, name):
     return [x for x in requirements if name != x.split(' ')[0]]
 
@@ -38,14 +43,16 @@ if os == 'Windows':
     dependency_links.append('https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl#egg=torchvision-0.3.0.0')
 
 setuptools.setup(
-    name="lightwood",
-    version='0.7.1',
-    author="MindsDB Inc",
-    author_email="jorge@mindsdb.com",
-    description="Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects. ",
+    name=about['__title__'],
+    version=about['__version__'],
+    url=about['__github__'],
+    download_url=about['__pypi__'],
+    license=about['__license__'],
+    author=about['__author__'],
+    author_email=about['__email__'],
+    description=about['__description__'],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mindsdb/lightwood",
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dependency_links=dependency_links,

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,42 @@
+import os
+import platform
 import setuptools
-from lightwood.version import lightwood_version
+
+
+def remove_requirement(requirements, name):
+    return [x for x in requirements if name != x.split(' ')[0]]
+
+os = platform.system()
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 with open('requirements.txt') as req_file:
     requirements = req_file.read().splitlines()
-print(lightwood_version)
+
+# Linux specific requirements
+if os == 'Linux':
+    requirements = remove_requirement(requirements,'torch')
+    requirements.append('torch == 1.1.0')
+
+# OSX specific requirements
+if os == 'Darwin':
+    requirements = requirements
+
+# Windows specific requirements
+if os == 'Windows':
+    requirements = remove_requirement(requirements,'torch')
+    requirements.append('torch == 1.1.0')
+
 setuptools.setup(
     name="lightwood",
-    version=lightwood_version,
+    version='0.7.1',
     author="MindsDB Inc",
     author_email="jorge@mindsdb.com",
-    description="MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects. ",
+    description="Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects. ",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mindsdb/mindsdb",
+    url="https://github.com/mindsdb/lightwood",
     packages=setuptools.find_packages(),
     install_requires=requirements,
     classifiers=(
@@ -22,5 +44,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ),
-    python_requires=">=3.3"
+    python_requires=">=3.6"
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ with open("README.md", "r") as fh:
 with open('requirements.txt') as req_file:
     requirements = req_file.read().splitlines()
 
+dependency_links = []
+
 # Linux specific requirements
 if os == 'Linux':
     requirements = remove_requirement(requirements,'torch')
@@ -39,6 +41,7 @@ setuptools.setup(
     url="https://github.com/mindsdb/lightwood",
     packages=setuptools.find_packages(),
     install_requires=requirements,
+    dependency_links=dependency_links,
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 
 about = {}
-with open("mindsdb/__about__.py") as fp:
+with open("lightwood/__about__.py") as fp:
     exec(fp.read(), about)
 
 

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -1,0 +1,31 @@
+import os
+import pathlib
+import pytest
+
+
+import pandas as pd
+from lightwood import Predictor
+
+####################
+config = {'input_features': [{'name': 'number_of_rooms', 'type': 'numeric'},
+                    {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
+                    {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
+                    {'name': 'neighborhood', 'type': 'categorical'}],
+ 'output_features': [{'name': 'rental_price', 'type': 'numeric'}]}
+
+
+
+df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
+
+predictor = Predictor(config)
+
+def iter_function(epoch, error, test_error, test_error_gradient):
+    print(
+        'epoch: {iter}, error: {error}, test_error: {test_error}, test_error_gradient: {test_error_gradient}, accuracy: {accuracy}'.format(
+            iter=epoch, error=error, test_error=test_error, test_error_gradient=test_error_gradient,
+            accuracy=predictor.train_accuracy))
+
+
+predictor.learn(from_data=df, callback_on_iter=iter_function, eval_every_x_epochs=10)
+
+print(predictor.predict(when={'number_of_rooms':3, 'number_of_bathrooms':2, 'sqft':700, 'location':'great'}))

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import pytest
 
 

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 
 
 import pandas as pd


### PR DESCRIPTION
* Added CI test and a .travis config to run it on all supported platform (could be useful to also add python 3.6 and 3.5 on linux if we wish to support them)
* Added platform specific dependencies in setup.py to allow the install to work on windows and linux.
* Removed a way of sourcing the version in setup.py which would cause a fresh install via pip3 install -e . to fail (since a dependency required to import the file in which the version resided needed to be installed beforehand).
* Added buttons for version & tests to README