### PR TITLE
Data parallelism

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.12.0'
+__version__ = '0.12.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -193,7 +193,7 @@ class DataSource(Dataset):
                         raise ValueError('No default encoder for {type}'.format(type=config['type']))
                 else:
                     encoder_class = config['encoder_class']
-
+                    
                 # Instantiate the encoder and pass any arguments given via the configuration
                 is_target = True if feature_set == 'output_features' else False
                 encoder_instance = encoder_class(is_target=is_target)

--- a/lightwood/encoders/text/__init__.py
+++ b/lightwood/encoders/text/__init__.py
@@ -1,2 +1,3 @@
 from lightwood.encoders.text.rnn import RnnEncoder
+from lightwood.encoders.text.infersent import InferSentEncoder
 default = RnnEncoder

--- a/lightwood/encoders/text/__init__.py
+++ b/lightwood/encoders/text/__init__.py
@@ -1,3 +1,4 @@
 from lightwood.encoders.text.rnn import RnnEncoder
 from lightwood.encoders.text.infersent import InferSentEncoder
-default = RnnEncoder
+
+default = InferSentEncoder

--- a/lightwood/encoders/text/infersent.py
+++ b/lightwood/encoders/text/infersent.py
@@ -35,7 +35,7 @@ class InferSentEncoder:
     def prepare_encoder(self, priming_data):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
-            
+
         self._download_necessary_files()
 
         no_null_sentences = [x if x is not None else '' for x in priming_data]

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -116,14 +116,14 @@ class DefaultNet(torch.nn.Module):
                 reset_layer_params(layer)
 
         self.net = self.net.to(self.device)
-        if self.available_devices > 0:
+        if self.available_devices > 1:
             self._foward_net = torch.nn.DataParallel(self.net)
         else:
             self._foward_net = self.net
 
         if self.selfaware:
             self.awareness_net = self.awareness_net.to(self.device)
-            if self.available_devices > 0:
+            if self.available_devices > 1:
                 self._foward_awareness_net = torch.nn.DataParallel(self.awareness_net)
             else:
                 self._foward_awareness_net = self.awareness_net

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -117,18 +117,16 @@ class DefaultNet(torch.nn.Module):
 
         self.net = self.net.to(self.device)
         if self.available_devices > 0:
-            self.parallel_net = torch.nn.DataParallel(self.net)
-            self.foward_net = self.parallel_net
+            self._foward_net = torch.nn.DataParallel(self.net)
         else:
-            self.foward_net = self.net
+            self._foward_net = self.net
 
         if self.selfaware:
             self.awareness_net = self.awareness_net.to(self.device)
             if self.available_devices > 0:
-                self.parallel_awareness_net = torch.nn.DataParallel(self.awareness_net)
-                self.foward_awareness_net = self.parallel_awareness_net
+                self._foward_awareness_net = torch.nn.DataParallel(self.awareness_net)
             else:
-                self.foward_awareness_net = self.net
+                self._foward_awareness_net = self.awareness_net
 
     def calculate_overall_certainty(self):
         """
@@ -165,11 +163,11 @@ class DefaultNet(torch.nn.Module):
         """
 
 
-        output = self.foward_net(input)
+        output = self._foward_net(input)
 
         if self.selfaware:
             interim = torch.cat((input, output), 1)
-            awareness = self.foward_awareness_net(interim)
+            awareness = self._foward_awareness_net(interim)
 
             return output, awareness
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -28,7 +28,7 @@ class NnMixer:
         self.optimizer_args = None
         self.criterion = None
 
-        self.batch_size = 200
+        self.batch_size = None
         self.epochs = 120000
 
         self.nn_class = DefaultNet
@@ -217,13 +217,11 @@ class NnMixer:
 
                 self._nonpersistent['sampler'] = torch.utils.data.WeightedRandomSampler(weights=weights,num_samples=len(weights),replacement=True)
 
-        if self._nonpersistent['sampler'] is None:
-            data_loader = DataLoader(ds, batch_size=self.batch_size, shuffle=True, num_workers=0)
-        else:
-            data_loader = DataLoader(ds, batch_size=self.batch_size, num_workers=0, sampler=self._nonpersistent['sampler'])
-
         self.net = self.nn_class(ds, self.dynamic_parameters)
         self.net = self.net.train()
+
+        self.batch_size = 200 * self.net.available_devices
+
         self.awareness_criterion = torch.nn.MSELoss()
 
         if self.criterion is None:
@@ -249,6 +247,12 @@ class NnMixer:
 
         self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
         total_epochs = self.epochs
+
+
+        if self._nonpersistent['sampler'] is None:
+            data_loader = DataLoader(ds, batch_size=self.batch_size, shuffle=True, num_workers=0)
+        else:
+            data_loader = DataLoader(ds, batch_size=self.batch_size, num_workers=0, sampler=self._nonpersistent['sampler'])
 
         total_iterations = 0
         for epoch in range(total_epochs):  # loop over the dataset multiple times

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -28,7 +28,7 @@ class NnMixer:
         self.optimizer_args = None
         self.criterion = None
 
-        self.batch_size = None
+        self.batch_size = 200
         self.epochs = 120000
 
         self.nn_class = DefaultNet
@@ -220,7 +220,8 @@ class NnMixer:
         self.net = self.nn_class(ds, self.dynamic_parameters)
         self.net = self.net.train()
 
-        self.batch_size = 200 * self.net.available_devices
+        if self.batch_size < self.net.available_devices:
+            self.batch_size = self.net.available_devices
 
         self.awareness_criterion = torch.nn.MSELoss()
 


### PR DESCRIPTION
Lightwood now adds a parallel wrapper to the model when it detects a multi-GPU machine, this is done in such a way as to maintain the interface of the default net unchanged.

Made `InferSentEncoder` the default text encoder. This seems to help get some meaningful representation out of text (based on testing set accuracy) compared to the RNN encoder, but is very memory heavy and time consuming, we should probably review how it's implemented at a later stage.