### PR TITLE
Memory aware model

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.3'
+__version__ = '0.11.4'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.6'
+__version__ = '0.11.7'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.4'
+__version__ = '0.11.6'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -8,7 +8,7 @@ class CONFIG:
 
     USE_DEVICE = None
 
-    DETERMINISTIC = False
+    DETERMINISTIC = True
 
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic
 

--- a/lightwood/mixers/helpers/batch_size.py
+++ b/lightwood/mixers/helpers/batch_size.py
@@ -1,7 +1,0 @@
-from lightwood.config.config import CONFIG
-
-
-def calculate_batch_size():
-    device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
-    if CONFIG.USE_DEVICE is not None:
-        device_str = CONFIG.USE_DEVICE

--- a/lightwood/mixers/helpers/batch_size.py
+++ b/lightwood/mixers/helpers/batch_size.py
@@ -1,0 +1,7 @@
+from lightwood.config.config import CONFIG
+
+
+def calculate_batch_size():
+    device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+    if CONFIG.USE_DEVICE is not None:
+        device_str = CONFIG.USE_DEVICE

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -2,6 +2,7 @@ import logging
 from lightwood.config.config import CONFIG
 from lightwood.mixers.helpers.shapes import *
 from lightwood.mixers.helpers.plinear import PLinear
+from lightwood.mixers.helpers.debugging import get_gpu_memory_map
 import torch
 
 
@@ -60,7 +61,10 @@ class DefaultNet(torch.nn.Module):
 
         if (not large_input) and (not large_output):
             shape = rombus(self.input_size,self.output_size,depth,self.input_size*2)
-
+            print(depth)
+            print(shape)
+            print(' HERE !')
+            exit()
         elif (not large_output) and large_input:
             shape = funnel(self.input_size,self.output_size,depth)
 
@@ -69,6 +73,11 @@ class DefaultNet(torch.nn.Module):
         else:
             shape = rectangle(self.input_size,self.output_size,depth - 2)
 
+        mem_usage = 0
+        for i in range(1,len(shape)):
+            mem_usage += shape[i]
+            mem_usage += shape[i] * shape[i-1]
+        mem_usage = mem_usage*32/pow(10,6)
 
         logging.info(f'Building network of shape: {shape}')
         rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU
@@ -93,8 +102,13 @@ class DefaultNet(torch.nn.Module):
                     torch.nn.init.normal_(layer.mean, mean=0., std=1 / math.sqrt(layer.out_features))
                     torch.nn.init.normal_(layer.bias, mean=0., std=0.1)
 
+        print(mem_usage)
+        print(shape)
+        print(get_gpu_memory_map())
         self.net = self.net.to(self.device)
+        print(get_gpu_memory_map())
 
+        exit()
 
     def forward(self, input):
         """

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -52,7 +52,7 @@ class DefaultNet(torch.nn.Module):
                 shape = funnel(self.input_size,self.output_size,depth)
             elif shape_name == 'rectangle':
                 shape = rectangle(self.input_size,self.output_size,depth)
-
+                
         logging.info(f'Building network of shape: {shape}')
         rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -34,6 +34,11 @@ class DefaultNet(torch.nn.Module):
         super(DefaultNet, self).__init__()
         input_sample, output_sample = ds[0]
 
+        self.input_size = len(input_sample)
+        self.output_size = len(output_sample)
+        del input_sample
+        del output_sample
+
         if 'network_depth' in self.dynamic_parameters:
             depth = self.dynamic_parameters['network_depth']
         else:

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class DefaultNet(torch.nn.Module):
 
-    def __init__(self, ds, dynamic_parameters):
+    def __init__(self, ds, dynamic_parameters, size_parameters={}):
         device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE
@@ -27,6 +27,7 @@ class DefaultNet(torch.nn.Module):
         self.device = torch.device(device_str)
 
         self.dynamic_parameters = dynamic_parameters
+        self.size_parameters = size_parameters
         """
         Here we define the basic building blocks of our model, in forward we define how we put it all together along wiht an input
         :param sample_batch: this is used to understand the characteristics of the input and target, it is an object of type utils.libs.data_types.batch.Batch
@@ -39,20 +40,24 @@ class DefaultNet(torch.nn.Module):
         del input_sample
         del output_sample
 
-        if 'network_depth' in self.dynamic_parameters:
-            depth = self.dynamic_parameters['network_depth']
+        if 'network_depth' in self.size_parameters:
+            depth = self.size_parameters['network_depth']
         else:
             depth = 5
 
