### PR TITLE
Initialization seed

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.0'
+__version__ = '0.11.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -22,7 +22,7 @@ class DataSource(Dataset):
         self.output_weights = None
         self.dropout_dict = {}
         self.disable_cache = not CONFIG.USE_CACHE
-        
+
 
         for col in self.configuration['input_features']:
             if len(self.configuration['input_features']) > 1:
@@ -45,6 +45,7 @@ class DataSource(Dataset):
 
 
     def extractRandomSubset(self, percentage):
+        np.random.seed(int(round(percentage*100000)))
         msk = np.random.rand(len(self.data_frame)) < (1-percentage)
         test_df = self.data_frame[~msk]
         self.data_frame = self.data_frame[msk]

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -8,7 +8,7 @@ class CONFIG:
 
     USE_DEVICE = None
 
-    FULLY_DETERMINISTIC = True
+    DETERMINISTIC = True
 
     USE_CACHE = True
 

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -7,6 +7,9 @@ class CONFIG:
         USE_CUDA = True
 
     USE_DEVICE = None
+
+    FULLY_DETERMINISTIC = True
+
     USE_CACHE = True
 
     NUMBER_OF_PROBABILISTIC_MODELS = 2

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -82,10 +82,8 @@ class DefaultNet(torch.nn.Module):
 
         for layer in self.net:
             if isinstance(layer, torch.nn.Linear):
-                torch.nn.init.normal_(layer.weight, std=1 / math.sqrt(layer.out_features))
-                fan_in, fan_out = torch.nn.init._calculate_fan_in_and_fan_out(layer.weight)
-                bound = 1 / math.sqrt(fan_in)
-                torch.nn.init.uniform_(layer.bias, -bound, bound)
+                torch.nn.init.normal_(layer.weight, mean=0, std=1 / math.sqrt(layer.out_features))
+                torch.nn.init.normal_(layer.bias, mean=0, std=0)
 
         self.net = self.net.to(self.device)
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -73,6 +73,13 @@ class DefaultNet(torch.nn.Module):
 
         self.net = torch.nn.Sequential(*layers)
 
+        for layer in self.net:
+            if isinstance(layer, torch.nn.Linear):
+                torch.nn.init.normal_(layer.weight, std=1 / math.sqrt(layer.out_features))
+                fan_in, fan_out = torch.nn.init._calculate_fan_in_and_fan_out(layer.weight)
+                bound = 1 / math.sqrt(fan_in)
+                nn.init.uniform_(layer.bias, -bound, bound)
+
         self.net = self.net.to(self.device)
 
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -12,11 +12,11 @@ class DefaultNet(torch.nn.Module):
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE
 
-        torch.manual_seed(74551)
-        if device_str == 'cuda':
-            if CONFIG.FULLY_DETERMINISTIC:
-                torch.backends.cudnn.deterministic = True
-                torch.backends.cudnn.benchmark = False
+        if CONFIG.DETERMINISTIC:
+            torch.manual_seed(74551)
+            if device_str == 'cuda':
+                    torch.backends.cudnn.deterministic = True
+                    torch.backends.cudnn.benchmark = False
 
 
         self.device = torch.device(device_str)

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -13,7 +13,7 @@ class DefaultNet(torch.nn.Module):
             device_str = CONFIG.USE_DEVICE
 
         if device_str == 'cuda':
-            torch.manual_seed(len(ds))
+            torch.manual_seed(74551)
         else:
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -13,7 +13,11 @@ class DefaultNet(torch.nn.Module):
             device_str = CONFIG.USE_DEVICE
 
         if CONFIG.DETERMINISTIC:
-            torch.manual_seed(74551)
+            '''
+                Seed that always has the same value on the same dataset plus setting the bellow CUDA options
+                In order to make sure pytroch randomly generate number will be the same every time when training on the same dataset
+            '''
+            torch.manual_seed(len(ds))
             if device_str == 'cuda':
                     torch.backends.cudnn.deterministic = True
                     torch.backends.cudnn.benchmark = False

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -82,8 +82,8 @@ class DefaultNet(torch.nn.Module):
 
         for layer in self.net:
             if isinstance(layer, torch.nn.Linear):
-                torch.nn.init.normal_(layer.weight, mean=0, std=1 / math.sqrt(layer.out_features))
-                torch.nn.init.normal_(layer.bias, mean=0, std=0)
+                torch.nn.init.normal_(layer.weight, mean=0., std=1 / math.sqrt(layer.out_features))
+                torch.nn.init.normal_(layer.bias, mean=0., std=0.1)
 
         self.net = self.net.to(self.device)
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -12,6 +12,12 @@ class DefaultNet(torch.nn.Module):
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE
 
+        if device_str == 'cuda':
+            torch.manual_seed(len(ds))
+        else:
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
         self.device = torch.device(device_str)
 
         self.dynamic_parameters = dynamic_parameters
@@ -78,7 +84,7 @@ class DefaultNet(torch.nn.Module):
                 torch.nn.init.normal_(layer.weight, std=1 / math.sqrt(layer.out_features))
                 fan_in, fan_out = torch.nn.init._calculate_fan_in_and_fan_out(layer.weight)
                 bound = 1 / math.sqrt(fan_in)
-                nn.init.uniform_(layer.bias, -bound, bound)
+                torch.nn.init.uniform_(layer.bias, -bound, bound)
 
         self.net = self.net.to(self.device)
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -12,11 +12,12 @@ class DefaultNet(torch.nn.Module):
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE
 
+        torch.manual_seed(74551)
         if device_str == 'cuda':
