### PR TITLE
Run on cpu

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.7.9'
+__version__ = '0.7.10'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.7.10'
+__version__ = '0.8.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__init__.py
+++ b/lightwood/__init__.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,6):
     sys.exit('Sorry, For Lightwood Python < 3.6 is not supported')
 
 import lightwood.constants.lightwood as  CONST
-
 from lightwood.api.predictor import Predictor
 from lightwood.mixers import BUILTIN_MIXERS
 from lightwood.encoders import BUILTIN_ENCODERS

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -119,7 +119,7 @@ class Predictor:
             if 'attrs' in  self.config['mixer']:
                 mixer_params = self.config['mixer']['attrs']
         else:
-            mixer_class = NnMixer #SkLearnMixer
+            mixer_class = SkLearnMixer # NnMixer #
 
 
         mixer = mixer_class()

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from lightwood.api.data_source import DataSource
 from lightwood.data_schemas.predictor_config import predictor_config_schema
-
+from lightwood.config.config import CONFIG
 from lightwood.mixers.sk_learn.sk_learn import SkLearnMixer
 from lightwood.mixers.nn.nn import NnMixer
 from sklearn.metrics import accuracy_score
@@ -60,6 +60,8 @@ class Predictor:
         self.train_accuracy = None
 
     def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20, stop_training_after_seconds=3600 * 24 * 5):
