### PR TITLE
Large data

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.10.0'
+__version__ = '0.10.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.9.12'
+__version__ = '0.10.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -41,7 +41,6 @@ class DataSource(Dataset):
         self.list_cache = {}
         self.encoded_cache = {}
         self.transformed_cache = None
-        self.decoded_cache = {}
 
 
     def extractRandomSubset(self, percentage):
@@ -71,6 +70,12 @@ class DataSource(Dataset):
         :param idx:
         :return:
         """
+
+        if idx % 200 == 0:
+            print(self.list_cache)
+            print(self.encoded_cache)
+            print(self.transformed_cache)
+            
         sample = {}
         disable_cache = self.disable_cache
 
@@ -230,7 +235,7 @@ class DataSource(Dataset):
         """
         :param column_name: column names to be decoded
         :param encoded_data: encoded data of tensor type
-        :return decoded_cache : Dict :Decoded data of input column
+        :return decoded_data : Dict :Decoded data of input column
         """
         if decoder_instance is None:
             if column_name not in self.encoders:
@@ -238,8 +243,7 @@ class DataSource(Dataset):
                     'Data must have been encoded before at some point, you should not decode before having encoding at least once')
             decoder_instance = self.encoders[column_name]
         decoded_data = decoder_instance.decode(encoded_data)
-        if self.disable_cache == True:
-            self.decoded_cache[column_name] = decoded_data
+
         return decoded_data
 
     def get_feature_names(self, where = 'input_features'):

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -197,7 +197,7 @@ class DataSource(Dataset):
 
         if column_name in self.encoders:
             encoded_vals = self.encoders[column_name].encode(*args)
-            if column_name not in self.encoded_cache and custom_data is not None:
+            if column_name not in self.encoded_cache and custom_data is None:
                 self.encoded_cache[column_name] = encoded_vals
             return encoded_vals
 
@@ -223,7 +223,7 @@ class DataSource(Dataset):
         self.encoders[column_name] = encoder_instance
         encoded_val = encoder_instance.encode(*args)
 
-        if custom_data is not None:
+        if custom_data is None:
             self.encoded_cache[column_name] = encoded_val
 
         return encoded_val

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -70,14 +70,6 @@ class DataSource(Dataset):
         :param idx:
         :return:
         """
-
-        if idx % 200 == 0:
-            print('-------------------')
-            print(self.list_cache)
-            print(self.encoded_cache)
-            print(self.transformed_cache)
-            print('=======================')
-
         sample = {}
 
         dropout_features = None

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -2,6 +2,8 @@ import importlib
 import numpy as np
 from torch.utils.data import Dataset
 import random
+from lightwood.config.config import CONFIG
+
 
 class DataSource(Dataset):
 
@@ -19,9 +21,8 @@ class DataSource(Dataset):
         self.training = False # Flip this flag if you are using the datasource while training
         self.output_weights = None
         self.dropout_dict = {}
-        self.disable_cache = False
-        # Testing
-        self.disable_cache = True
+        self.disable_cache = not CONFIG.USE_CACHE
+        
 
         for col in self.configuration['input_features']:
             if len(self.configuration['input_features']) > 1:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -35,15 +35,14 @@ class DataSource(Dataset):
 
 
     def _clear_cache(self):
-
         self.list_cache = {}
         self.encoded_cache = {}
         self.transformed_cache = None
         self.decoded_cache = {}
+        self.disable_cache = False
 
 
     def extractRandomSubset(self, percentage):
-
         msk = np.random.rand(len(self.data_frame)) < (1-percentage)
         test_df = self.data_frame[~msk]
         self.data_frame = self.data_frame[msk]
@@ -77,7 +76,7 @@ class DataSource(Dataset):
         if self.training == True and random.randint(0,2) == 1:
             dropout_features = [feature['name'] for feature in self.configuration['input_features'] if random.random() > (1 - self.dropout_dict[feature['name']])]
 
-        if self.transformed_cache is None:
+        if self.transformed_cache is None and not self.disable_cache:
             self.transformed_cache = [None] * self.__len__()
 
         if dropout_features is None or len(dropout_features) < 1:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -72,9 +72,11 @@ class DataSource(Dataset):
         """
 
         if idx % 200 == 0:
+            print('-------------------')
             print(self.list_cache)
             print(self.encoded_cache)
             print(self.transformed_cache)
+            print('=======================')
 
         sample = {}
 
@@ -141,7 +143,7 @@ class DataSource(Dataset):
         if self.transformer:
             sample = self.transformer.transform(sample)
 
-        if not disable_cache:
+        if not self.disable_cache:
             self.transformed_cache[idx] = sample
             return self.transformed_cache[idx]
         else:
@@ -195,7 +197,7 @@ class DataSource(Dataset):
 
         if column_name in self.encoders:
             encoded_vals = self.encoders[column_name].encode(*args)
-            if column_name not in self.encoded_cache or custom_data is not None:
+            if column_name not in self.encoded_cache and custom_data is not None:
                 self.encoded_cache[column_name] = encoded_vals
             return encoded_vals
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -327,7 +327,6 @@ class Predictor:
         return self
 
 
-
     def predict(self, when_data=None, when=None):
         """
         Predict given when conditions
