### PR TITLE
Categorial autoencoder

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.3'
+__version__ = '0.11.8'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -11,9 +11,9 @@ class CONFIG:
     CACHE_ENCODED_DATA = True
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
-    OVERSAMPLE = False
+    OVERSAMPLE = True
     SELFAWARE = True
-    
+
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic
 

--- a/lightwood/encoders/categorical/__init__.py
+++ b/lightwood/encoders/categorical/__init__.py
@@ -1,6 +1,6 @@
 from lightwood.encoders.categorical.categorical import CategoricalEncoder
-from lightwood.encoders.categorical.autoencoder import AutoEncoder
+from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
 
 default = CategoricalEncoder
 oh = CategoricalEncoder
-ae = AutoEncoder
+ae = CategoricalAutoEncoder

--- a/lightwood/encoders/categorical/__init__.py
+++ b/lightwood/encoders/categorical/__init__.py
@@ -1,6 +1,6 @@
 from lightwood.encoders.categorical.categorical import CategoricalEncoder
 from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
 
-default = CategoricalEncoder
+default = CategoricalAutoEncoder
 oh = CategoricalEncoder
 ae = CategoricalAutoEncoder

--- a/lightwood/encoders/categorical/__init__.py
+++ b/lightwood/encoders/categorical/__init__.py
@@ -1,2 +1,6 @@
 from lightwood.encoders.categorical.categorical import CategoricalEncoder
+from lightwood.encoders.categorical.autoencoder import AutoEncoder
+
 default = CategoricalEncoder
+oh = CategoricalEncoder
+ae = AutoEncoder

--- a/lightwood/encoders/categorical/__init__.py
+++ b/lightwood/encoders/categorical/__init__.py
@@ -2,5 +2,5 @@ from lightwood.encoders.categorical.categorical import CategoricalEncoder
 from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
 
 default = CategoricalAutoEncoder
-oh = CategoricalEncoder
-ae = CategoricalAutoEncoder
+onehot = CategoricalEncoder
+autoencoder = CategoricalAutoEncoder

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -1,0 +1,79 @@
+import torch
+import numpy as np
+from lightwood.mixers.helpers.default_net import DefaultNet
+from lightwood.mixers.helpers.transformer import Transformer
+from lightwood.mixers.helpers.ranger import Ranger
+
+UNCOMMON_WORD = '<UNCOMMON>'
+UNCOMMON_TOKEN = 0
+
+class AutoEncoder:
+
+    def __init__(self, is_target = False):
+        self._lang = None
+        self._pytorch_wrapper = torch.FloatTensor
+        self._prepared = False
+
+    def prepare_encoder(self, priming_data):
+        if self._prepared:
+            raise Exception('You can only call "prepare_encoder" once for a given encoder.')
+
+        self._lang = Lang('default')
+        self._lang.index2word = {UNCOMMON_TOKEN: UNCOMMON_WORD}
+        self._lang.word2index = {UNCOMMON_WORD: UNCOMMON_TOKEN}
+        self._lang.word2count[UNCOMMON_WORD] = 0
+        self._lang.n_words = 1
+        for category in priming_data:
+            if category != None:
+                self._lang.addWord(str(category))
+
+        self._prepared = True
+
+    def encode(self, column_data):
+        if not self._prepared:
+            raise Exception('You need to call "prepare_encoder" before calling "encode" or "decode".')
+        ret = []
+        v_len = self._lang.n_words
+
+        for word in column_data:
+            encoded_word = [0]*v_len
+            if word != None:
+                word = str(word)
+                index = self._lang.word2index[word] if word in self._lang.word2index else UNCOMMON_TOKEN
+                encoded_word[index] = 1
+
+            ret.append(encoded_word)
+
+        return self._pytorch_wrapper(ret)
+
+
+    def decode(self, encoded_data):
+        encoded_data_list = encoded_data.tolist()
+        ret = []
+
+        for vector in encoded_data_list:
+            ohe_index = np.argmax(vector)
+
+            ret.append(self._lang.index2word[ohe_index])
+        return ret
+
+
+if __name__ == "__main__":
+
+    data = ['category 1', 'category 3', 'category 4', None]
+
+    enc = CategoricalEncoder()
+
+    enc.fit(data)
+    encoded_data = enc.encode(data)
+    decoded_data = enc.decode(enc.encode(['category 2', 'category 1', 'category 3', None]))
+
+    assert(len(encoded_data) == 4)
+    assert(decoded_data[1] == 'category 1')
+    assert(decoded_data[2] == 'category 3')
+    for i in [0,3]:
+        assert(encoded_data[0][i] == UNCOMMON_TOKEN)
+        assert(decoded_data[i] == UNCOMMON_WORD)
+
+    print(f'Encoded values: \n{encoded_data}')
+    print(f'Decoded values: \n{decoded_data}')

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -21,6 +21,7 @@ class CategoricalAutoEncoder:
         self.encoder = None
         self.decoder = None
         self.oh_encoder = CategoricalEncoder()