+        print(CONFIG.USE_CUDA)
+        exit()
         """
         Train and save a model (you can use this to retrain model from data)
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -141,6 +141,7 @@ class Predictor:
         started_training_at = int(time.time())
         #iterate over the iter_fit and see what the epoch and mixer error is
         for epoch, mix_error in enumerate(mixer.iter_fit(from_data_ds)):
+            print(lowest_error,lowest_error_epoch,epoch)
             if self._stop_training_flag == True:
                 logging.info('Learn has been stopped')
                 break
@@ -197,7 +198,13 @@ class Predictor:
                     callback_on_iter(epoch, mix_error, test_error, delta_mean)
 
                 # if the model is overfitting that is, that the the test error is becoming greater than the train error
-                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*1.2)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
+                print('\n=========================\n')
+                print(epoch)
+                print(lowest_error_epoch)
+                print(round(max(eval_every_x_epochs*2+2,epoch*0.3)))
+                print('\n=========================\n')
+                
+                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.3)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -248,7 +248,6 @@ class Predictor:
         when_data_ds = DataSource(when_data, self.config)
         when_data_ds.encoders = self._mixer.encoders
 
-        print(self._mixer.predict(when_data_ds))
         return self._mixer.predict(when_data_ds)
 
     def calculate_accuracy(self, from_data):
@@ -270,9 +269,6 @@ class Predictor:
 
             else:
                 accuracies[output_column] = r2_score(ds.get_encoded_column_data(output_column), predictions[output_column]["encoded_predictions"])
-
-
-
 
         return accuracies
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -141,7 +141,6 @@ class Predictor:
         started_training_at = int(time.time())
         #iterate over the iter_fit and see what the epoch and mixer error is
         for epoch, mix_error in enumerate(mixer.iter_fit(from_data_ds)):
-            print(lowest_error,lowest_error_epoch,epoch)
             if self._stop_training_flag == True:
                 logging.info('Learn has been stopped')
                 break
@@ -198,11 +197,13 @@ class Predictor:
                     callback_on_iter(epoch, mix_error, test_error, delta_mean)
 
                 # if the model is overfitting that is, that the the test error is becoming greater than the train error
+                '''
                 print('\n=========================\n')
                 print(epoch)
                 print(lowest_error_epoch)
                 print(round(max(eval_every_x_epochs*2+2,epoch*0.3)))
                 print('\n=========================\n')
+                '''
 
                 if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
                     mixer.update_model(last_good_model)

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -115,14 +115,9 @@ class Predictor:
         mixer_params = {}
 
         if 'mixer' in self.config:
-            if self.config['mixer'] == 'sklearn':
-                mixer_class = SkLearnMixer
-            elif self.config['mixer'] == 'nn':
-                mixer_class = NnMixer
-            else:
-                mixer_class = self.config['mixer']['class']
-                if 'attrs' in  self.config['mixer']:
-                    mixer_params = self.config['mixer']['attrs']
+            mixer_class = self.config['mixer']['class']
+            if 'attrs' in  self.config['mixer']:
+                mixer_params = self.config['mixer']['attrs']
         else:
             mixer_class = NnMixer
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -154,7 +154,6 @@ class Predictor:
                 eval_next_on_epoch = tmp_next
 
                 test_error = mixer.error(test_data_ds)
-
                 # initialize lowest_error_variable if not initialized yet
                 if lowest_error is None:
                     lowest_error = test_error

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -210,7 +210,6 @@ class Predictor:
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break
 
-
         # make sure that we update the encoders, we do this, so that the predictor or parent object can pickle the mixers
         self._mixer.encoders = from_data_ds.encoders
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -119,7 +119,7 @@ class Predictor:
             if 'attrs' in  self.config['mixer']:
                 mixer_params = self.config['mixer']['attrs']
         else:
-            mixer_class = SkLearnMixer # NnMixer #
+            mixer_class = NnMixer #SkLearnMixer
 
 
         mixer = mixer_class()

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -207,8 +207,28 @@ class Predictor:
                 print('\n=========================\n')
                 #'''
 
-                #if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
-                if ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
+                # Decide if we should stop training
+                stop_training = False
+
+                # Stop if we're past the time limit alloted for training
+                if (int(time.time()) - started_training_at) > stop_training_after_seconds:
+                    stop_training = True
+
+                # Stop if the error on the testing data is close to zero (0.15%)
+                if test_error < 0.0015:
+                    stop_training = True
+
+                # If accuracy stopped improving on the testing set and the test error is small enough, stop
+                if delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1:
+                    stop_training = True
+
+                # If we've seen no imporvement for a long while, stop
+                if lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch:
+                    stop_training = True
+
+
+
+                if stop_training:
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -203,8 +203,8 @@ class Predictor:
                 print(lowest_error_epoch)
                 print(round(max(eval_every_x_epochs*2+2,epoch*0.3)))
                 print('\n=========================\n')
-                
-                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.3)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
+
+                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -197,15 +197,18 @@ class Predictor:
                     callback_on_iter(epoch, mix_error, test_error, delta_mean)
 
                 # if the model is overfitting that is, that the the test error is becoming greater than the train error
-                '''
+                #'''
                 print('\n=========================\n')
                 print(epoch)
                 print(lowest_error_epoch)
                 print(round(max(eval_every_x_epochs*2+2,epoch*0.3)))
+                print(lowest_error)
+                print(( (int(time.time()) - started_training_at) - stop_training_after_seconds))
                 print('\n=========================\n')
-                '''
+                #'''
 
-                if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
+                #if (delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1) or (test_error < 0.0015) or (lowest_error_epoch + round(max(eval_every_x_epochs*2+2,epoch*0.5)) < epoch) or ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
+                if ( (int(time.time()) - started_training_at) > stop_training_after_seconds):
                     mixer.update_model(last_good_model)
                     self.train_accuracy = self.calculate_accuracy(test_data_ds)
                     break

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -196,16 +196,7 @@ class Predictor:
                 if callback_on_iter is not None:
                     callback_on_iter(epoch, mix_error, test_error, delta_mean)
 
-                # if the model is overfitting that is, that the the test error is becoming greater than the train error
-                #'''
-                print('\n=========================\n')
-                print(epoch)
-                print(lowest_error_epoch)
-                print(round(max(eval_every_x_epochs*2+2,epoch*0.3)))
-                print(lowest_error)
-                print(( (int(time.time()) - started_training_at) - stop_training_after_seconds))
-                print('\n=========================\n')
-                #'''
+
 
                 # Decide if we should stop training
                 stop_training = False
@@ -218,7 +209,7 @@ class Predictor:
                 if test_error < 0.0015:
                     stop_training = True
 
-                # If accuracy stopped improving on the testing set and the test error is small enough, stop
+                ## Stop if the model is overfitting, that is, the test error is becoming greater than the train error and the test error is small enough, stop
                 if delta_mean < 0 and len(error_delta_buffer) > 5 and test_error < 0.1:
                     stop_training = True
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -119,7 +119,7 @@ class Predictor:
             if 'attrs' in  self.config['mixer']:
                 mixer_params = self.config['mixer']['attrs']
         else:
-            mixer_class = NnMixer
+            mixer_class = NnMixer #SkLearnMixer
 
 
         mixer = mixer_class()

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -119,10 +119,12 @@ class Predictor:
             if 'attrs' in  self.config['mixer']:
                 mixer_params = self.config['mixer']['attrs']
         else:
-            mixer_class = NnMixer #SkLearnMixer
+            #mixer_class = NnMixer
+            mixer_class = SkLearnMixer
 
 
         mixer = mixer_class()
+        self._mixer = mixer
 
         for param in mixer_params:
             if hasattr(mixer, param):
@@ -246,6 +248,7 @@ class Predictor:
         when_data_ds = DataSource(when_data, self.config)
         when_data_ds.encoders = self._mixer.encoders
 
+        print(self._mixer.predict(when_data_ds))
         return self._mixer.predict(when_data_ds)
 
     def calculate_accuracy(self, from_data):

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -59,9 +59,7 @@ class Predictor:
 
         self.train_accuracy = None
 
-    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20, stop_training_after_seconds=3600 * 24 * 5):
-        print(CONFIG.USE_CUDA)
-        exit()
+    def learn(self, from_data, test_data=None, callback_on_iter = None, eval_every_x_epochs = 20, stop_training_after_seconds=3600 * 8):
         """
         Train and save a model (you can use this to retrain model from data)
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -115,12 +115,16 @@ class Predictor:
         mixer_params = {}
 
         if 'mixer' in self.config:
