### PR TITLE
Publishing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,24 @@
 language: python
 matrix:
   include:
-    # - name: "Python 3.7.3 on Ubuntu 16.0.4"
-      # os: linux
-      # python: 3.7.3
-      # dist: xenial
-      # sudo: true
-      # env:
-        # DEPLOYMENT_ENV="true"
-#
-    # - name: "Python 3.6 on Ubuntu 16.0.4"
-      # os: linux
-      # python: 3.6
-      # dist: xenial
-      # sudo: true
-#
-    # - name: "Python 3.7.2 on OSX"
-      # os: osx
-      # language: shell
-      # dist: xcode10.2
+    - name: "Python 3.7.3 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.7.3
+      dist: xenial
+      sudo: true
+      env:
+        DEPLOYMENT_ENV="true"
 
+    - name: "Python 3.6 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.6
+      dist: xenial
+      sudo: true
+
+    - name: "Python 3.7.2 on OSX"
+      os: osx
+      language: shell
+      dist: xcode10.2
 
     - name: "Python 3.7.3 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - echo "CHANGEd THIS STEP TO TEST DEPLOY"
+  - echo "fasf THIS STEP TO TEST DEPLOY"
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,5 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
-      - branch: publishing_changes
-      - condition: $DEPLOYMENT_ENV = true
+      branch: publishing_changes
+      condition: $DEPLOYMENT_ENV = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ matrix:
 cache: pip
 # install dependencies
 install:
-  - pip3 install --upgrade pip
-  - travis_wait pip3 install -e .
+  -
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then pip install --upgrade pip; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; pip3 install --upgrade pip; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
-  - travis_wait pip3 install pytest
   - if [ "$DEPLOYMENT_ENV" = "true" ]; then travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi
 
 before_script: cd tests/ci_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   #- travis_wait pip3 install pytest
-  #- travis_wait pip3 install mkdocs
+  - travis_wait pip3 install mkdocs
 
 before_script: cd tests/ci_tests
 # run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,5 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
-        - branch: publishing_changes
-        - condition: $DEPLOYMENT_ENV = true
+      - branch: publishing_changes
+      - condition: $DEPLOYMENT_ENV = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - DEPLOYMENT_ENV=true
+        DEPLOYMENT_ENV=true
 
     # - name: "Python 3.6 on Ubuntu 16.0.4"
       # os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - echo "fasf THIS STEP TO TEST DEPLOY"
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,10 @@ script:
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
 
 before_deploy:
+  - cd docs
   - mkdocs build --verbose --clean --strict
-
+  - cd ..
+  
 # deploy to pip
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,42 +9,42 @@ matrix:
       env:
         DEPLOYMENT_ENV="true"
 
-    # - name: "Python 3.6 on Ubuntu 16.0.4"
-      # os: linux
-      # python: 3.6
-      # dist: xenial
-      # sudo: true
-#
-    # - name: "Python 3.7.2 on OSX"
-      # os: osx
-      # language: shell
-      # dist: xcode10.2
-      # sudo: true
-#
-    # - name: "Python 3.7.3 on Windows"
-      # os: windows           # Windows 10.0.17134 N/A Build 17134
-      # language: shell       # 'language: python' is an error on Travis CI Windows
-      # before_install:
-        # - choco install python
-        # - python -m pip install --upgrade pip
+    - name: "Python 3.6 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.6
+      dist: xenial
+      sudo: true
+
+    - name: "Python 3.7.2 on OSX"
+      os: osx
+      language: shell
+      dist: xcode10.2
+      sudo: true
+
+    - name: "Python 3.7.3 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python
+
 
 
 cache: pip
 # install dependencies
 install:
-  #- pip3 install --upgrade pip
-  #- travis_wait pip3 install -e .
-  #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
-  #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
-  #- travis_wait pip3 install pytest
+  - pip3 install --upgrade pip
+  - travis_wait pip3 install -e .
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
+  - travis_wait pip3 install pytest
   - if [ "$DEPLOYMENT_ENV" = "true" ]; then travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi
 
 before_script: cd tests/ci_tests
 # run tests
 script:
   - echo "fasf THIS STEP TO TEST DEPLOY"
-  #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
-  #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
   - cd ../..
 
 before_deploy:
@@ -55,18 +55,17 @@ before_deploy:
 
 # deploy to pip
 deploy:
