### PR TITLE
Specify what GPU to use

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -90,6 +90,8 @@ class Predictor:
     def convert_to_device(self,device_str=None):
         if device_str is None:
             device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+        if CONFIG.USE_DEVICE is not None:
+            device_str = CONFIG.USE_DEVICE
 
         device = torch.device(device_str)
 

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -5,3 +5,6 @@ class CONFIG:
     USE_CUDA = False
     if torch.cuda.device_count() > 0:
         USE_CUDA = True
+
+
+    USE_DEVICE = None

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -24,7 +24,11 @@ class Img2Vec():
         :param layer: String or Int depending on model.  See more docs: https://github.com/christiansafka/img2vec.git
         :param layer_output_size: Int depicting the output size of the requested layer
         """
-        self.device = torch.device("cuda" if CONFIG.USE_CUDA else "cpu")
+        device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+        if CONFIG.USE_DEVICE is not None:
+            device_str = CONFIG.USE_DEVICE
+
+        self.device = torch.device(device_str)
         self.layer_output_size = layer_output_size
         self.model_name = model
 

--- a/lightwood/mixers/nn/helpers/default_net.py
+++ b/lightwood/mixers/nn/helpers/default_net.py
@@ -8,10 +8,11 @@ import torch
 class DefaultNet(torch.nn.Module):
 
     def __init__(self, ds, dynamic_parameters):
-        if CONFIG.USE_CUDA:
-            self.device = torch.device('cuda')
-        else:
-            self.device = torch.device('cpu')
+        device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+        if CONFIG.USE_DEVICE is not None:
+            device_str = CONFIG.USE_DEVICE
+
+        self.device = torch.device(device_str)
 
         self.dynamic_parameters = dynamic_parameters
         """
@@ -26,7 +27,7 @@ class DefaultNet(torch.nn.Module):
         # Select architecture
 
         # 1. Determine, based on the machines specification, if the input/output size are "large"
-        if CONFIG.USE_CUDA:
+        if CONFIG.USE_CUDA or CONFIG.USE_DEVICE is not None:
             large_input = True if input_size > 4000 else False
             large_output = True if output_size > 400 else False
         else:

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -25,7 +25,6 @@ if sys.platform not in ['win32','cygwin','windows']:
 
 lightwood.config.config.CONFIG.USE_CUDA = False
 
-
 df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
 
 predictor = Predictor(config)


### PR DESCRIPTION
Added variable in the CONFIG that allows us to specify what GPU to use. Variable is called `Specify what GPU to use` and is a string, the values that should be usually given are `cuda:0`, `cuda:1`... etc, where the number is the number of the GPU.

Resolves #7 