### PR TITLE
Selfaware fix

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.4'
+__version__ = '0.11.5'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -11,8 +11,9 @@ class CONFIG:
     CACHE_ENCODED_DATA = True
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
-    OVERSAMPLE = True
-
+    OVERSAMPLE = False
+    SELFAWARE = True
+    
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic
 

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -11,8 +11,8 @@ class CONFIG:
     CACHE_ENCODED_DATA = True
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
-    OVERSAMPLE = False
-    
+    OVERSAMPLE = True
+
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -87,7 +87,7 @@ class DefaultNet(torch.nn.Module):
         awareness_layers = []
 
         for ind in range(len(awareness_net_shape) - 1):
-            awareness_layers.append(torch.nn.Linear(shape[ind],shape[ind+1]))
+            awareness_layers.append(torch.nn.Linear(awareness_net_shape[ind],awareness_net_shape[ind+1]))
             if ind < len(awareness_layers) - 2:
                 awareness_layers.append(rectifier())
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -83,7 +83,15 @@ class DefaultNet(torch.nn.Module):
 
         self.net = torch.nn.Sequential(*layers)
 
-        self.awareness_net = linear_function(self.input_size + self.output_size, self.output_size)
+        awareness_net_shape = funnel(self.input_size + self.output_size, self.output_size, 4)
+        awareness_layers = []
+
+        for ind in range(len(awareness_net_shape) - 1):
+            awareness_layers.append(torch.nn.Linear(shape[ind],shape[ind+1]))
+            if ind < len(awareness_layers) - 2:
+                awareness_layers.append(rectifier())
+
+        self.awareness_net = torch.nn.Sequential(*awareness_layers)
 
         if CONFIG.DETERMINISTIC: # set initial weights based on a specific distribution if we have deterministic enabled
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -83,15 +83,16 @@ class DefaultNet(torch.nn.Module):
 
         self.net = torch.nn.Sequential(*layers)
 
-        awareness_net_shape = funnel(self.input_size + self.output_size, self.output_size, 4)
-        awareness_layers = []
+        if CONFIG.SELFAWARE:
+            awareness_net_shape = funnel(self.input_size + self.output_size, self.output_size, 4)
+            awareness_layers = []
 
-        for ind in range(len(awareness_net_shape) - 1):
-            awareness_layers.append(torch.nn.Linear(awareness_net_shape[ind],awareness_net_shape[ind+1]))
-            if ind < len(awareness_layers) - 2:
-                awareness_layers.append(rectifier())
+            for ind in range(len(awareness_net_shape) - 1):
+                awareness_layers.append(torch.nn.Linear(awareness_net_shape[ind],awareness_net_shape[ind+1]))
+                if ind < len(awareness_layers) - 2:
+                    awareness_layers.append(rectifier())
 
-        self.awareness_net = torch.nn.Sequential(*awareness_layers)
+            self.awareness_net = torch.nn.Sequential(*awareness_layers)
 
         if CONFIG.DETERMINISTIC: # set initial weights based on a specific distribution if we have deterministic enabled
 
@@ -105,7 +106,9 @@ class DefaultNet(torch.nn.Module):
                     torch.nn.init.normal_(layer.mean, mean=0., std=1 / math.sqrt(layer.out_features))
                     torch.nn.init.normal_(layer.bias, mean=0., std=0.1)
 
-            reset_layer_params(self.awareness_net)
+            if CONFIG.SELFAWARE:
+                for layer in self.awareness_net:
+                    reset_layer_params(layer)
 
             for layer in self.net:
                 reset_layer_params(layer)
@@ -137,7 +140,7 @@ class DefaultNet(torch.nn.Module):
 
         return (self.max_variance- mean_variance)/self.max_variance
 