-  # - provider: pypi
-    # user: "mindsdb_sysadmin"
-    # password: $PYPI_SYSADMIN_PASSWORD
-    # on:
-      # - branch: publishing_changes
-      # - condition: $DEPLOYMENT_ENV = true
-
+  - provider: pypi
+    user: "mindsdb_sysadmin"
+    password: $PYPI_SYSADMIN_PASSWORD
+    on:
+      branch: master
+      condition: $DEPLOYMENT_ENV = "true"
 
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
-      branch: publishing_changes
+      branch: master
       condition: $DEPLOYMENT_ENV = "true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,12 @@ matrix:
 cache: pip
 # install dependencies
 install:
-  - echo "$PYPI_SYSADMIN_PASSWORD" = "glorpzorp"
   #- pip3 install --upgrade pip
   #- travis_wait pip3 install -e .
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   #- travis_wait pip3 install pytest
-  - travis_wait pip3 install mkdocs
+  - travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments
 
 before_script: cd tests/ci_tests
 # run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   #- travis_wait pip3 install pytest
-  - if [ "$DEPLOYMENT_ENV" = "true" ]; travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments
+  - if [ "$DEPLOYMENT_ENV" = "true" ]; travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi
 
 before_script: cd tests/ci_tests
 # run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
       python: 3.7.3
       dist: xenial
       sudo: true
+      env:
+        - DEPLOYMENT_ENV=true
 
     # - name: "Python 3.6 on Ubuntu 16.0.4"
       # os: linux
@@ -48,7 +50,7 @@ script:
 before_deploy:
   - cd docs
   - mkdocs build --verbose --clean --strict
-  - cd ..
+  # - cd ..
 
 # deploy to pip
 deploy:
@@ -56,7 +58,8 @@ deploy:
     # user: "mindsdb_sysadmin"
     # password: $PYPI_SYSADMIN_PASSWORD
     # on:
-      # branch: publishing_changes
+      # - branch: publishing_changes
+      # - condition: $DEPLOYMENT_ENV = true
 
 
   - provider: pages
@@ -64,4 +67,5 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
-        branch: publishing_changes
+        - branch: publishing_changes
+        - condition: $DEPLOYMENT_ENV = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   #- travis_wait pip3 install pytest
-  - if [ "$DEPLOYMENT_ENV" = "true" ]; travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi
+  - if [ "$DEPLOYMENT_ENV" = "true" ]; then travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi
 
 before_script: cd tests/ci_tests
 # run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
   - cd ../..
-  
+
 before_deploy:
   - cd docs
   - mkdocs build --verbose --clean --strict
@@ -57,7 +57,7 @@ deploy:
     user: "mindsdb_sysadmin"
     password: $PYPI_SYSADMIN_PASSWORD
     on:
-      branch: master
+      branch: publishing_changes
     distributions: sdist
 
   - provider: pages
@@ -65,4 +65,4 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
-        branch: master
+        branch: publishing_changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,12 @@ matrix:
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
         - choco install python
-
-
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 cache: pip
 # install dependencies
 install:
-  -
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then pip install --upgrade pip; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then pip3 install --upgrade pip; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,12 @@ before_deploy:
 
 # deploy to pip
 deploy:
-  - provider: pypi
-    user: "mindsdb_sysadmin"
-    password: $PYPI_SYSADMIN_PASSWORD
-    on:
-      branch: publishing_changes
-    distributions: sdist
+  # - provider: pypi
+    # user: "mindsdb_sysadmin"
+    # password: $PYPI_SYSADMIN_PASSWORD
+    # on:
+      # branch: publishing_changes
+
 
   - provider: pages
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        DEPLOYMENT_ENV=true
+        DEPLOYMENT_ENV="true"
 
     # - name: "Python 3.6 on Ubuntu 16.0.4"
       # os: linux
@@ -37,7 +37,7 @@ install:
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   #- travis_wait pip3 install pytest
-  - travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments
+  - if [ "$DEPLOYMENT_ENV" = "true" ]; travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments
 
 before_script: cd tests/ci_tests
 # run tests
@@ -50,7 +50,8 @@ script:
 before_deploy:
   - cd docs
   - mkdocs build --verbose --clean --strict
-  # - cd ..
+  - cp -r site ../
+  - cd ..
 
 # deploy to pip
 deploy:
@@ -68,4 +69,4 @@ deploy:
     local_dir: site
     on:
       branch: publishing_changes
-      condition: $DEPLOYMENT_ENV = true
+      condition: $DEPLOYMENT_ENV = "true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ cache: pip
 install:
   -
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then pip install --upgrade pip; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; pip3 install --upgrade pip; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then pip3 install --upgrade pip; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
   - if [ "$DEPLOYMENT_ENV" = "true" ]; then travis_wait pip3 install mkdocs mkdocs-material pymdown-extensions pygments; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - echo "PASSING THIS STEP TO TEST DEPLOY"