-        if 'shape' in self.dynamic_parameters:
-            shape_name = self.dynamic_parameters['shape']
+        if 'shape' in self.size_parameters:
+            shape_name = self.size_parameters['shape']
             if shape_name == 'rombus':
                 shape = rombus(self.input_size,self.output_size,depth,self.input_size*2)
             elif shape_name == 'funnel':
                 shape = funnel(self.input_size,self.output_size,depth)
             elif shape_name == 'rectangle':
                 shape = rectangle(self.input_size,self.output_size,depth)
-                
+            else:
+                raise Exception(f'Invalid shape: "{shape}" !')
+        else:
+            shape = funnel(self.input_size,self.output_size,depth)
+
         logging.info(f'Building network of shape: {shape}')
         rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU
 

--- a/lightwood/mixers/helpers/shapes.py
+++ b/lightwood/mixers/helpers/shapes.py
@@ -7,10 +7,14 @@ def funnel(in_size, out_size, depth):
         logging.warning('Depth must be at least 2 for the funnel function to work correctly, setting it to 2')
         depth = 2
 
-    step_denominator = depth - 1
-    layers = list( range(out_size, in_size, round((in_size - out_size)/step_denominator) ) )
-    layers.reverse()
-    layers = [in_size, *layers]
+    step = abs(in_size-out_size)/(depth-1)
+
+    for k in range(0,depth-1):
+            layers.append(round(max(in_size,out_size) - k * step))
+    layers.append(min(in_size,out_size))
+
+    if in_size < out_size:
+        layers.reverse()
     return layers
 
 def rectangle(in_size,out_size,depth):
@@ -32,12 +36,17 @@ def rombus(in_size,out_size,depth,max_size=None):
     funnel_size = math.ceil(depth/2)
 
     first_funnel = funnel(in_size, max_size,funnel_size)
-
+    print(first_funnel)
     if depth % 2 == 1:
         first_funnel = first_funnel[:-1]
 
     second_funnel = funnel(max_size,out_size,funnel_size)
 
+    print(first_funnel)
+    print(second_funnel)
     layers = [*first_funnel,*second_funnel]
 
+    print(layers)
+    print(depth)
+    exit()
     return layers

--- a/lightwood/mixers/helpers/shapes.py
+++ b/lightwood/mixers/helpers/shapes.py
@@ -9,6 +9,7 @@ def funnel(in_size, out_size, depth):
 
     step = abs(in_size-out_size)/(depth-1)
 
+    layers = []
     for k in range(0,depth-1):
             layers.append(round(max(in_size,out_size) - k * step))
     layers.append(min(in_size,out_size))
@@ -36,17 +37,11 @@ def rombus(in_size,out_size,depth,max_size=None):
     funnel_size = math.ceil(depth/2)
 
     first_funnel = funnel(in_size, max_size,funnel_size)
-    print(first_funnel)
     if depth % 2 == 1:
         first_funnel = first_funnel[:-1]
 
     second_funnel = funnel(max_size,out_size,funnel_size)
 
-    print(first_funnel)
-    print(second_funnel)
     layers = [*first_funnel,*second_funnel]
 
-    print(layers)
-    print(depth)
-    exit()
     return layers

--- a/lightwood/mixers/helpers/size_estimation.py
+++ b/lightwood/mixers/helpers/size_estimation.py
@@ -1,0 +1,38 @@
+from lightwood.config.config import CONFIG
+from psutil import virtual_memory
+import torch
+
+
+def calculate_batch_size():
+    device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+    if CONFIG.USE_DEVICE is not None:
+        device_str = CONFIG.USE_DEVICE
+
+def get_cpu_available_memory():
+    mem = virtual_memory()
+    return mem.available, mem.total
+
+def get_gpu_available_memory():
+    total = torch.cuda.get_device_properties(0).total_memory
+    cached = torch.cuda.memory_cached(0)
+    allocated = torch.cuda.memory_allocated(0)
+    return allocated, total
+
+def estimate_size(net, sample, device):
+        if 'cuda' in str(device):
+            get_available_memory = get_gpu_available_memory
+        else:
+            get_available_memory = get_cpu_available_memory
+
+        before_memory, total = get_available_memory()
+
+        net = net.train()
+        net(sample)
+
+        after_memory, total = get_available_memory()
+        net.zero_grad()
+
+        network_max_memory = after_memory - before_memory
+        percentage_left = (total - after_memory) / total
+
+        return network_max_memory, percentage_left

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -210,8 +210,13 @@ class NnMixer:
                     targets_c = torch.LongTensor(target_indexes)
                     labels = targets_c.to(self.net.device)
 