-    def forward(self, input, return_awareness = False):
+    def forward(self, input):
         """
         In this particular model, we just need to forward the network defined in setup, with our input
 
@@ -150,11 +153,10 @@ class DefaultNet(torch.nn.Module):
 
         output = self.net(input)
 
-        interim = torch.cat((input, output), 1)
-        awareness = self.awareness_net(interim)
+        if CONFIG.SELFAWARE:
+            interim = torch.cat((input, output), 1)
+            awareness = self.awareness_net(interim)
 
-        if return_awareness:
             return output, awareness
 
-        # else return only the awareness
         return output

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -220,7 +220,12 @@ class NnMixer:
             if optimizer_arg_name in self.dynamic_parameters:
                 self.optimizer_args[optimizer_arg_name] = self.dynamic_parameters[optimizer_arg_name]
 
+        # Set a much smaller learning rate for selfware networks, otherwise the gradients explode
         if CONFIG.SELFAWARE:
+            if 'lr' not in self.optimizer_args:
+                self.optimizer_args['lr'] = 0.00005
+            else:
+                self.optimizer_args['lr'] = self.optimizer_args['lr']/20
 
         #self.optimizer = self.optimizer_class(self.net.net.parameters(), **self.optimizer_args)
         #self.awareness_optimizer = self.optimizer_class(self.net.awareness_net.parameters(), **self.optimizer_args)

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -220,6 +220,8 @@ class NnMixer:
             if optimizer_arg_name in self.dynamic_parameters:
                 self.optimizer_args[optimizer_arg_name] = self.dynamic_parameters[optimizer_arg_name]
 
+        #self.optimizer = self.optimizer_class(self.net.net.parameters(), **self.optimizer_args)
+        #self.awareness_optimizer = self.optimizer_class(self.net.awareness_net.parameters(), **self.optimizer_args)
         self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
         total_epochs = self.epochs
 
@@ -240,7 +242,7 @@ class NnMixer:
 
                 # forward + backward + optimize
                 # outputs = self.net(inputs)
-                outputs, awareness = self.net(inputs, True)  # ask it to return awareness
+                outputs, awareness = self.net(inputs, True)
 
                 if self.is_categorical_output:
                     target = labels.cpu().numpy()
@@ -251,44 +253,22 @@ class NnMixer:
                 else:
                     loss = self.criterion(outputs, labels)
 
-                #loss.backward()
-                #self.optimizer.step()
+                # Unsure why `my_loss` has to be used here
+                real_loss = torch.abs(labels - outputs) # error precentual to the target
+                real_loss = torch.Tensor(real_loss.tolist()) # disconnect from the graph (test if this is necessary)
+                real_loss = real_loss.to(self.net.device)
 
-                #######################
-                ### time to optimize AWARENESS
-                #######################
+                awareness_loss = self.awareness_criterion(awareness, real_loss)
 
-                # zero the parameter gradients
-                #self.optimizer.zero_grad()
-                # forward + backward + optimize
-
-
-                my_loss = torch.abs(labels - outputs) # error precentual to the target
-                my_loss = torch.Tensor(my_loss.tolist()) # disconnect from the graph (test if this is necessary)
-                my_loss = my_loss.to(self.net.device)
-
-                awareness_loss = self.awareness_criterion(awareness, my_loss)
-
-                total_loss = awareness_loss * loss
+                total_loss = awareness_loss + loss
                 total_loss.backward()
-
-                # now that we have run backward in both losses, optimize() (review: we may need to optimize for each step)
                 self.optimizer.step()
-
-
-                # Maybe make this a scheduler later
-                # Start flat and then go into cosine annealing
-
-                """
-                if total_iterations > 600 and epoch > 20:
-                    for group in self.optimizer.param_groups:
-                        if self.optimizer.initial_lr * 1/100 < group['lr']:
-                            group['lr'] = group['lr'] - self.optimizer.initial_lr * 1/400
-                """
-
-                running_loss += loss.item()
+                # now that we have run backward in both losses, optimize() (review: we may need to optimize for each step)
+                running_loss += total_loss.item()
                 error = running_loss / (i + 1)
 
+            print(error)
+            #exit(0)
             yield error
 
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -220,6 +220,8 @@ class NnMixer:
             if optimizer_arg_name in self.dynamic_parameters:
                 self.optimizer_args[optimizer_arg_name] = self.dynamic_parameters[optimizer_arg_name]
 
+        if CONFIG.SELFAWARE:
+
         #self.optimizer = self.optimizer_class(self.net.net.parameters(), **self.optimizer_args)
         #self.awareness_optimizer = self.optimizer_class(self.net.awareness_net.parameters(), **self.optimizer_args)
         self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
@@ -242,7 +244,10 @@ class NnMixer:
 
                 # forward + backward + optimize
                 # outputs = self.net(inputs)
-                outputs, awareness = self.net(inputs, True)
+                if CONFIG.SELFAWARE:
+                    outputs, awareness = self.net(inputs)
+                else:
+                    outputs = self.net(inputs)
 
                 if self.is_categorical_output:
                     target = labels.cpu().numpy()
@@ -267,8 +272,6 @@ class NnMixer:
                 running_loss += total_loss.item()
                 error = running_loss / (i + 1)
 
-            print(error)
-            #exit(0)
             yield error
 
 


### PR DESCRIPTION
Selfaware was failing to train (loss started being nan after 2-4 batches) on all of our benchmark datasets and the testing dataset (home rentals). There seemed to be no obvious reasons for this, after further exploring it seemed to boil down to the awareness netwrok being to small to be train-able and/or the learning rate being too high (changing these fixed stuff on a case by case basis).

Thus the changes include:

* Increase awareness network size (4 layers, funnel shape)
* Decreasing Ranger's lr by 1/100 when selfware is toggled on 

Also:

* Cleaned up the selfaware code
* Added selfaware toggle via config
* Bumped version to re-deploy to pypi

Not, I haven't ran the benchmarks yet, running as we speak.