+  - echo "CHANGEd THIS STEP TO TEST DEPLOY"
   #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
   #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,26 @@ cache: pip
 # install dependencies
 install:
   - echo "$PYPI_SYSADMIN_PASSWORD" = "glorpzorp"
-  - pip3 install --upgrade pip
+  #- pip3 install --upgrade pip
   #- travis_wait pip3 install -e .
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
-  - travis_wait pip3 install pytest
-  - travis_wait pip3 install mkdocs
+  #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait pip install --no-cache-dir -e .; fi
+  #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait pip3 install --no-cache-dir -e .; fi
+  #- travis_wait pip3 install pytest
+  #- travis_wait pip3 install mkdocs
 
 before_script: cd tests/ci_tests
 # run tests
 script:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
-
+  - echo "PASSING THIS STEP TO TEST DEPLOY"
+  #- if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait python full_test.py; fi
+  #- if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait python3 full_test.py; fi
+  - cd ../..
+  
 before_deploy:
   - cd docs
   - mkdocs build --verbose --clean --strict
   - cd ..
-  
+
 # deploy to pip
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,25 @@
 language: python
 matrix:
   include:
-    - name: "Python 3.7.3 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.7.3
-      dist: xenial
-      sudo: true
-      env:
-        DEPLOYMENT_ENV="true"
+    # - name: "Python 3.7.3 on Ubuntu 16.0.4"
+      # os: linux
+      # python: 3.7.3
+      # dist: xenial
+      # sudo: true
+      # env:
+        # DEPLOYMENT_ENV="true"
+#
+    # - name: "Python 3.6 on Ubuntu 16.0.4"
+      # os: linux
+      # python: 3.6
+      # dist: xenial
+      # sudo: true
+#
+    # - name: "Python 3.7.2 on OSX"
+      # os: osx
+      # language: shell
+      # dist: xcode10.2
 
-    - name: "Python 3.6 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.6
-      dist: xenial
-      sudo: true
-
-    - name: "Python 3.7.2 on OSX"
-      os: osx
-      language: shell
-      dist: xcode10.2
-      sudo: true
 
     - name: "Python 3.7.3 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -75,3 +75,5 @@ print(prediction)
 ```
 
 Of course, that example was just the tip of the iceberg, please read about the main concepts of lightwood, [the API](API.md) and then jump into examples.
+
+**this is just something I added to check if deployment of the docs worked, please remove**

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -75,5 +75,3 @@ print(prediction)
 ```
 
 Of course, that example was just the tip of the iceberg, please read about the main concepts of lightwood, [the API](API.md) and then jump into examples.