-            mixer_class = self.config['mixer']['class']
-            if 'attrs' in  self.config['mixer']:
-                mixer_params = self.config['mixer']['attrs']
+            if self.config['mixer'] == 'sklearn':
+                mixer_class = SkLearnMixer
+            elif self.config['mixer'] == 'nn':
+                mixer_class = NnMixer
+            else:
+                mixer_class = self.config['mixer']['class']
+                if 'attrs' in  self.config['mixer']:
+                    mixer_params = self.config['mixer']['attrs']
         else:
-            #mixer_class = NnMixer
-            mixer_class = SkLearnMixer
+            mixer_class = NnMixer
 
 
         mixer = mixer_class()

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -1,4 +1,7 @@
+import torch
+
 
 class CONFIG:
-    
     USE_CUDA = False
+    if torch.cuda.device_count() > 0:
+        USE_CUDA = True

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -25,7 +25,7 @@ class NumericEncoder:
                     continue
 
                 if number is None or math.isnan(number):
-                    print('Lightwood does not support working with NaN values !')
+                    logging.error('Lightwood does not support working with NaN values !')
                     exit()
 
                 self._min_value = number if self._min_value is None or self._min_value > number else self._min_value

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -25,7 +25,8 @@ class NumericEncoder:
                     continue
 
                 if number is None or math.isnan(number):
-                    continue
+                    print('Lightwood does not support working with NaN values !')
+                    exit()
 
                 self._min_value = number if self._min_value is None or self._min_value > number else self._min_value
                 self._max_value = number if self._max_value is None or self._max_value < number else self._max_value

--- a/lightwood/mixers/nn/helpers/adamw.py
+++ b/lightwood/mixers/nn/helpers/adamw.py
@@ -1,0 +1,116 @@
+import math
+import torch
+from torch.optim.optimizer import Optimizer
+
+
+# From https://pytorch.org/docs/master/_modules/torch/optim/adamw.html
+# Reasons for using: https://www.fast.ai/2018/07/02/adam-weight-decay/#understanding-amsgrad
+class AdamW(Optimizer):
+    r"""Implements AdamW algorithm.
+
+    The original Adam algorithm was proposed in `Adam: A Method for Stochastic Optimization`_.
+    The AdamW variant was proposed in `Decoupled Weight Decay Regularization`_.
+
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-8)
+        weight_decay (float, optional): weight decay coefficient (default: 1e-2)
+        amsgrad (boolean, optional): whether to use the AMSGrad variant of this
+            algorithm from the paper `On the Convergence of Adam and Beyond`_
+            (default: False)
+
+    .. _Adam\: A Method for Stochastic Optimization:
+        https://arxiv.org/abs/1412.6980
+    .. _Decoupled Weight Decay Regularization:
+        https://arxiv.org/abs/1711.05101
+    .. _On the Convergence of Adam and Beyond:
+        https://openreview.net/forum?id=ryQu7f-RZ
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+                 weight_decay=1e-2, amsgrad=False):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        defaults = dict(lr=lr, betas=betas, eps=eps,
+                        weight_decay=weight_decay, amsgrad=amsgrad)
+        super(AdamW, self).__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super(AdamW, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault('amsgrad', False)
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+
+                # Perform stepweight decay
+                p.data.mul_(1 - group['lr'] * group['weight_decay'])
+
+                # Perform optimization step
+                grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError('Adam does not support sparse gradients, please consider SparseAdam instead')
+                amsgrad = group['amsgrad']
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+                    if amsgrad:
+                        # Maintains max of all exp. moving avg. of sq. grad. values
+                        state['max_exp_avg_sq'] = torch.zeros_like(p.data)
+
+                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
+                if amsgrad:
+                    max_exp_avg_sq = state['max_exp_avg_sq']
+                beta1, beta2 = group['betas']
+
+                state['step'] += 1
+                bias_correction1 = 1 - beta1 ** state['step']
+                bias_correction2 = 1 - beta2 ** state['step']
+
+                # Decay the first and second moment running average coefficient
+                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                if amsgrad:
+                    # Maintains the maximum of all 2nd moment running avg. till now
+                    torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)
+                    # Use the max. for normalizing running avg. of gradient
+                    denom = (max_exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(group['eps'])
+                else:
+                    denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(group['eps'])
+
+                step_size = group['lr'] / bias_correction1
+
+                p.data.addcdiv_(-step_size, exp_avg, denom)
+
+        return loss

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -31,13 +31,13 @@ class DefaultNet(nn.Module):
             large_input = True if input_size > 1000 else False
             large_output = True if output_size > 100 else False
 
-        # 1. Determine in/out proportions
+        # 2. Determine in/out proportions
         # @TODO: Maybe provide a warning if the output is larger, this really shouldn't usually be the case (outside of very specific things, such as text to image)
         larger_output = True if output_size > input_size*2 else False
         larger_input = True if input_size > output_size*2 else False
         even_input_output = larger_input and large_output
 
-
+        # 3. Determine shpae based on the sizes & proportions
         if not large_input and not large_output:
             if larger_input:
                 shape = shapes.rombus(input_size,output_size,5,input_size*2)

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -1,6 +1,7 @@
 from lightwood.config.config import CONFIG
 import torch.nn as nn
 import torch
+from shapes import rombus, rectangle, funnel
 
 
 

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -41,7 +41,6 @@ class DefaultNet(nn.Module):
         self.net = self.net.to(self.device)
 
 
-
     def forward(self, input):
         """
         In this particular model, we just need to forward the network defined in setup, with our input
