### PR TITLE
Better text and category encoding

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.12.3'
+__version__ = '0.13.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.12.2'
+__version__ = '0.12.3'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -12,7 +12,7 @@ class CONFIG:
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
     OVERSAMPLE = True
-    SELFAWARE = True
+    SELFAWARE = False
 
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -12,7 +12,7 @@ class CONFIG:
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
     OVERSAMPLE = True
-    SELFAWARE = False
+    SELFAWARE = True
 
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -74,7 +74,6 @@ class CategoricalAutoEncoder:
                     error = running_loss / (i + 1)
                     error_buffer.append(error)
 
-                print(error)
                 if len(error_buffer) > 5:
                     error_buffer.append(error)
                     error_buffer = error_buffer[-5:]

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -43,9 +43,7 @@ class CategoricalAutoEncoder:
 
             self.net = DefaultNet(ds=None, dynamic_parameters={},shape=[input_len, embeddings_layer_len, input_len], selfaware=False)
 
-            encoded_priming_data = self.onehot_encoder.encode(priming_data)
-
-            data_loader = torch.utils.data.DataLoader(encoded_priming_data, batch_size=256, shuffle=True)
+            data_loader = torch.utils.data.DataLoader(priming_data, batch_size=256, shuffle=True)
 
             criterion = torch.nn.CrossEntropyLoss()
             optimizer = Ranger(self.net.parameters())
@@ -55,7 +53,7 @@ class CategoricalAutoEncoder:
                 running_loss = 0
                 error = 0
                 for i, data in enumerate(data_loader, 0):
-                    oh_encoded_categories = data
+                    oh_encoded_categories = self.onehot_encoder.encode(data)
                     oh_encoded_categories = torch.Tensor(oh_encoded_categories)
                     oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                     self.net(oh_encoded_categories)
@@ -76,6 +74,7 @@ class CategoricalAutoEncoder:
                     error = running_loss / (i + 1)
                     error_buffer.append(error)
 
+                print(error)
                 if len(error_buffer) > 5:
                     error_buffer.append(error)
                     error_buffer = error_buffer[-5:]

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -59,7 +59,6 @@ class CategoricalAutoEncoder:
                 itterable_priming_data = zip(*[iter(priming_data)]*batch_size)
                 for i, data in enumerate(itterable_priming_data):
                     oh_encoded_categories = self.onehot_encoder.encode(data)
-                    oh_encoded_categories = torch.Tensor(oh_encoded_categories)
                     oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                     self.net(oh_encoded_categories)
 

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -28,7 +28,7 @@ class OneHotEncoder:
 
         while self._lang.n_words > max_dimensions:
             necessary_words = UNCOMMON_WORD
-            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words))
+            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words)+1)
 
             word_to_remove = None
             for word in least_occuring_words:

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -13,7 +13,7 @@ class OneHotEncoder:
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
 
-    def prepare_encoder(self, priming_data):
+    def prepare_encoder(self, priming_data, max_dimensions=20000):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
@@ -25,6 +25,18 @@ class OneHotEncoder:
         for category in priming_data:
             if category != None:
                 self._lang.addWord(str(category))
+
+        while self._lang.n_words > max_dimensions:
+            necessary_words = UNCOMMON_WORD
+            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words))
+
+            word_to_remove = None
+            for word in least_occuring_words:
+                if word not in necessary_words:
+                    word_to_remove = word
+                    break
+
+            self._lang.removeWord(word_to_remove)
 
         self._prepared = True
 
@@ -61,11 +73,14 @@ if __name__ == "__main__":
 
     data = ['category 1', 'category 3', 'category 4', None]
 
-    enc = CategoricalEncoder()
+    enc = OneHotEncoder()
 
     enc.prepare_encoder(data)
     encoded_data = enc.encode(data)
     decoded_data = enc.decode(enc.encode(['category 2', 'category 1', 'category 3', None]))
+
+    print(f'Encoded values: \n{encoded_data}')
+    print(f'Decoded values: \n{decoded_data}')
 
     assert(len(encoded_data) == 4)
     assert(decoded_data[1] == 'category 1')