-
-**this is just something I added to check if deployment of the docs worked, please remove**

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,8 +10,15 @@ Lightwood was inspired on [Keras](https://keras.io/)+[Ludwig](https://github.com
 
 ## Installing Lightwood
 
+
+### On Linux, OSX and all other operating systems
 ```bash
 pip3 install lightwood
+```
+
+### On Windows
+```
+pip install git+https://github.com/mindsdb/lightwood.git@master
 ```
 
 If this fails, please report the bug on github and try installing the current master branch:
@@ -19,7 +26,7 @@ If this fails, please report the bug on github and try installing the current ma
 ```bash
 git clone git@github.com:mindsdb/lightwood.git;
 cd lightwood;
-pip3 install --no-cache-dir -e .
+pip install --no-cache-dir -e .
 ```
 
 **Please note that, depending on your os and python setup, you might want to use `pip` instead of `pip3`, so please try the commands with `pip` if the ones above fail**

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -11,7 +11,7 @@ Lightwood was inspired on [Keras](https://keras.io/)+[Ludwig](https://github.com
 ## Installing Lightwood
 
 ```bash
-pip3 install  --no-cache-dir lightwood
+pip3 install lightwood
 ```
 
 If this fails, please report the bug on github and try installing the current master branch:

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.7.6'
+__version__ = '0.7.7'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__init__.py
+++ b/lightwood/__init__.py
@@ -9,5 +9,5 @@ import lightwood.constants.lightwood as  CONST
 from lightwood.api.predictor import Predictor
 from lightwood.mixers import BUILTIN_MIXERS
 from lightwood.encoders import BUILTIN_ENCODERS
-print('Temporary change so that ravis actually runs stuff')
+
 COLUMN_DATA_TYPES = CONST.COLUMN_DATA_TYPES

--- a/lightwood/__init__.py
+++ b/lightwood/__init__.py
@@ -9,5 +9,5 @@ import lightwood.constants.lightwood as  CONST
 from lightwood.api.predictor import Predictor
 from lightwood.mixers import BUILTIN_MIXERS
 from lightwood.encoders import BUILTIN_ENCODERS
-
+print('Temporary change so that ravis actually runs stuff')
 COLUMN_DATA_TYPES = CONST.COLUMN_DATA_TYPES

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import subprocess
 
 
 # @TODO: Figure out a way to check for this
-is_installed_from_pypi = True
+is_installed_from_pypi = False
 
 about = {}
 with open("lightwood/__about__.py") as fp:

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,12 @@ elif sys_platform == 'darwin':
     requirements = remove_requirements(requirements,'torch',replace='torch == 1.1.0.post2')
 
 # Windows specific requirements
-elif sys_platform in ['win32','cygwin','windows'] :
+elif sys_platform in ['win32','cygwin','windows']:
 
     # Bellow should work for python3.7 + cudnn 10... though, surprisingly, it seems to also work for no cudnn
     #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
     #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
-    
+
     requirements = remove_requirements(requirements,'torch')
     requirements = remove_requirements(requirements,'torchvision')
     requirements.append('cwrap')
@@ -81,12 +81,16 @@ setuptools.setup(
     python_requires=">=3.6"
 )
 
-try:
-    subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
-except:
-    print('Can\'t install pytroch')
 
-try:
-    subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
-except:
-    print('Can\'t install pytroch')
+if sys_platform in ['win32','cygwin','windows'] :
+    try:
+        subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
+        print('Successfully installed pytorch !')
+    except:
+        print('Failed to install pytroch, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')
+
+    try:
+        subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
+        print('Successfully installed Torchvision !')
+    except:
+        print('Failed to install torchvision, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ if is_installed_from_pypi and (sys_platform in ['win32','cygwin','windows']):
         print('Failed to install pytroch, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')
 
     try:
-        subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
+        subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
         print('Successfully installed Torchvision !')
     except:
         print('Failed to install torchvision, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import setuptools
+import subprocess
+
 
 print('Installing lightwood dynamically !')
 
@@ -44,8 +46,8 @@ elif sys_platform in ['win32','cygwin','windows'] :
     #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
     #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
     
-    requirements = remove_requirements(requirements,'torch',replace='torch >= 0.1.2.post2')
-    requirements = remove_requirements(requirements,'torchvision',replace='torchvision >= 0.2.2')
+    requirements = remove_requirements(requirements,'torch')
+    requirements = remove_requirements(requirements,'torchvision')
     requirements.append('cwrap')
 
     # This doens't work as well as the `@` version
@@ -78,3 +80,13 @@ setuptools.setup(
     ],
     python_requires=">=3.6"
 )
+
+try:
+    subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
+except:
+    print('Can\'t install pytroch')
+
+try:
+    subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
+except:
+    print('Can\'t install pytroch')

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ elif sys_platform in ['win32','cygwin','windows'] :
     #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
     #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
     
-    requirements = remove_requirements(requirements,'torch',replace='torch == 1.1.0.post2')
+    requirements = remove_requirements(requirements,'torch',replace='torch >= 1.0.0')
     requirements = remove_requirements(requirements,'torchvision',replace='torchvision == 0.3.0')
     requirements.append('cwrap')
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import setuptools
 import subprocess
 
 
-print('Installing lightwood dynamically !')
+# @TODO: Figure out a way to check for this
+is_installed_from_pypi = True
 
 about = {}
 with open("lightwood/__about__.py") as fp:
@@ -42,12 +43,14 @@ elif sys_platform == 'darwin':
 # Windows specific requirements
 elif sys_platform in ['win32','cygwin','windows']:
 
-    # Bellow should work for python3.7 + cudnn 10... though, surprisingly, it seems to also work for no cudnn
-    #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
-    #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
+    if is_installed_from_pypi:
+        requirements = remove_requirements(requirements,'torch')
+        requirements = remove_requirements(requirements,'torchvision')
+    else:
+        # Bellow should work for python3.7 + cudnn 10... though, surprisingly, it seems to also work for no cudnn
+        requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
+        requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
 
-    requirements = remove_requirements(requirements,'torch')
-    requirements = remove_requirements(requirements,'torchvision')
     requirements.append('cwrap')
 
     # This doens't work as well as the `@` version
@@ -58,7 +61,7 @@ elif sys_platform in ['win32','cygwin','windows']:
 else:
     print('\n\n====================\n\nError, platform {sys_platform} not recognized, proceeding to install anyway, but lightwood might not work properly !\n\n====================\n\n')
 
-if sys_platform in ['win32','cygwin','windows'] :
+if is_installed_from_pypi and (sys_platform in ['win32','cygwin','windows']):
     try:
         subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
         print('Successfully installed pytorch !')

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ elif sys_platform in ['win32','cygwin','windows'] :
     #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
     
     requirements = remove_requirements(requirements,'torch',replace='torch >= 0.1.2.post2')
-    requirements = remove_requirements(requirements,'torchvision',replace='torchvision == 0.3.0')
+    requirements = remove_requirements(requirements,'torchvision',replace='torchvision >= 0.2.2')
     requirements.append('cwrap')
 
     # This doens't work as well as the `@` version

--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,14 @@ dependency_links = []
 # Linux specific requirements
 if sys_platform == 'linux' or sys_platform.startswith('linux'):
     requirements = remove_requirements(requirements,'torch',replace='torch == 1.1.0')
-    
+
 
 # OSX specific requirements
 elif sys_platform == 'darwin':
     requirements = remove_requirements(requirements,'torch',replace='torch == 1.1.0.post2')
 
 # Windows specific requirements
-elif sys_platform in ['win32','cygwin'] :
+elif sys_platform in ['win32','cygwin','windows'] :
 
     # Bellow should work for python3.7 + cudnn 10... though, surprisingly, it seems to also work for no cudnn
     requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,11 @@ elif sys_platform == 'darwin':
 elif sys_platform in ['win32','cygwin','windows'] :
 
     # Bellow should work for python3.7 + cudnn 10... though, surprisingly, it seems to also work for no cudnn
-    requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
-    requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
-
+    #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
+    #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
+    
+    requirements = remove_requirements(requirements,'torch',replace='torch == 1.1.0.post2')
+    requirements = remove_requirements(requirements,'torchvision',replace='torchvision == 0.3.0')
     requirements.append('cwrap')
 
     # This doens't work as well as the `@` version

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ elif sys_platform in ['win32','cygwin','windows'] :
     #requirements = remove_requirements(requirements,'torch',replace='torch @ https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl')
     #requirements = remove_requirements(requirements,'torchvision',replace='torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl')
     
-    requirements = remove_requirements(requirements,'torch',replace='torch >= 1.0.0')
+    requirements = remove_requirements(requirements,'torch',replace='torch >= 0.1.2.post2')
     requirements = remove_requirements(requirements,'torchvision',replace='torchvision == 0.3.0')
     requirements.append('cwrap')
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,19 @@ elif sys_platform in ['win32','cygwin','windows']:
 else:
     print('\n\n====================\n\nError, platform {sys_platform} not recognized, proceeding to install anyway, but lightwood might not work properly !\n\n====================\n\n')
 
+if sys_platform in ['win32','cygwin','windows'] :
+    try:
+        subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
+        print('Successfully installed pytorch !')
+    except:
+        print('Failed to install pytroch, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')
+
+    try:
+        subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
+        print('Successfully installed Torchvision !')
+    except:
+        print('Failed to install torchvision, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')
+
 setuptools.setup(
     name=about['__title__'],
     version=about['__version__'],
@@ -80,17 +93,3 @@ setuptools.setup(
     ],
     python_requires=">=3.6"
 )
-
-
-if sys_platform in ['win32','cygwin','windows'] :
-    try:
-        subprocess.call(['pip','install','https://download.pytorch.org/whl/cu100/torch-1.1.0-cp37-cp37m-win_amd64.whl'])
-        print('Successfully installed pytorch !')
-    except:
-        print('Failed to install pytroch, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')
-
-    try:
-        subprocess.call(['pip','install','torchvision @ https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp37-cp37m-win_amd64.whl'])
-        print('Successfully installed Torchvision !')
-    except:
-        print('Failed to install torchvision, please install pytroch and torchvision manually be following the simple instructions over at: https://pytorch.org/get-started/locally/')


### PR DESCRIPTION
* Docs are auto publish when tests pass after a merge/PR into master
* Pip version is auto published when tests pass after a merge/PR into master
* Only publishing `sdist` (distribution from source) to pip in order to force `setup.py` to and be able to source dependencies dynamically and run other install scripts that way. 

Note:

We should consider going back to wheels once we can build them on multiple environments, but for now I don't think it's worth it, since we don't have any custom C extension (which is the main selling point for wheel anyway, as far as I can see)