@@ -49,7 +48,5 @@ class DefaultNet(nn.Module):
         :return:
         """
 
-        input = input.to(self.device)
-
-        output = self.net(input).to(self.device)
+        output = self.net(input)
         return output

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -1,7 +1,7 @@
 from lightwood.config.config import CONFIG
+import lightwood.mixers.nn.helpers.shapes as shapes
 import torch.nn as nn
 import torch
-import lightwood.mixers.nn.helpers.shapes as shapes # rombus, rectangle, funnel
 
 
 

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -1,5 +1,5 @@
 from lightwood.config.config import CONFIG
-import lightwood.mixers.nn.helpers.shapes as shapes
+from .shapes import *
 import torch.nn as nn
 import torch
 
@@ -40,24 +40,24 @@ class DefaultNet(nn.Module):
         # 3. Determine shpae based on the sizes & propotions
         if not large_input and not large_output:
             if larger_input:
-                shape = shapes.rombus(input_size,output_size,5,input_size*2)
+                shape = rombus(input_size,output_size,5,input_size*2)
             else:
-                shape = shapes.rectangle(input_size,output_size,4)
+                shape = rectangle(input_size,output_size,4)
 
         elif not large_output and large_input:
             depth = 5
             if large_output:
                 depth = depth - 1
-            shape = shapes.funnel(input_size,output_size,depth)
+            shape = funnel(input_size,output_size,depth)
 
         elif not large_input and large_output:
             if larger_input:
-                shape = shapes.funnel(input_size,output_size,4)
+                shape = funnel(input_size,output_size,4)
             else:
-                shape = shapes.rectangle(input_size,output_size,4)
+                shape = rectangle(input_size,output_size,4)
 
         else:
-            shape = shapes.rectangle(input_size,output_size,3)
+            shape = rectangle(input_size,output_size,3)
 
         print(f'Building network of shape: {shape}')
         rectifier = nn.SELU  #alternative: nn.ReLU

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -20,10 +20,18 @@ class DefaultNet(nn.Module):
         input_size = len(input_sample)
         output_size = len(output_sample)
 
-        if input_size < 3 * pow(10,3):
+        if input_size < 3 * pow(10,3) and True:
             self.net = nn.Sequential(
                 nn.Linear(input_size, 2*input_size),
-                nn.ReLU(),
+                nn.SELU(),
+                nn.Linear(2*input_size, 4*input_size),
+                nn.SELU(),
+                nn.Linear(4*input_size, 8*input_size),
+                nn.SELU(),
+                nn.Linear(8*input_size, 4*input_size),
+                nn.SELU(),
+                nn.Linear(4*input_size, 2*input_size),
+                nn.SELU(),
                 nn.Linear(2*input_size, output_size)
             )
         else:

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -1,12 +1,16 @@
 from lightwood.config.config import CONFIG
 import torch.nn as nn
+import torch
 
 
 
 class DefaultNet(nn.Module):
 
     def __init__(self, ds):
-
+        if CONFIG.USE_CUDA:
+            self.device = torch.device('cuda')
+        else:
+            self.device = torch.device('cpu')
         """
         Here we define the basic building blocks of our model, in forward we define how we put it all together along wiht an input
         :param sample_batch: this is used to understand the characteristics of the input and target, it is an object of type utils.libs.data_types.batch.Batch
@@ -15,8 +19,8 @@ class DefaultNet(nn.Module):
         input_sample, output_sample = ds[0]
         input_size = len(input_sample)
         output_size = len(output_sample)
-        print(input_size)
-        if input_size < 3 * pow(10,1):
+
+        if input_size < 3 * pow(10,3):
             self.net = nn.Sequential(
                 nn.Linear(input_size, 2*input_size),
                 nn.ReLU(),
@@ -34,8 +38,7 @@ class DefaultNet(nn.Module):
             )
 
 
-        if CONFIG.USE_CUDA:
-            self.net.cuda()
+        self.net = self.net.to(self.device)
 
 
 