+        self.maximum_error = 0.05
 
     def prepare_encoder(self, priming_data):
         if self._prepared:
@@ -40,7 +41,7 @@ class CategoricalAutoEncoder:
         criterion = torch.nn.CrossEntropyLoss()
         optimizer = Ranger(self.net.parameters())
 
-        for epcohs in range(5000):
+        for epcohs in range(50000):
             running_loss = 0
             error = 0
             for i, data in enumerate(data_loader, 0):
@@ -65,7 +66,7 @@ class CategoricalAutoEncoder:
                 error = running_loss / (i + 1)
 
             print(error)
-            if error < 0.005:
+            if error < self.maximum_error:
                 break
 
         modules = [module for module in self.net.modules() if type(module) != torch.nn.Sequential and type(module) != DefaultNet]

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -87,7 +87,6 @@ if __name__ == "__main__":
     # Generate some tests data
     import random
     import string
-    import pandas as pd
     from sklearn.metrics import accuracy_score
 
     random.seed(2)
@@ -102,11 +101,9 @@ if __name__ == "__main__":
             if i % 3 == 0 or i == 1:
                 test_data.append(category)
 
-    priming_data = pd.Series(priming_data).sample(1, random_state=2)
-    test_data = pd.Series(test_data).sample(1, random_state=2)
-    priming_data = list(priming_data)
-    test_data = list(test_data)
-    
+    random.shuffle(priming_data)
+    random.shuffle(test_data)
+
     enc = CategoricalAutoEncoder()
 
     enc.prepare_encoder(priming_data)

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -104,7 +104,9 @@ if __name__ == "__main__":
 
     priming_data = pd.Series(priming_data).sample(1, random_state=2)
     test_data = pd.Series(test_data).sample(1, random_state=2)
-
+    priming_data = list(priming_data)
+    test_data = list(test_data)
+    
     enc = CategoricalAutoEncoder()
 
     enc.prepare_encoder(priming_data)

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     for category in cateogries:
         times = random.randint(1,600)
         for i in range(times):
-            priming_data.appned(category)
+            priming_data.append(category)
             if i % 3 == 0 or i == 1:
                 test_data.append(category)
 

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -30,8 +30,10 @@ class CategoricalAutoEncoder:
         self.oh_encoder.prepare_encoder(priming_data)
 
         input_len = self.oh_encoder._lang.n_words
-        self.use_autoencoder = input_len > max_encoded_length
-        if use_autoencoder:
+        self.use_autoencoder = input_len > self.max_encoded_length
+        if self.use_autoencoder:
+            logging.info('Preparing a categorical autoencoder, this might take a while')
+
             embeddings_layer_len = self.max_encoded_length
 
             self.net = DefaultNet(ds=None, dynamic_parameters={},shape=[input_len, embeddings_layer_len, input_len])
@@ -70,7 +72,6 @@ class CategoricalAutoEncoder:
                     error_buffer.append(error)
 
                 if len(error_buffer) > 5:
-                    print(error)
                     error_buffer.append(error)
                     error_buffer = error_buffer[-5:]
                     delta_mean = np.mean(error_buffer)
@@ -80,6 +81,8 @@ class CategoricalAutoEncoder:
             modules = [module for module in self.net.modules() if type(module) != torch.nn.Sequential and type(module) != DefaultNet]
             self.encoder = torch.nn.Sequential(*modules[0:2])
             self.decoder = torch.nn.Sequential(*modules[2:3])
+            logging.info('Categorical autoencoder ready')
+
         self._prepared = True
 
     def encode(self, column_data):

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -1,5 +1,6 @@
 import torch
 import numpy as np
+import math
 
 from lightwood.mixers.helpers.default_net import DefaultNet
 from lightwood.mixers.helpers.transformer import Transformer
@@ -11,12 +12,14 @@ UNCOMMON_WORD = '<UNCOMMON>'
 UNCOMMON_TOKEN = 0
 MAX_LENGTH = 100
 
-class AutoEncoder:
+class CategoricalAutoEncoder:
 
     def __init__(self, is_target = False):
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
         self.net = None
+        self.encoder = None
+        self.decoder = None
         self.oh_encoder = CategoricalEncoder()
 
     def prepare_encoder(self, priming_data):
@@ -26,52 +29,55 @@ class AutoEncoder:
         self.oh_encoder.prepare_encoder(priming_data)
 
         input_len = self.oh_encoder._lang.n_words
