### PR TITLE
Examples

### DIFF
--- a/docs/examples/cifar_100.py
+++ b/docs/examples/cifar_100.py
@@ -1,0 +1,36 @@
+import requests
+import os
+import tarfile
+import pandas as pd
+from lightwood import Predictor
+
+
+with open(f'cifar_100.tar.gz', 'wb') as f:
+    r = requests.get(f'https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/cifar_100.tar.gz')
+    f.write(r.content)
+
+try:
+    tar = tarfile.open(f'cifar_100.tar.gz', 'r:gz')
+except:
+    tar = tarfile.open(f'cifar_100.tar.gz', 'r')
+
+tar.extractall()
+tar.close()
+
+os.chdir('cifar_100')
+
+config = {'input_features': [{'name': 'image_path', 'type': 'image', 'encoder_attrs': {'aim': 'speed'}}], 'output_features': [{'name': 'superclass', 'type': 'categorical', 'encoder_attrs': {}}, {'name': 'class', 'type': 'categorical', 'encoder_attrs': {}}]}
+predictor = Predictor(config)
+
+
+def iter_function(epoch, error, test_error, test_error_gradient):
+    print(
+        'epoch: {iter}, error: {error}, test_error: {test_error}, test_error_gradient: {test_error_gradient}, accuracy: {accuracy}'.format(
+            iter=epoch, error=error, test_error=test_error, test_error_gradient=test_error_gradient,
+            accuracy=predictor.train_accuracy))
+
+
+predictor.learn(from_data=pd.read_csv('train_sample.csv'), callback_on_iter=iter_function, eval_every_x_epochs=1)
+
+results = predictor.predict(when_data=pd.read_csv('test_sample.csv'))
+print(results)

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -47,7 +47,7 @@ class Img2Vec():
         if self.model_name in ('alexnet', 'mobilenet', 'resnext-50-small'):
             my_embedding = torch.zeros(1, self.layer_output_size)
         elif self.model_name in ('resnet-18', 'resnext-50'):
-            my_embedding = torch.zeros(1, self.layer_output_size)
+            my_embedding = torch.zeros(1, self.layer_output_size, 1, 1)
 
         def copy_data(m, i, o):
             my_embedding.copy_(o.data)

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -21,7 +21,7 @@ class Img2VecEncoder:
         """
         if self._model is None:
             if self.aim == 'speed':
-                self._model = Img2Vec(model='resnet18')
+                self._model = Img2Vec(model='resnet-18')
             elif self.aim == 'balance':
                 self._model = Img2Vec(model='resnext-50-small')#(model='resnet-18')
             elif self.aim == 'accuracy':


### PR DESCRIPTION
* Added cifrar 100 example for using lightwood, this same "template" can be more or less used for all other examples in the mindsdb-example-data bucket, however, I'm waiting until I have a few more datasets until adding more to lightwood.

* Small fix in image encoders so that resnet-18 and normal resnext-50 can work properly once again