@@ -46,8 +49,7 @@ class DefaultNet(nn.Module):
         :return:
         """
 
-        if CONFIG.USE_CUDA:
-            input.cuda()
+        input = input.to(self.device)
 
-        output = self.net(input)
+        output = self.net(input).to(self.device)
         return output

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -37,7 +37,7 @@ class DefaultNet(nn.Module):
         larger_input = True if input_size > output_size*2 else False
         even_input_output = larger_input and large_output
 
-        # 3. Determine shpae based on the sizes & proportions
+        # 3. Determine shpae based on the sizes & propotions
         if not large_input and not large_output:
             if larger_input:
                 shape = shapes.rombus(input_size,output_size,5,input_size*2)

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -59,7 +59,6 @@ class DefaultNet(nn.Module):
         else:
             shape = shapes.rectangle(input_size,output_size,3)
 
-
         print(f'Building network of shape: {shape}')
         rectifier = nn.SELU  #alternative: nn.ReLU
 

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -1,3 +1,4 @@
+import logging
 from lightwood.config.config import CONFIG
 from .shapes import *
 import torch.nn as nn
@@ -59,7 +60,7 @@ class DefaultNet(nn.Module):
         else:
             shape = rectangle(input_size,output_size,3)
 
-        print(f'Building network of shape: {shape}')
+        logging.info(f'Building network of shape: {shape}')
         rectifier = nn.SELU  #alternative: nn.ReLU
 
         layers = []

--- a/lightwood/mixers/nn/helpers/shapes.py
+++ b/lightwood/mixers/nn/helpers/shapes.py
@@ -23,15 +23,14 @@ def rectangle(in_size,out_size,depth):
 
 def rombus(in_size,out_size,depth,max_size=None):
     if max_size is None:
-        max_size = in_size*2
+        max_size = max(in_size,out_size)*2
     if depth < 3:
         print('Depth must be at least 3 for the rombus function to work correctly, setting it to 3')
         depth = 3
 
     funnel_size = math.ceil(depth/2)
 
-    first_funnel = funnel(max_size,in_size,funnel_size)
-    first_funnel.reverse()
+    first_funnel = funnel(in_size, max_size,funnel_size)
 
     if depth % 2 == 1:
         first_funnel = first_funnel[:-1]

--- a/lightwood/mixers/nn/helpers/shapes.py
+++ b/lightwood/mixers/nn/helpers/shapes.py
@@ -1,0 +1,43 @@
+import math
+
+
+def funnel(in_size, out_size, depth):
+    if depth < 2:
+        print('Depth must be at least 2 for the funnel function to work correctly, setting it to 2')
+        depth = 2
+
+    step_denominator = depth - 1
+    layers = list( range(out_size, in_size, round((in_size - out_size)/step_denominator) ) )
+    layers.reverse()
+    layers = [in_size, *layers]
+    return layers
+
+def rectangle(in_size,out_size,depth):
+    if depth < 2:
+        print('Depth must be at least 2 for the rectangle function to work correctly, setting it to 2')
+        depth = 2
+
+    layers = [in_size for x in range(depth - 1)]
+    layers = [*layers,out_size]
+    return layers
+
+def rombus(in_size,out_size,depth,max_size=None):
+    if max_size is None:
+        max_size = in_size*2
+    if depth < 3:
+        print('Depth must be at least 3 for the rombus function to work correctly, setting it to 3')
+        depth = 3
+
+    funnel_size = math.ceil(depth/2)
+
+    first_funnel = funnel(max_size,in_size,funnel_size)
+    first_funnel.reverse()
+
+    if depth % 2 == 1:
+        first_funnel = first_funnel[:-1]
+
+    second_funnel = funnel(max_size,out_size,funnel_size)
+
+    layers = [*first_funnel,*second_funnel]
+
+    return layers

--- a/lightwood/mixers/nn/helpers/shapes.py
+++ b/lightwood/mixers/nn/helpers/shapes.py
@@ -1,9 +1,10 @@
+import logging
 import math
 
 
 def funnel(in_size, out_size, depth):
     if depth < 2:
-        print('Depth must be at least 2 for the funnel function to work correctly, setting it to 2')
+        logging.warning('Depth must be at least 2 for the funnel function to work correctly, setting it to 2')
         depth = 2
 
     step_denominator = depth - 1
@@ -14,7 +15,7 @@ def funnel(in_size, out_size, depth):
 
 def rectangle(in_size,out_size,depth):
     if depth < 2:
-        print('Depth must be at least 2 for the rectangle function to work correctly, setting it to 2')
+        logging.warning('Depth must be at least 2 for the rectangle function to work correctly, setting it to 2')
         depth = 2
 
     layers = [in_size for x in range(depth - 1)]
@@ -25,7 +26,7 @@ def rombus(in_size,out_size,depth,max_size=None):
     if max_size is None:
         max_size = max(in_size,out_size)*2
     if depth < 3:
-        print('Depth must be at least 3 for the rombus function to work correctly, setting it to 3')
+        logging.warning('Depth must be at least 3 for the rombus function to work correctly, setting it to 3')
         depth = 3
 
     funnel_size = math.ceil(depth/2)

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -149,14 +149,18 @@ class NnMixer:
 
         self.net = self.nn_class(ds)
         self.net.train()
-        lr = 0.001
-        self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False) #self.optimizer_class(self.net.parameters(), **self.optimizer_args)
+
+        #lr = 0.001
+        #self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
+        self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
 
         total_epochs = self.epochs
 
         for epoch in range(total_epochs):  # loop over the dataset multiple times
             running_loss = 0.0
             error = 0
+
+            '''
             print(lr)
             if epoch < 120:
                 if lr < 0.01:
@@ -166,6 +170,7 @@ class NnMixer:
                 if lr > 0.001:
                     lr=lr - 0.0001
                     self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
+            '''
 
             for i, data in enumerate(data_loader, 0):
                 # get the inputs; data is a list of [inputs, labels]

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -30,7 +30,7 @@ class NnMixer:
         self.epochs = 120000
 
         if self.dynamic_adamw:
-            self.optimizer_classs = AdamW
+            self.optimizer_class = AdamW
             slef.optimizer_args = {'amsgrad': False, 'lr':0.001}
         else:
             self.optimizer_class = optim.Adadelta

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -1,4 +1,3 @@
-
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
@@ -98,7 +97,8 @@ class NnMixer:
         for i, data in enumerate(data_loader, 0):
             # get the inputs; data is a list of [inputs, labels]
             inputs, labels = data
-
+            inputs = inputs.to(self.net.device)
+            labels = labels.to(self.net.device)
             # forward + backward + optimize
             outputs = self.net(inputs)
             loss = self.criterion(outputs, labels)
@@ -160,6 +160,7 @@ class NnMixer:
 
                 # forward + backward + optimize
                 outputs = self.net(inputs)
+                labels = labels.to(self.net.device)
                 loss = self.criterion(outputs, labels)
                 loss.backward()
                 self.optimizer.step()

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -31,7 +31,7 @@ class NnMixer:
 
         if self.dynamic_adamw:
             self.optimizer_classs = AdamW
-            slef.optimizer_args = {'amsgrad'=False, 'lr':0.001}
+            slef.optimizer_args = {'amsgrad': False, 'lr':0.001}
         else:
             self.optimizer_class = optim.Adadelta
             self.optimizer_args = {'lr': 0.1}

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -55,6 +55,9 @@ class NnMixer:
         self.net.eval()
         data = next(iter(data_loader))
         inputs, labels = data
+        inputs = inputs.to(self.net.device)
+        labels = labels.to(self.net.device)
+
         outputs = self.net(inputs)
 
         output_encoded_vectors = {}
@@ -99,6 +102,7 @@ class NnMixer:
             inputs, labels = data
             inputs = inputs.to(self.net.device)
             labels = labels.to(self.net.device)
+
             # forward + backward + optimize
             outputs = self.net(inputs)
             loss = self.criterion(outputs, labels)

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -31,10 +31,10 @@ class NnMixer:
 
         if self.dynamic_adamw:
             self.optimizer_classs = AdamW
-            slef.optimizer_args = {amsgrad=False, 'self.optimizer_args['lr']':0.001}
+            slef.optimizer_args = {amsgrad=False, 'lr':0.001}
         else:
             self.optimizer_class = optim.Adadelta
-            self.optimizer_args = {'self.optimizer_args['lr']': 0.1}
+            self.optimizer_args = {'lr': 0.1}
 
         self.nn_class = DefaultNet
         self.batch_size = 100

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -155,12 +155,15 @@ class NnMixer:
                 # get the inputs; data is a list of [inputs, labels]
                 inputs, labels = data
 
+                labels = labels.to(self.net.device)
+                inputs = inputs.to(self.net.device)
+
                 # zero the parameter gradients
                 self.optimizer.zero_grad()
 
                 # forward + backward + optimize
                 outputs = self.net(inputs)
-                labels = labels.to(self.net.device)
+
                 loss = self.criterion(outputs, labels)
                 loss.backward()
                 self.optimizer.step()
@@ -170,13 +173,6 @@ class NnMixer:
                 error = running_loss / (i + 1)
 
             yield error
-
-
-
-
-
-
-
 
 
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -31,7 +31,7 @@ class NnMixer:
 
         if self.dynamic_adamw:
             self.optimizer_classs = AdamW
-            slef.optimizer_args = {amsgrad=False, 'lr':0.001}
+            slef.optimizer_args = {'amsgrad'=False, 'lr':0.001}
         else:
             self.optimizer_class = optim.Adadelta
             self.optimizer_args = {'lr': 0.1}

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -9,6 +9,7 @@ import logging
 import numpy as np
 
 from lightwood.mixers.nn.helpers.default_net import DefaultNet
+from lightwood.mixers.nn.helpers.adamw import AdamW
 from lightwood.mixers.nn.helpers.transformer import Transformer
 
 
@@ -148,13 +149,24 @@ class NnMixer:
 
         self.net = self.nn_class(ds)
         self.net.train()
-        self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
+        lr = 0.001
+        self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False) #self.optimizer_class(self.net.parameters(), **self.optimizer_args)
 
         total_epochs = self.epochs
 
         for epoch in range(total_epochs):  # loop over the dataset multiple times
             running_loss = 0.0
             error = 0
+            print(lr)
+            if epoch < 120:
+                if lr < 0.01:
+                    lr=lr + 0.00025
+                    self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
+            else:
+                if lr > 0.001:
+                    lr=lr - 0.0001
+                    self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
+
             for i, data in enumerate(data_loader, 0):
                 # get the inputs; data is a list of [inputs, labels]
                 inputs, labels = data

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -16,6 +16,7 @@ from lightwood.mixers.nn.helpers.transformer import Transformer
 class NnMixer:
 
     def __init__(self):
+        self.dynamic_adamw = False
         self.net = None
         self.optimizer = None
         self.input_column_names = None
@@ -27,8 +28,14 @@ class NnMixer:
 
         self.criterion = nn.MSELoss()
         self.epochs = 120000
-        self.optimizer_class = optim.Adadelta
-        self.optimizer_args = {'lr': 0.1}
+
+        if self.dynamic_adamw:
+            self.optimizer_classs = AdamW
+            slef.optimizer_args = {amsgrad=False, 'self.optimizer_args['lr']':0.001}
+        else:
+            self.optimizer_class = optim.Adadelta
+            self.optimizer_args = {'self.optimizer_args['lr']': 0.1}
+
         self.nn_class = DefaultNet
         self.batch_size = 100
 
@@ -150,8 +157,6 @@ class NnMixer:
         self.net = self.nn_class(ds)
         self.net.train()
 
-        #lr = 0.001
-        #self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
         self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
 
         total_epochs = self.epochs
@@ -160,17 +165,16 @@ class NnMixer:
             running_loss = 0.0
             error = 0
 
-            '''
-            print(lr)
-            if epoch < 120:
-                if lr < 0.01:
-                    lr=lr + 0.00025
-                    self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
-            else:
-                if lr > 0.001:
-                    lr=lr - 0.0001
-                    self.optimizer = AdamW(self.net.parameters(), lr=lr, amsgrad=False)
-            '''
+            if self.dynamic_adamw:
+                print(self.optimizer_args['lr'])
+                if epoch < 120:
+                    if self.optimizer_args['lr'] < 0.01:
+                        self.optimizer_args['lr']=self.optimizer_args['lr'] + 0.00025
+                else:
+                    if self.optimizer_args['lr'] > 0.001:
+                        self.optimizer_args['lr']=self.optimizer_args['lr'] - 0.0001
+
+                self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
 
             for i, data in enumerate(data_loader, 0):
                 # get the inputs; data is a list of [inputs, labels]

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -31,7 +31,7 @@ class NnMixer:
 
         if self.dynamic_adamw:
             self.optimizer_class = AdamW
-            slef.optimizer_args = {'amsgrad': False, 'lr':0.001}
+            self.optimizer_args = {'amsgrad': False, 'lr':0.001}
         else:
             self.optimizer_class = optim.Adadelta
             self.optimizer_args = {'lr': 0.1}

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -166,7 +166,6 @@ class NnMixer:
             error = 0
 
             if self.dynamic_adamw:
-                print(self.optimizer_args['lr'])
                 if epoch < 120:
                     if self.optimizer_args['lr'] < 0.01:
                         self.optimizer_args['lr']=self.optimizer_args['lr'] + 0.00025

--- a/lightwood/mixers/sk_learn/sk_learn.py
+++ b/lightwood/mixers/sk_learn/sk_learn.py
@@ -10,8 +10,7 @@ from lightwood.mixers.sk_learn.sk_learn_helper import SkLearnMixerHelper
 
 class SkLearnMixer(SkLearnMixerHelper):
 
-    def __init__(self, input_column_names, output_column_names, score_threshold=0.5,
-                 classifier_class=MultiOutputClassifier, regression_class=MultiOutputRegressor):
+    def __init__(self, score_threshold=0.5, classifier_class=MultiOutputClassifier, regression_class=MultiOutputRegressor):
         """
         :param input_column_names: is a list [col_name1, col_name2]
         :param output_column_names: is a list [col_name1, col_name2]