+                from lightwood.mixers.helpers.debugging import print_gpuutil_status
+
                 loss = self.criterion(outputs, labels)
+                print_gpuutil_status()
                 loss.backward()
+                print_gpuutil_status()
+                print('------------------------------\n\n')
 
                 self.optimizer.step()
                 # Maybe make this a scheduler later

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -173,7 +173,7 @@ class NnMixer:
                 self.optimizer_args[optimizer_arg_name] = self.dynamic_parameters[optimizer_arg_name]
 
         input_sample, output_sample = ds[0]
-        input_size = len(input_size)
+        input_size = len(input_sample)
         output_size = len(output_sample)
         del input_sample
         del output_sample

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -189,7 +189,7 @@ class NnMixer:
                 self.size_parameters['network_depth'] = 3
 
             # Determine what the largest network we can comfortably fit in memory is
-            for i in range(0,7):
+            for i in range(0,6):
                 try:
                     net = self.nn_class(ds, self.size_parameters)
                     net = net.train()
@@ -212,7 +212,7 @@ class NnMixer:
                     break
                 elif self.size_parameters['shape'] == 'funnel':
                     self.size_parameters['shape'] = 'rectangle'
-                elif self.size_parameters['shape'] == 'rectangle':
+                elif self.size_parameters['shape'] == 'rectangle' and output_size < input_size:
                     self.size_parameters['shape'] = 'rombus'
                 else:
                     self.size_parameters['network_depth'] = self.size_parameters['network_depth'] + 1

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -206,7 +206,8 @@ class NnMixer:
                     torch.cuda.empty_cache()
                 break
 
-            if percentage_left < 0.5:
+            # Don't occupy too much space, since training will allocate more memory and we want to leave some room for error
+            if percentage_left < 0.6:
                 break
             elif self.dynamic_parameters['shape'] == 'funnel':
                 self.dynamic_parameters['shape'] = 'rectangle'
@@ -217,9 +218,6 @@ class NnMixer:
 
             self.net = net
             self.optimizer = optimizer
-
-        print(self.net.modules())
-        exit()
 
         if self.criterion is None:
             if self.is_categorical_output:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ xlrd >= 1.0.0
 requests >= 2.0.0
 ax-platform >= 0.1.3
 pyro-ppl >= 0.4.1
+psutil >= 2.0.0


### PR DESCRIPTION
**Important**: This PR will have to be refactored a bit after we merge the Oversample and Selfaware PR, I recommend merging those first as this PR is a bit more complicated and arguably less relevant to our goals (getting explainable models) than Selfaware and improves accuracy on benchmark datasets less than Oversample.

In short:

With this PR the architectures we select for a model are now dependent on how much memory the user has left on the device he chose (cpu == ram and cuda == memory of a given gpu).

More in depth:

* Made some corrections to the way we generate a "funnel" shape for the network, this shouldn't affect most models but the error came in when we had a network with small depth (<4), very large input size and very small input size.

* Implemented an algorithm that iterates through ever-increasing network sizes until either:
a) We run OOM (in which case we safely recover and use the last largest network size we got)
b) We end up with more than 40% of the memory on the device being taken up by the model
c) We reach a "maximum" size for the network past which it would help very little to increase it

Initially we iterate through network shapes: Funnel, Square and then rombus... so essentially (for most cases):

```
# Example here corresponds to a network of 4 inputs and 2 outputs and showcases how we would "grow" the shape with this PR if available memory existed on the machine
                                                                                              *
   
                                                                                              *

*                                            *       *                                *       *      * 
      *                                       
*           *                                *       *      *                         *       *      * 
      *                  =>                                             =>          
*           *                                *        *     *                         *       *      * 
      *
*                                             *        *                               *       *      * 

                                                                                                *
                                                                                                *
```

After that, we grow the depth of the network from 3 layer (1 hidden) to 6 (4 hidden). Once we reach that point, even if there's enough memory left, we stop


* Benchmarked this new implementation, it gives better results on CIFRAR1000 and worst/slightly worst results on the default on credit, pulsar star and cancer50 datasets. However, these results are being compared to the Oversample branch (which is the one that obtains oversample results). I'd like to benchmark this after merging with Oversample and see if the results end up being better or worst.

* Overall, there's room for improvement, the memory usage and available memory determination algorithms are pretty weak at the moment. However, determining available memory is more complicated than I thought and requires some extra dependencies (some of which can't be installed via pip, e.g. nvidia-sim), so before sinking even more time into it, I'd rather see the performance with the current one once merged with Oversample and deciding whether or not this approach is overall a good one to go with.