-            torch.manual_seed(74551)
-        else:
-            torch.backends.cudnn.deterministic = True
-            torch.backends.cudnn.benchmark = False
+            if CONFIG.FULLY_DETERMINISTIC:
+                torch.backends.cudnn.deterministic = True
+                torch.backends.cudnn.benchmark = False
+
 
         self.device = torch.device(device_str)
 

--- a/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
+++ b/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
@@ -1,10 +1,16 @@
 import ax
+from random import randint
+
 
 class BasicAxOptimizer:
     def __init__(self):
         self.total_trials = 32
 
     def evaluate(self, error_yielding_function):
+        if if CONFIG.DETERMINISTIC:
+            random_seed = self.total_trials
+        else:
+            random_seed = randint(1,pow(2,32))
         best_parameters, values, experiment, model = ax.optimize(
             parameters=[
                 {'name': 'beta1', 'type': 'choice', 'values': [0.90,0.95]},
@@ -15,7 +21,7 @@ class BasicAxOptimizer:
             evaluation_function=error_yielding_function,
             objective_name='accuracy',
             total_trials = self.total_trials,
-            random_seed = self.total_trials
+            random_seed = random_seed
         )
 
         return best_parameters

--- a/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
+++ b/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
@@ -7,7 +7,7 @@ class BasicAxOptimizer:
         self.total_trials = 32
 
     def evaluate(self, error_yielding_function):
-        if if CONFIG.DETERMINISTIC:
+        if CONFIG.DETERMINISTIC:
             random_seed = self.total_trials
         else:
             random_seed = randint(1,pow(2,32))

--- a/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
+++ b/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
@@ -1,5 +1,6 @@
 import ax
 from random import randint
+from lightwood.config.config import CONFIG
 
 
 class BasicAxOptimizer:

--- a/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
+++ b/lightwood/model_building/basic_ax_optimizer/basic_ax_optimizer.py
@@ -15,6 +15,7 @@ class BasicAxOptimizer:
             evaluation_function=error_yielding_function,
             objective_name='accuracy',
             total_trials = self.total_trials,
+            random_seed = self.total_trials
         )
 
         return best_parameters

--- a/pr.ref.md
+++ b/pr.ref.md
@@ -1,0 +1,5 @@
+##Refrences for version `0.11.1` PR -- branch: initialization_seed
+
+* SNN paper: https://arxiv.org/pdf/1706.02515.pdf
+* SNN initialization code (slight modifcation): https://github.com/tonyduan/snn
+* Docs on obtaining deterministic models: https://pytorch.org/docs/stable/notes/randomness.html

--- a/pr.ref.md
+++ b/pr.ref.md
@@ -1,5 +1,5 @@
 ##Refrences for version `0.11.1` PR -- branch: initialization_seed
 
 * SNN paper: https://arxiv.org/pdf/1706.02515.pdf
-* SNN initialization code (slight modifcation): https://github.com/tonyduan/snn
+* SNN paper code (see 8 for initialization): https://github.com/bioinf-jku/SNNs/blob/master/SelfNormalizingNetworks_MLP_MNIST.ipynb
 * Docs on obtaining deterministic models: https://pytorch.org/docs/stable/notes/randomness.html

--- a/pr.ref.txt
+++ b/pr.ref.txt
@@ -1,0 +1,2 @@
+https://arxiv.org/pdf/1706.02515.pdf
+https://github.com/tonyduan/snn

--- a/pr.ref.txt
+++ b/pr.ref.txt
@@ -1,3 +1,5 @@
-https://arxiv.org/pdf/1706.02515.pdf
-https://github.com/tonyduan/snn
-https://pytorch.org/docs/stable/notes/randomness.html
+
+Refrences for version `0.11.1` PR -- branch: initialization_seed
+SNN paper: https://arxiv.org/pdf/1706.02515.pdf
+SNN initialization code (slight modifcation): https://github.com/tonyduan/snn
+Docs on obtaining deterministic models: https://pytorch.org/docs/stable/notes/randomness.html

--- a/pr.ref.txt
+++ b/pr.ref.txt
@@ -1,2 +1,3 @@
 https://arxiv.org/pdf/1706.02515.pdf
 https://github.com/tonyduan/snn
+https://pytorch.org/docs/stable/notes/randomness.html

--- a/pr.ref.txt
+++ b/pr.ref.txt
@@ -1,5 +1,0 @@
-
-Refrences for version `0.11.1` PR -- branch: initialization_seed
-SNN paper: https://arxiv.org/pdf/1706.02515.pdf
-SNN initialization code (slight modifcation): https://github.com/tonyduan/snn
-Docs on obtaining deterministic models: https://pytorch.org/docs/stable/notes/randomness.html


### PR DESCRIPTION
Added random seeds wherever possible plus CUDA options to make training deterministic, in spite of what the pytroch docs say I haven't notice a significant decrease in lightwood training speed (< 1%)

Over 5x runs on default on credit and 2x runs on all the benchmark datasets (with optimization enabled) we got the exact same accuracy to the second to last decimal.

Also added explicit weight/bias initialization for the default net, so that doesn't change randomly when torch version gets changed or users have different versions of torch. Since already use the SELU activations I used the initialization they propose in their paper (see ` pr.ref.md `), for bias initialization I ended up using 0.1 (tried using `0` as their code shows but torch doesn't allow me to create a normal distribution with std `0`, which presumably would initialize all biases to 0... maybe we should switch to torch.zeros for biases ?)

Added ` pr.ref.md ` to keep track of references for the various changes.

This should allow us to reliably see improvements/drops on the benchmarks without outlier models getting in the way, granted, it reduces the possibility for outlier models, but we can disable it via `CONFIG.DETERMINISTIC` if we ever want to train an ensemble.