@@ -19,8 +18,6 @@ class SkLearnMixer(SkLearnMixerHelper):
         :param classifier_class: model name for classification
         :param regression_class: model name for Regression
         """
-        self.input_column_names = input_column_names
-        self.output_column_names = output_column_names
 
         self.feature_columns = {}  # the columns that are actually used in the fit and predict
         self.output_encoders = {}

--- a/lightwood/mixers/sk_learn/sk_learn.py
+++ b/lightwood/mixers/sk_learn/sk_learn.py
@@ -10,7 +10,8 @@ from lightwood.mixers.sk_learn.sk_learn_helper import SkLearnMixerHelper
 
 class SkLearnMixer(SkLearnMixerHelper):
 
-    def __init__(self, score_threshold=0.5, classifier_class=MultiOutputClassifier, regression_class=MultiOutputRegressor):
+    def __init__(self, score_threshold=0.5,
+                 classifier_class=MultiOutputClassifier, regression_class=MultiOutputRegressor):
         """
         :param input_column_names: is a list [col_name1, col_name2]
         :param output_column_names: is a list [col_name1, col_name2]
@@ -39,9 +40,7 @@ class SkLearnMixer(SkLearnMixerHelper):
             model_class = self._determine_model_class(column, data_source)
             output_encoded_column = self._output_encoded_columns(column, data_source)
 