@@ -74,5 +89,26 @@ if __name__ == "__main__":
         assert(encoded_data[0][i] == UNCOMMON_TOKEN)
         assert(decoded_data[i] == UNCOMMON_WORD)
 
-    print(f'Encoded values: \n{encoded_data}')
-    print(f'Decoded values: \n{decoded_data}')
+    # Test max_dimensions
+    for max_dimensions in [2,3]:
+        data = ['category 1', 'category 1', 'category 3', 'category 4', 'category 4', 'category 4', None]
+
+        enc = OneHotEncoder()
+
+        enc.prepare_encoder(data, max_dimensions=max_dimensions)
+        encoded_data = enc.encode(data)
+        decoded_data = enc.decode(enc.encode(['category 1', 'category 2', 'category 3', 'category 4', None]))
+
+        print(f'Encoded values: \n{encoded_data}')
+        print(f'Decoded values: \n{decoded_data}')
+
+        if max_dimensions == 3:
+            assert(decoded_data[0] == 'category 1')
+        else:
+            assert(decoded_data[0] == UNCOMMON_WORD)
+
+        assert(decoded_data[1] == UNCOMMON_WORD)
+        assert(decoded_data[2] == UNCOMMON_WORD)
+        assert(decoded_data[4] == UNCOMMON_WORD)
+
+        assert(decoded_data[3] == 'category 4')

--- a/lightwood/encoders/text/helpers/rnn_helpers.py
+++ b/lightwood/encoders/text/helpers/rnn_helpers.py
@@ -193,9 +193,9 @@ class Lang:
 
     def getLeastOccurring(self, n=1):
         if n == 1:
-            return min(word2count, key=word2count.get)
+            return min(self.word2count, key=self.word2count.get)
         else:
-            sorted_word2count = sorted(word2count.items(), key=operator.itemgetter(1))
+            sorted_word2count = sorted(self.word2count.items(), key=operator.itemgetter(1))
             return [x[0] for x in sorted_word2count[:n]]
 
 

--- a/lightwood/encoders/text/helpers/rnn_helpers.py
+++ b/lightwood/encoders/text/helpers/rnn_helpers.py
@@ -89,6 +89,7 @@ import unicodedata
 import string
 import re
 import random
+import operator
 
 import torch
 import torch.nn as nn
@@ -166,11 +167,36 @@ class Lang:
     def addWord(self, word):
         if word not in self.word2index:
             self.word2index[word] = self.n_words
-            self.word2count[word] = 1
+            self.word2count[word] = 0
             self.index2word[self.n_words] = word
             self.n_words += 1
+
+        self.word2count[word] += 1
+
+    # @NOTE: Very slow, especially for a large language, can be made faster by making index2word a list
+    def removeWord(self, word):
+        word_index = self.word2index[word]
+        del self.word2index[word]
+        del self.word2count[word]
+        del self.index2word[word_index]
+
+        self.n_words -= 1
+
+        for index in [x for x in self.index2word.keys() if x > word_index]:
+            word = self.index2word[index]
+            new_index = index - 1
+
+            self.word2index[word] = new_index
+
+            del self.index2word[index]
+            self.index2word[new_index] = word
+
+    def getLeastOccurring(self, n=1):
+        if n == 1:
+            return min(word2count, key=word2count.get)
         else:
-            self.word2count[word] += 1
+            sorted_word2count = sorted(word2count.items(), key=operator.itemgetter(1))
+            return [x[0] for x in sorted_word2count[:n]]
 
 
 ######################################################################


### PR DESCRIPTION
In broad:

* Categorical auto encoder now only encodes the batches it trains on, not the whole dataset, which means it's less likely to run out of memory on large datasets

* One hot encoder + Lang model are updated to allow for removal of words. Specifically, if there are over 20,000 categories we start removing the least frequent ones until it gets down to 20,000. We might want to set this number lower/higher in the future. Also updated the tests for the OHE to work and to factor in testing this new feature.

This *should* be enough to fix #77 

* InferSent is now able to run on the GPU, some batch reduction when GPU is enabled was required, otherwise it was using too much memory.