@@ -365,11 +364,11 @@ class Predictor:
                     'value': accuracy_score(ds.get_column_original_data(output_column), predictions[output_column]["predictions"])
                 }
             else:
-                real = [pow(2,63) if math.isnan(x) or math.isinf(x) else x for x in ds.get_column_original_data(output_column)]
-                predicted = [pow(2,63) if math.isnan(x) or math.isinf(x) else x for x in predictions[output_column]["predictions"]]
+                # Note: We use this method instead of using `encoded_predictions` since the values in encoded_predictions are never prefectly 0 or 1, and this leads to rather large unwaranted different in the r2 score, re-encoding the predictions means all "flag" values (sign, isnull, iszero) become either 1 or 0
+                encoded_predictions = ds.encoders[output_column].encode(predictions[output_column]["predictions"])
                 accuracies[output_column] = {
                     'function': 'r2_score',
-                    'value': r2_score(real, predicted)
+                    'value': r2_score(ds.get_encoded_column_data(output_column), encoded_predictions)
                 }
 
         return accuracies

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -361,7 +361,7 @@ class Predictor:
             if properties['type'] == 'categorical':
                 accuracies[output_column] = {
                     'function': 'accuracy_score',
-                    'value': accuracy_score(ds.get_column_original_data(output_column), predictions[output_column]["predictions"])
+                    'value': accuracy_score(list(map(str,ds.get_column_original_data(output_column))), list(map(str,predictions[output_column]["predictions"])))
                 }
             else:
                 # Note: We use this method instead of using `encoded_predictions` since the values in encoded_predictions are never prefectly 0 or 1, and this leads to rather large unwaranted different in the r2 score, re-encoding the predictions means all "flag" values (sign, isnull, iszero) become either 1 or 0

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 import time
+import math
 
 import dill
 import copy
@@ -364,9 +365,11 @@ class Predictor:
                     'value': accuracy_score(ds.get_column_original_data(output_column), predictions[output_column]["predictions"])
                 }
             else:
+                real = [pow(2,63) if math.isnan(x) or math.isinf(x) else x for x in ds.get_column_original_data(output_column)]
+                predicted = [pow(2,63) if math.isnan(x) or math.isinf(x) else x for x in predictions[output_column]["predictions"]]
                 accuracies[output_column] = {
                     'function': 'r2_score',
-                    'value': r2_score(ds.get_column_original_data(output_column), predictions[output_column]["predictions"])
+                    'value': r2_score(real, predicted)
                 }
 
         return accuracies

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -2,9 +2,10 @@ import logging
 import traceback
 import time
 import math
+import copy
+import sys
 
 import dill
-import copy
 import pandas
 import numpy as np
 import torch
@@ -69,7 +70,7 @@ class Predictor:
 
         if max_training_time is None and max_epochs is None:
             logging.error("Please provide either `max_training_time` or `max_epochs` when calling `evaluate_mixer`")
-            exit()
+            sys.exit(1)
 
         lowest_error_epoch = 0
         for epoch, training_error in enumerate(mixer.iter_fit(from_data_ds)):
@@ -175,7 +176,6 @@ class Predictor:
                 mixer_params = self.config['mixer']['attrs']
         else:
             mixer_class = NnMixer
-
         # Initialize data sources
         try:
             mixer_class({}).fit_data_source(from_data_ds)
@@ -218,7 +218,6 @@ class Predictor:
         else:
             # Run a bunch of models through AX and figure out some decent values to put in here
             best_parameters = {}
-
         mixer = mixer_class(best_parameters, is_categorical_output=is_categorical_output)
         self._mixer = mixer
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -69,8 +69,9 @@ class Predictor:
         mixer = mixer_class(dynamic_parameters, is_categorical_output)
 
         if max_training_time is None and max_epochs is None:
-            logging.error("Please provide either `max_training_time` or `max_epochs` when calling `evaluate_mixer`")
-            sys.exit(1)
+            err = "Please provide either `max_training_time` or `max_epochs` when calling `evaluate_mixer`"
+            logging.error(err)
+            raise Exception(err)
 
         lowest_error_epoch = 0
         for epoch, training_error in enumerate(mixer.iter_fit(from_data_ds)):

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -8,3 +8,4 @@ class CONFIG:
 
 
     USE_DEVICE = None
+    USE_CACHE = True