-            useful_input_encoded_features, self.feature_columns[column] = self._extract_features(data_source,
-                                                                                                 model_class,
-                                                                                                 output_encoded_column)
+            useful_input_encoded_features, self.feature_columns[column] = self._extract_features(data_source, model_class, output_encoded_column)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 self.model[column] = model_class.fit(useful_input_encoded_features, output_encoded_column)
@@ -92,6 +91,10 @@ class SkLearnMixer(SkLearnMixerHelper):
         :param ds:  is a DataSource object
         :return error : Dictionary: error of actual vs predicted encoded values
         """
+        self.input_column_names = self.input_column_names if self.input_column_names is not None else ds.get_feature_names(
+            'input_features')
+        self.output_column_names = self.output_column_names if self.output_column_names is not None else ds.get_feature_names(
+            'output_features')
         self.encoders = ds.encoders
         for i in range(1):
             self.fit(ds)

--- a/lightwood/mixers/sk_learn/sk_learn.py
+++ b/lightwood/mixers/sk_learn/sk_learn.py
@@ -70,7 +70,7 @@ class SkLearnMixer(SkLearnMixerHelper):
             decoded_predictions = self._decoded_data([output_column], when_data_source,
                                                      torch.from_numpy(encoded_predictions))
             predictions[output_column] = {'Encoded Predictions': encoded_predictions,
-                                          'Actual Predictions': decoded_predictions}
+                                          'predictions': decoded_predictions}
 
         logging.info('Model predictions and decoding completed')
         return predictions

--- a/lightwood/mixers/sk_learn/sk_learn.py
+++ b/lightwood/mixers/sk_learn/sk_learn.py
@@ -19,7 +19,8 @@ class SkLearnMixer(SkLearnMixerHelper):
         :param classifier_class: model name for classification
         :param regression_class: model name for Regression
         """