-        embeddings_layer_len = min(input_len/2,MAX_LENGTH)
+        embeddings_layer_len = min(int(math.ceil(input_len/2)),MAX_LENGTH)
 
-        self.net = DefaultNet(dynamic_parameters={},shape=[input_len, embeddings_layer_len, input_len])
+        self.net = DefaultNet(ds=None, dynamic_parameters={},shape=[input_len, embeddings_layer_len, input_len])
 
-        for category in priming_data:
-            encoded_category = self.oh_encoder(category)
+        encoded_priming_data = self.oh_encoder.encode(priming_data)
 
-        ds = torch.utils.data.TensorDataset(priming_data)
-        data_loader = torch.utils.data.DataLoader(ds, batch_size=200, shuffle=True)
+        data_loader = torch.utils.data.DataLoader(encoded_priming_data, batch_size=200, shuffle=True)
 
         criterion = torch.nn.MSELoss()
         optimizer = Ranger(self.net.parameters())
 
-        for epcohs in range(100):
+        for epcohs in range(10000):
             running_loss = 0
             error = 0
             for i, data in enumerate(data_loader, 0):
                 oh_encoded_categories = data
+                oh_encoded_categories = torch.Tensor(oh_encoded_categories)
                 oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                 self.net(oh_encoded_categories)
 
-                self.optimizer.zero_grad()
+                optimizer.zero_grad()
 
-                outputs = self.net(inputs)
-                loss = criterion(outputs, labels)
+                outputs = self.net(oh_encoded_categories)
+                loss = criterion(outputs, oh_encoded_categories)
                 loss.backward()
                 optimizer.step()
                 running_loss += loss.item()
                 error = running_loss / (i + 1)
                 print(error)
 
-            if error < 0.02:
+            if error < 0.01:
                 break
+
+        modules = [module for module in self.net.modules() if type(module) != torch.nn.Sequential]
+        self.encoder = torch.nn.Sequential(*modules[0:2])
+        self.decoder = torch.nn.Sequential(*modules[2:3])
 
         self._prepared = True
 
     def encode(self, column_data):
         oh_encoded_tensor = self.oh_encoder.encode(column_data)
-        oh_encoded_tensor = oh_encoded_tensor.to(self.nn.device)
-        embeddings = self.nn.modules()[0:3](oh_encoded_tensor)
+        oh_encoded_tensor = oh_encoded_tensor.to(self.net.device)
+        embeddings = self.encoder(oh_encoded_tensor)
 
         return embeddings
 
 
     def decode(self, encoded_data):
-        oh_encoded_tensor = nn.modules()[1:4](encoded_data)
+        oh_encoded_tensor = self.decoder(encoded_data)
         oh_encoded_tensor = oh_encoded_tensor.to('cpu')
         decoded_categories = self.oh_encoder.decode(oh_encoded_tensor)
 
@@ -82,18 +88,19 @@ if __name__ == "__main__":
 
     data = ['category 1', 'category 3', 'category 4', None]
 
-    enc = CategoricalEncoder()
+    enc = CategoricalAutoEncoder()
 
-    enc.fit(data)
-    encoded_data = enc.encode(data)
-    decoded_data = enc.decode(enc.encode(['category 2', 'category 1', 'category 3', None]))
+    enc.prepare_encoder(data)
+    encoded_data = enc.encode(['category 2', 'category 1', 'category 3', None])
+    decoded_data = enc.decode(encoded_data)
 
-    assert(len(encoded_data) == 4)
-    assert(decoded_data[1] == 'category 1')
-    assert(decoded_data[2] == 'category 3')
-    for i in [0,3]:
-        assert(encoded_data[0][i] == UNCOMMON_TOKEN)
-        assert(decoded_data[i] == UNCOMMON_WORD)
+    print(f'Original: {data}')
+    print(f'Encoded: {encoded_data}')
+    print(f'Decoded: {decoded_data}')
+
+    assert(len(decoded_data) == 4)
+    for i in range(len(decoded_data)):
+        assert(decoded_data[i] == encoded_data[i])
 
     print(f'Encoded values: \n{encoded_data}')
     print(f'Decoded values: \n{decoded_data}')

--- a/lightwood/encoders/categorical/categorical.py
+++ b/lightwood/encoders/categorical/categorical.py
@@ -1,7 +1,7 @@
 import torch
 from lightwood.encoders.text.helpers.rnn_helpers import Lang
 import numpy as np
-
+import logging
 
 UNCOMMON_WORD = '<UNCOMMON>'
 UNCOMMON_TOKEN = 0

--- a/lightwood/encoders/categorical/categorical.py
+++ b/lightwood/encoders/categorical/categorical.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
 
     enc = CategoricalEncoder()
 