--- a/lightwood/data_schemas/predictor_config.py
+++ b/lightwood/data_schemas/predictor_config.py
@@ -8,8 +8,7 @@ feature_schema = Schema({
     Optional('encoder_attrs'): dict,
     Optional('depends_on_column'): str,
     Optional('dropout'): float,
-    Optional('weights'): dict,
-    Optional('disable_cache'): bool
+    Optional('weights'): dict
 })
 
 mixer_graph_schema = Schema({

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -27,8 +27,9 @@ class NumericEncoder:
                 continue
 
             if math.isnan(number):
-                logging.error('Lightwood does not support working with NaN values !')
-                sys.exit(1)
+                err = 'Lightwood does not support working with NaN values !'
+                logging.error(err)
+                raise Exception(err)
 
             self._min_value = number if self._min_value is None or self._min_value > number else self._min_value
             self._max_value = number if self._max_value is None or self._max_value < number else self._max_value

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -1,6 +1,8 @@
 import torch
 import math
 import logging
+import sys
+
 
 class NumericEncoder:
 
@@ -26,7 +28,7 @@ class NumericEncoder:
 
             if math.isnan(number):
                 logging.error('Lightwood does not support working with NaN values !')
-                exit()
+                sys.exit(1)
 
             self._min_value = number if self._min_value is None or self._min_value > number else self._min_value
             self._max_value = number if self._max_value is None or self._max_value < number else self._max_value

--- a/lightwood/mixers/nn/helpers/transformer.py
+++ b/lightwood/mixers/nn/helpers/transformer.py
@@ -6,7 +6,7 @@ class Transformer:
 
         self.input_features = input_features
         self.output_features = output_features
-
+        
         self.feature_len_map = {}
 
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -45,6 +45,7 @@ class NnMixer:
         :param when_data_source:
         :return:
         """
+
         when_data_source.transformer = self.transformer
         when_data_source.encoders = self.encoders
         data_loader = DataLoader(when_data_source, batch_size=len(when_data_source), shuffle=False, num_workers=0)
@@ -131,7 +132,17 @@ class NnMixer:
     def fit_data_source(self, ds):
         self.input_column_names = self.input_column_names if self.input_column_names is not None else ds.get_feature_names('input_features')
         self.output_column_names = self.output_column_names if self.output_column_names is not None else ds.get_feature_names('output_features')
-        ds.transformer = Transformer(self.input_column_names, self.output_column_names)
+
+        transformer_already_initialized = False
+        try:
+            if len(list(ds.transformer.feature_len_map.keys())) > 0:
+                transformer_already_initialized = True
+        except:
+            pass
+
+        if not transformer_already_initialized:
+            ds.transformer = Transformer(self.input_column_names, self.output_column_names)
+            
         self.encoders = ds.encoders
         self.transformer = ds.transformer
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -72,7 +72,7 @@ class NnMixer:
 
         for output_column in output_encoded_vectors:
 
-            decoded_predictions = when_data_source.get_decoded_column_data(output_column, when_data_source.encoders[output_column]._pytorch_wrapper(output_encoded_vectors[output_column]),  cache=False)
+            decoded_predictions = when_data_source.get_decoded_column_data(output_column, when_data_source.encoders[output_column]._pytorch_wrapper(output_encoded_vectors[output_column]))
             predictions[output_column] = {'predictions': decoded_predictions}
             if include_encoded_predictions:
                 predictions[output_column]['encoded_predictions'] = output_encoded_vectors[output_column]

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -6,7 +6,7 @@ import lightwood
 
 ####################
 config = {'input_features': [
-                    {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric', 'disable_cache': True},
+                    {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
                     {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
                     {'name': 'neighborhood', 'type': 'categorical','dropout':0.4},{'name': 'rental_price', 'type': 'numeric'}],
  'output_features': [{'name': 'number_of_rooms', 'type': 'categorical', 'weights':{


### PR DESCRIPTION
Main feature:

* Allow for cache disabling via the `CONFIG`, this is useful for running large dataset, it does decrease speed but it doesn't seem to affect it that significantly. We should control this option dynamically from mindsdb in the future based on the computer's available memory and the dataset size (PR incoming tonight or tomorrow).

In the process of doing this I've removed the option to disable the cache for a particular column only, since it proved to cumbersome to implement properly and it was hardly working as intended. Might be worth looking at implementing it again when we have more time and/or when we restructure some of the dataset logic. But I don't think now is the correct moment.

Various fixes:

* Changed the r2 accuracy score for numerical target variables to use the encoded values, which fixed #47. Unlike the previous implementation though, we take the decoded predictions and encode them, that way flags (the positions that represent isnull, iszero and sign) will be either 0 or 1, rather than `0.0x` or `9.9x`, which was decreasing the r2 score significantly.

* Changed an internal logic of fitting a data source to a model so that the transformer doesn't get replaced with a new one every time, if the data source already has a trasnformer. This fixes #46 

* Fix to accuracy score so that it works well when the panda df interprets one of the categorical column as a number