-
+        self.input_column_names = None
+        self.output_column_names = None
         self.feature_columns = {}  # the columns that are actually used in the fit and predict
         self.output_encoders = {}
         self.score_threshold = score_threshold
@@ -91,10 +92,8 @@ class SkLearnMixer(SkLearnMixerHelper):
         :param ds:  is a DataSource object
         :return error : Dictionary: error of actual vs predicted encoded values
         """
-        self.input_column_names = self.input_column_names if self.input_column_names is not None else ds.get_feature_names(
-            'input_features')
-        self.output_column_names = self.output_column_names if self.output_column_names is not None else ds.get_feature_names(
-            'output_features')
+        self.input_column_names = self.input_column_names if self.input_column_names is not None else ds.get_feature_names('input_features')
+        self.output_column_names = self.output_column_names if self.output_column_names is not None else ds.get_feature_names('output_features')
         self.encoders = ds.encoders
         for i in range(1):
             self.fit(ds)

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -1,18 +1,18 @@
 import os
-
-
 import pandas as pd
 from lightwood import Predictor
+import lightwood
 
 ####################
 config = {'input_features': [{'name': 'number_of_rooms', 'type': 'numeric'},
                     {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
                     {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
                     {'name': 'neighborhood', 'type': 'categorical','dropout':0.4}],
- 'output_features': [{'name': 'rental_price', 'type': 'numeric'}]}
+ 'output_features': [{'name': 'rental_price', 'type': 'numeric'}],
+ 'mixer':{'class': lightwood.BUILTIN_MIXERS.NnMixer}}
 
+lightwood.config.config.CONFIG.USE_CUDA = False
 
-lightwood.CONFIG.USE_CUDA = False
 df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
 
 predictor = Predictor(config)

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -12,7 +12,7 @@ config = {'input_features': [{'name': 'number_of_rooms', 'type': 'numeric'},
  'output_features': [{'name': 'rental_price', 'type': 'numeric'}]}
 
 
-
+lightwood.CONFIG.USE_CUDA = False
 df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
 
 predictor = Predictor(config)


### PR DESCRIPTION
* The `USE_CUDA` config option is now properly used to train the model on the GPU (when true) and on the CPU (when false). Default value is `False` when no GPU is detected and `True` when a GPU is detected.
* Updated and cleaned up the Sklearn mixer (it wasn't working before), it can now be specified from the config
* Added some fundamental building blocks for automatically constructing basic FCNN shapes
* Generating the basic FCNN in `default_net` based on the size of the input/output
* Added AdamW and training with an lr curve using  AdamW (currently disabled but can be enabled via setting the `adamw` flag to `True`). This seemed to increase training speed and sometimes even accuracy on some models, but I won't enable it for now, introducing this into production might happen after a longer design session with @torrmal 
* Dropped `nan` support, will now crash if a `nan` value is detected in the numerical encoder