-    enc.fit(data)
+    enc.prepare_encoder(data)
     encoded_data = enc.encode(data)
     decoded_data = enc.decode(enc.encode(['category 2', 'category 1', 'category 3', None]))
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -8,7 +8,7 @@ import torch
 
 class DefaultNet(torch.nn.Module):
 
-    def __init__(self, ds, dynamic_parameters, shape=None, selfaware=None):
+    def __init__(self, ds, dynamic_parameters, shape=None, selfaware=None, size_parameters={}):
         if selfaware is None:
             selfaware = CONFIG.SELFAWARE
         self.selfaware = selfaware
@@ -43,15 +43,8 @@ class DefaultNet(torch.nn.Module):
             self.input_size = len(input_sample)
             self.output_size = len(output_sample)
 
-            # Select architecture
-
-            # 1. Determine, based on the machines specification, if the input/output size are "large"
-            if CONFIG.USE_CUDA or CONFIG.USE_DEVICE is not None:
-                large_input = True if self.input_size > 4000 else False
-                large_output = True if self.output_size > 400 else False
-            else:
-                large_input = True if self.input_size > 1000 else False
-                large_output = True if self.output_size > 100 else False
+            large_input = True if self.input_size > 1000 else False
+            large_output = True if self.output_size > 1000 else False
 
             # 2. Determine in/out proportions
             # @TODO: Maybe provide a warning if the output is larger, this really shouldn't usually be the case (outside of very specific things, such as text to image)
@@ -66,15 +59,10 @@ class DefaultNet(torch.nn.Module):
 
             if (not large_input) and (not large_output):
                 shape = rombus(self.input_size,self.output_size,depth,self.input_size*2)
-
-            elif (not large_output) and large_input:
-                shape = funnel(self.input_size,self.output_size,depth)
-
-            elif (not large_input) and large_output:
+            elif large_input and large_output:
                 shape = rectangle(self.input_size,self.output_size,depth - 1)
             else:
-                shape = rectangle(self.input_size,self.output_size,depth - 2)
-
+                shape = funnel(self.input_size,self.output_size,depth)
 
         logging.info(f'Building network of shape: {shape}')
         rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -8,7 +8,7 @@ import torch
 
 class DefaultNet(torch.nn.Module):
 
-    def __init__(self, ds=None, dynamic_parameters, shape=None):
+    def __init__(self, ds, dynamic_parameters, shape=None):
         device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE

--- a/lightwood/mixers/helpers/shapes.py
+++ b/lightwood/mixers/helpers/shapes.py
@@ -7,10 +7,15 @@ def funnel(in_size, out_size, depth):
         logging.warning('Depth must be at least 2 for the funnel function to work correctly, setting it to 2')
         depth = 2
 
-    step_denominator = depth - 1
-    layers = list( range(out_size, in_size, round((in_size - out_size)/step_denominator) ) )
-    layers.reverse()
-    layers = [in_size, *layers]
+    step = abs(in_size-out_size)/(depth-1)
+
+    layers = []
+    for k in range(0,depth-1):
+            layers.append(round(max(in_size,out_size) - k * step))
+    layers.append(min(in_size,out_size))
+
+    if in_size < out_size:
+        layers.reverse()
     return layers
 
 def rectangle(in_size,out_size,depth):
@@ -32,7 +37,6 @@ def rombus(in_size,out_size,depth,max_size=None):
     funnel_size = math.ceil(depth/2)
 
     first_funnel = funnel(in_size, max_size,funnel_size)
-
     if depth % 2 == 1:
         first_funnel = first_funnel[:-1]
 


### PR DESCRIPTION
Added a new **default** encoder for categorical data `CategoricalAutoEncoder`, and unit tests for this encoder.

The way it operates on a high level is as follows:

* Prepares a one-hot encoder for the column
* If the dictionary length (== nr of dimensions for the one-hot encoding) is smaller then what we set as `max_encoded_length` (set it to 100, but we could chose some other value), it operates just like a one-hot encoder. Otherwise, it train a very simple (input -> hidden -> SELU -> output) autoencoder and uses the `hidden` layer's output's in the `encode` method.

This does not seem to significantly affect any benchmarks, though it obtains worst values than the benchmarks done with `Oversample`, so I'd recommend merging #57 into `master` then merging `master` to this and running the benchmarks again.

Also:
* fixed test for the one-hot categorical encoder
* tweaked the DefaultNet implementation to work with a custom shape (so I could re-use it for the AE)
* Threw in a fix to the funnel shape generation algorithm from the memory aware PR
* Made some changes to the choice of network shape (which should also make the algorithm simpler), also inspired by the changes in the memory aware PR

In the future we could use some fancier autoencoder here, for now this simple one seems to be reasonably good if a bit slow to train.