### PR TITLE
Selfaware and autoencoding fixes

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.11.8'
+__version__ = '0.12.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -119,6 +119,7 @@ class DataSource(Dataset):
 
                     for val in weights:
                         encoded_val = self.get_encoded_column_data(col_config['name'],'output_features',custom_data={col_config['name']:[val]})
+                        # @Note: This assumes one-hot encoding for the encoded_value
                         value_index = np.argmax(encoded_val[0])
 
                         if new_weights is None:
@@ -194,7 +195,8 @@ class DataSource(Dataset):
                     encoder_class = config['encoder_class']
 
                 # Instantiate the encoder and pass any arguments given via the configuration
-                encoder_instance = encoder_class()
+                is_target = True if feature_set == 'output_features' else False
+                encoder_instance = encoder_class(is_target=is_target)
 
                 encoder_attrs = config['encoder_attrs'] if 'encoder_attrs' in config else {}
                 for attr in encoder_attrs:
@@ -254,8 +256,7 @@ class DataSource(Dataset):
         """
         if decoder_instance is None:
             if column_name not in self.encoders:
-                raise ValueError(
-                    'Data must have been encoded before at some point, you should not decode before having encoding at least once')
+                raise ValueError('Data must have been encoded before at some point, you should not decode before having encoding at least once')
             decoder_instance = self.encoders[column_name]
         decoded_data = decoder_instance.decode(encoded_data)
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -317,6 +317,7 @@ class Predictor:
                 if delta_mean < 0 and len(error_delta_buffer) > 9:
                     stop_training = True
 
+
                 # Stop if we're past the time limit alloted for training
                 if (int(time.time()) - started_training_at) > stop_training_after_seconds:
                    stop_training = True

--- a/lightwood/encoders/__init__.py
+++ b/lightwood/encoders/__init__.py
@@ -5,7 +5,8 @@ from lightwood.encoders.numeric.numeric import NumericEncoder
 from lightwood.encoders.text.infersent import InferSentEncoder
 from lightwood.encoders.text.rnn import RnnEncoder
 from lightwood.encoders.time_series.cesium_ts import CesiumTsEncoder
-from lightwood.encoders.categorical.categorical import CategoricalEncoder
+from lightwood.encoders.categorical.onehot import OneHotEncoder
+from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
 
 class DateTime:
     DatetimeEncoder = DatetimeEncoder
@@ -25,7 +26,8 @@ class TimeSeries:
     CesiumTsEncoder = CesiumTsEncoder
 
 class Categorical:
-    CategoricalEncoder = CategoricalEncoder
+    OneHotEncoder = OneHotEncoder
+    CategoricalAutoEncoder = CategoricalAutoEncoder
 
 class BuiltinEncoders:
     DateTime = DateTime

--- a/lightwood/encoders/categorical/__init__.py
+++ b/lightwood/encoders/categorical/__init__.py
@@ -1,6 +1,6 @@
-from lightwood.encoders.categorical.categorical import CategoricalEncoder
+from lightwood.encoders.categorical.onehot import OneHotEncoder
 from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
 
-default = CategoricalEncoder
-onehot = CategoricalEncoder
+default = CategoricalAutoEncoder
+onehot = OneHotEncoder
 autoencoder = CategoricalAutoEncoder

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -36,6 +36,7 @@ class CategoricalAutoEncoder:
 
         input_len = self.onehot_encoder._lang.n_words
         self.use_autoencoder = self.max_encoded_length is not None and input_len > self.max_encoded_length
+        print(f'\n\n\nValue of use autoencoder: {self.use_autoencoder}\n\n\n')
         if self.use_autoencoder:
             logging.info('Preparing a categorical autoencoder, this might take a while')
 

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -36,7 +36,6 @@ class CategoricalAutoEncoder:
 
         input_len = self.onehot_encoder._lang.n_words
         self.use_autoencoder = self.max_encoded_length is not None and input_len > self.max_encoded_length
-        print(f'\n\n\nValue of use autoencoder: {self.use_autoencoder}\n\n\n')
         if self.use_autoencoder:
             logging.info('Preparing a categorical autoencoder, this might take a while')
 

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -6,7 +6,7 @@ import logging
 UNCOMMON_WORD = '<UNCOMMON>'
 UNCOMMON_TOKEN = 0
 
-class CategoricalEncoder:
+class OneHotEncoder:
 
     def __init__(self, is_target=False):
         self._lang = None

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -9,7 +9,7 @@ from lightwood.config.config import CONFIG
 
 class Img2VecEncoder:
 
-    def __init__(self):
+    def __init__(self, is_target=False):
         self._model = None
         # I think we should make this an enum, something like: speed, balance, accuracy
         self.aim = 'balance'
@@ -19,7 +19,7 @@ class Img2VecEncoder:
     def prepare_encoder(self, priming_data):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
-            
+
         if self._model is None:
             if self.aim == 'speed':
                 self._model = Img2Vec(model='resnet-18')

--- a/lightwood/encoders/image/nn.py
+++ b/lightwood/encoders/image/nn.py
@@ -6,7 +6,7 @@ import torch
 
 class NnAutoEncoder:
 
-    def __init__(self):
+    def __init__(self, is_target=False):
         self._model = None
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
@@ -14,7 +14,7 @@ class NnAutoEncoder:
     def prepare_encoder(self, priming_data):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
-            
+
         self._model = NnEncoderHelper(images)
         self._prepared = True
 

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -6,7 +6,7 @@ import sys
 
 class NumericEncoder:
 
-    def __init__(self, data_type=None):
+    def __init__(self, data_type=None, is_target=False):
         self._type = data_type
         self._min_value = None
         self._max_value = None

--- a/lightwood/mixers/helpers/ranger.py
+++ b/lightwood/mixers/helpers/ranger.py
@@ -27,6 +27,9 @@ class Ranger(Optimizer):
         defaults = dict(lr=lr, alpha=alpha, k=k, betas=betas, N_sma_threshold=N_sma_threshold, eps=eps, weight_decay=weight_decay)
         super().__init__(params,defaults)
 
+        # Since we keep LR the same for all param groups, store it here for now for quick&easy access if we want to know it
+        self.lr = lr
+
         #adjustable threshold
         self.N_sma_threshold = N_sma_threshold
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -279,7 +279,6 @@ class NnMixer:
 
 
                 if np.isnan(running_loss) or np.isinf(running_loss):
-                    print(f'\n\n Learning rate of: {self.optimizer.lr} \n\n')
                     self.optimizer_args['lr'] = self.optimizer.lr/2
 
                     gc.collect()

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -196,6 +196,7 @@ class NnMixer:
                 weights = []
                 for row in ds:
                     _, out = row
+                    # @Note: This assumes one-hot encoding for the encoded_value
                     weights.append(ds.output_weights[torch.argmax(out).item()])
 
                 self._nonpersistent['sampler'] = torch.utils.data.WeightedRandomSampler(weights=weights,num_samples=len(weights),replacement=True)


### PR DESCRIPTION
Benchmarks are still running for this PR, I'll update it with the results when they are finished.

### Selfaware related (Rather important)

* If the losses get too large (inf or nan) we halve the learning rate and re-start training at that (resetting all the weights)
* If the overall error gets small enough (arbitrarily picked as `< 1`), then we switch the loss combination operator that combines the awarenessloss with the prediction loss is switched from 
* Extracting a confidence for the prediction from the awareness output and giving it to the user (this is computed at line 93 in nn.py), this is probably the most critical thing to review and possibly suggest changes to.

### Autoencoder related changes (Not that important)

Basically, the categorical autoencoder wasn't playing along very well with a lot of the unbalanced-categories related features and with the CrossEntropy loss we use for categorical output. Rather than making the necessary changes to adjust of auto-encoded categorical output, I thought that it might be better to just use one-hot for categorical outputs indifferent of their dimension. In order to achieve this three changes were made:

* The `is_target` argument was added to all the encoder constructors (was already present in most anyways)
* The encoder initialization now passes the `is_target` argument as `True` when initializing an encoder for an output column
* The categorical autoencoder always falls back to one-hot encoding when `is_target == True` (previously it only did this if the categorical column contained less than 100 distinct values, see `max_encoded_length`).