### PR TITLE
Transform text encoders

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.12.3'
+__version__ = '0.13.2'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.12.2'
+__version__ = '0.12.3'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -23,7 +23,6 @@ class DataSource(Dataset):
         self.dropout_dict = {}
         self.disable_cache = not CONFIG.CACHE_ENCODED_DATA
 
-
         for col in self.configuration['input_features']:
             if len(self.configuration['input_features']) > 1:
                 dropout = 0.0
@@ -193,7 +192,7 @@ class DataSource(Dataset):
                         raise ValueError('No default encoder for {type}'.format(type=config['type']))
                 else:
                     encoder_class = config['encoder_class']
-                    
+
                 # Instantiate the encoder and pass any arguments given via the configuration
                 is_target = True if feature_set == 'output_features' else False
                 encoder_instance = encoder_class(is_target=is_target)
@@ -206,7 +205,6 @@ class DataSource(Dataset):
                 # Prime the encoder using the data (for example, to get the one-hot mapping in a categorical encoder)
                 encoder_instance.prepare_encoder(args[0])
                 self.encoders[column_name] = encoder_instance
-                encoded_val = encoder_instance.encode(*args)
 
         return True
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -119,6 +119,7 @@ class Predictor:
 
         :return: None
         """
+        eval_every_x_epochs = 1
         self._stop_training_flag = False
 
         if stop_model_building_after_seconds is None:

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -12,7 +12,7 @@ class CONFIG:
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
     OVERSAMPLE = True
-    SELFAWARE = True
+    SELFAWARE = False
 
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -20,3 +20,6 @@ class CONFIG:
 
     """Bayesian Network"""
     NUMBER_OF_PROBABILISTIC_MODELS = 2
+
+    """Encoder options"""
+    TRAIN_TO_PREDICT_TARGET = True

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -74,7 +74,6 @@ class CategoricalAutoEncoder:
                     error = running_loss / (i + 1)
                     error_buffer.append(error)
 
-                print(error)
                 if len(error_buffer) > 5:
                     error_buffer.append(error)
                     error_buffer = error_buffer[-5:]

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -43,9 +43,7 @@ class CategoricalAutoEncoder:
 
             self.net = DefaultNet(ds=None, dynamic_parameters={},shape=[input_len, embeddings_layer_len, input_len], selfaware=False)
 
-            encoded_priming_data = self.onehot_encoder.encode(priming_data)
-
-            data_loader = torch.utils.data.DataLoader(encoded_priming_data, batch_size=256, shuffle=True)
+            data_loader = torch.utils.data.DataLoader(priming_data, batch_size=256, shuffle=True)
 
             criterion = torch.nn.CrossEntropyLoss()
             optimizer = Ranger(self.net.parameters())
@@ -55,7 +53,7 @@ class CategoricalAutoEncoder:
                 running_loss = 0
                 error = 0
                 for i, data in enumerate(data_loader, 0):
-                    oh_encoded_categories = data
+                    oh_encoded_categories = self.onehot_encoder.encode(data)
                     oh_encoded_categories = torch.Tensor(oh_encoded_categories)
                     oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                     self.net(oh_encoded_categories)
@@ -76,6 +74,7 @@ class CategoricalAutoEncoder:
                     error = running_loss / (i + 1)
                     error_buffer.append(error)
 
+                print(error)
                 if len(error_buffer) > 5:
                     error_buffer.append(error)
                     error_buffer = error_buffer[-5:]

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -57,7 +57,9 @@ class CategoricalAutoEncoder:
                 error = 0
                 random.shuffle(priming_data)
                 itterable_priming_data = zip(*[iter(priming_data)]*batch_size)
+
                 for i, data in enumerate(itterable_priming_data):
+                    print(len(data))
                     oh_encoded_categories = self.onehot_encoder.encode(data)
                     oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                     self.net(oh_encoded_categories)

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -59,7 +59,6 @@ class CategoricalAutoEncoder:
                 itterable_priming_data = zip(*[iter(priming_data)]*batch_size)
                 for i, data in enumerate(itterable_priming_data):
                     oh_encoded_categories = self.onehot_encoder.encode(data)
-                    oh_encoded_categories = torch.Tensor(oh_encoded_categories)
                     oh_encoded_categories = oh_encoded_categories.to(self.net.device)
                     self.net(oh_encoded_categories)
 

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -28,7 +28,7 @@ class OneHotEncoder:
 
         while self._lang.n_words > max_dimensions:
             necessary_words = UNCOMMON_WORD
-            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words))
+            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words)+1)
 
             word_to_remove = None
             for word in least_occuring_words:

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -13,7 +13,7 @@ class OneHotEncoder:
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
 
-    def prepare_encoder(self, priming_data):
+    def prepare_encoder(self, priming_data, max_dimensions=20000):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
@@ -25,6 +25,18 @@ class OneHotEncoder:
         for category in priming_data:
             if category != None:
                 self._lang.addWord(str(category))
+
+        while self._lang.n_words > max_dimensions:
+            necessary_words = UNCOMMON_WORD
+            least_occuring_words = self._lang.getLeastOccurring(n=len(necessary_words))
+
+            word_to_remove = None
+            for word in least_occuring_words:
+                if word not in necessary_words:
+                    word_to_remove = word
+                    break
+
+            self._lang.removeWord(word_to_remove)
 
         self._prepared = True
 
@@ -61,11 +73,14 @@ if __name__ == "__main__":
 
     data = ['category 1', 'category 3', 'category 4', None]
 
-    enc = CategoricalEncoder()
+    enc = OneHotEncoder()
 
     enc.prepare_encoder(data)
     encoded_data = enc.encode(data)
     decoded_data = enc.decode(enc.encode(['category 2', 'category 1', 'category 3', None]))
+
+    print(f'Encoded values: \n{encoded_data}')
+    print(f'Decoded values: \n{decoded_data}')
 
     assert(len(encoded_data) == 4)
     assert(decoded_data[1] == 'category 1')
@@ -74,5 +89,26 @@ if __name__ == "__main__":
         assert(encoded_data[0][i] == UNCOMMON_TOKEN)
         assert(decoded_data[i] == UNCOMMON_WORD)
 
-    print(f'Encoded values: \n{encoded_data}')
-    print(f'Decoded values: \n{decoded_data}')
+    # Test max_dimensions
+    for max_dimensions in [2,3]:
+        data = ['category 1', 'category 1', 'category 3', 'category 4', 'category 4', 'category 4', None]
+
+        enc = OneHotEncoder()
+
+        enc.prepare_encoder(data, max_dimensions=max_dimensions)
+        encoded_data = enc.encode(data)
+        decoded_data = enc.decode(enc.encode(['category 1', 'category 2', 'category 3', 'category 4', None]))
+
+        print(f'Encoded values: \n{encoded_data}')
+        print(f'Decoded values: \n{decoded_data}')
+
+        if max_dimensions == 3:
+            assert(decoded_data[0] == 'category 1')
+        else:
+            assert(decoded_data[0] == UNCOMMON_WORD)
+
+        assert(decoded_data[1] == UNCOMMON_WORD)
+        assert(decoded_data[2] == UNCOMMON_WORD)
+        assert(decoded_data[4] == UNCOMMON_WORD)
+
+        assert(decoded_data[3] == 'category 4')

--- a/lightwood/encoders/text/__init__.py
+++ b/lightwood/encoders/text/__init__.py
@@ -1,4 +1,6 @@
 from lightwood.encoders.text.rnn import RnnEncoder
 from lightwood.encoders.text.infersent import InferSentEncoder
+from lightwood.encoders.text.distilbert import DistilBertEncoder
 
-default = InferSentEncoder
+default = DistilBertEncoder
+#default = InferSentEncoder

--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -1,0 +1,55 @@
+import torch
+from pytorch_transformers import DistilBertModel, DistilBertForSequenceClassification, DistilBertTokenizer
+
+
+class DistilBertEncoder:
+    def __init__(self):
+        self._tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
+        self._model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased')
+        self._pytorch_wrapper = torch.FloatTensor
+        self._max_len = None
+        self._max_ele = None
+
+    def encode(self, column_data):
+        encoded_representation = []
+        tokenized_inputs = []
+        for text in column_data:
+            tokenized_input = torch.tensor([self._tokenizer.encode(text, add_special_tokens=True)])
+
+            #encoded_representation.append(list(tokenized_input[0]))
+            tokenized_input = torch.tensor(list(tokenized_input[0][0:512]))
+            tokenized_input.unsqueeze_(-1)
+            tokenized_input = tokenized_input.transpose(1,0)
+            tokenized_inputs.append(tokenized_input)
+
+        '''
+        if self._max_len is None:
+            self._max_len = max([len(x) for x in encoded_representation])
+        if self._max_ele is None:
+            self._max_ele = 0
+            for arr in encoded_representation:
+                for ele in arr:
+                    if ele > self._max_ele:
+                        self._max_ele = ele
+        for arr in encoded_representation:
+            while len(arr) < self._max_len:
+                arr.append(0)
+            while len(arr) > self._max_len:
+                arr.pop(self._max_len)
+            for i in range(len(arr)):
+                arr[i] = arr[i]/self._max_ele
+        return self._pytorch_wrapper(encoded_representation)
+        '''
+        # See this later
+        with torch.no_grad():
+            for tokenized_input in tokenized_inputs:
+                hidden_states = self._model(tokenized_input)
+                vec = hidden_states[0][0].tolist()
+                print(vec)
+                encoded_representation.append(vec)
+
+        return self._pytorch_wrapper(encoded_representation)
+
+    def decode(self, encoded_values_tensor, max_length = 100):
+        # When test is an output... a bit trickier to handle this case, thinking on it
+        pass

--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -1,71 +1,135 @@
+import time
+import copy
+
+import numpy as np
 import torch
+from pytorch_transformers import DistilBertModel, DistilBertForSequenceClassification, DistilBertTokenizer, AdamW
+
 from lightwood.config.config import CONFIG
-from pytorch_transformers import DistilBertModel, DistilBertForSequenceClassification, DistilBertTokenizer, DistilBertForQuestionAnswering, GPT2Tokenizer, GPT2LMHeadModel, DistilBertForMaskedLM
+from lightwood.constants.lightwood import COLUMN_DATA_TYPES
 
 
 class DistilBertEncoder:
     def __init__(self, is_target=False):
         self._tokenizer = None
         self._model = None
+        self._pad_token = None
         self._pytorch_wrapper = torch.FloatTensor
         self._max_len = None
         self._max_ele = None
         self._prepared = False
+        self._model_type = None
+        self.desired_error = 0.05
+        self.max_training_time = 1800
 
-    def prepare_encoder(self, priming_data):
-        print(CONFIG.CACHE_ENCODED_DATA)
+        device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+        if CONFIG.USE_DEVICE is not None:
+            device_str = CONFIG.USE_DEVICE
+        self.device = torch.device(device_str)
+
+    def prepare_encoder(self, priming_data, training_data=None):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
-        print('Priming text encoder !')
         self._max_len = min(max([len(x) for x in priming_data]),768)
-
         self._tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
-        #self._model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased')
-        self._model = DistilBertModel.from_pretrained('distilbert-base-uncased')
+        self._pad_token = self._tokenizer.convert_tokens_to_ids([self._tokenizer])[0]
+        # @TODO: Support multiple targets if they are all categorical or train for the categorical target if it's a mix (maybe ?)
+        # @TODO: Attach a language modeling head and/or use GPT2 and/or provide outputs better suited to a LM head (which will be the mixer) if the output if text
 
-        '''
-        for text in priming_data:
-            for i in range(0,100):
-                input = torch.tensor(self._tokenizer.encode(text[0:512])).unsqueeze(0)
+        if training_data is not None and 'targets' in training_data and len(training_data['targets']) ==1 and training_data['targets'][0]['output_type'] == COLUMN_DATA_TYPES.CATEGORICAL and CONFIG.TRAIN_TO_PREDICT_TARGET:
+            self._model_type = 'classifier'
+            self._model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased', num_labels=len(set(training_data['targets'][0]['unencoded_output'])) + 1).to(self.device)
 
-                outputs = self._model(input, masked_lm_labels=input)
-                loss, prediction_scores = outputs[:2]
-                print(loss)
+            no_decay = ['bias', 'LayerNorm.weight']
+            optimizer_grouped_parameters = [
+                {'params': [p for n, p in self._model.named_parameters() if not any(nd in n for nd in no_decay)], 'weight_decay': 0.0001},
+                {'params': [p for n, p in self._model.named_parameters() if any(nd in n for nd in no_decay)], 'weight_decay': 0.0}
+            ]
 
-                outputs = self._model(input)
-                print(len(outputs))
-                #lhs = outputs[2]
+            optimizer = AdamW(optimizer_grouped_parameters, lr=5e-5, eps=1e-8)
+            # This import is present in github but not in the pypi library yet
+            #scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=args.warmup_steps, num_training_steps=t_total)
 
-                predicted_token = self._tokenizer.convert_ids_to_tokens(outputs[0])[0]
-                print(predicted_token)
-                loss.backward()
+            self._model.train()
+            error_buffer = []
+            started = time.time()
 
-        tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
-        model = GPT2LMHeadModel.from_pretrained('gpt2')
+            best_error = None
+            best_model = None
+            best_epoch = None
 
-        for text in priming_data:
-            input_ids = torch.tensor(tokenizer.encode(text[0:512])).unsqueeze(0)
-            outputs = model(input_ids, labels=input_ids)
-            print(tokenizer.decode(outputs, clean_up_tokenization_spaces=True, skip_special_tokens=True))
-        '''
-        print('Primed text encoder !')
+            for epoch in range(5000):
+                running_loss = 0
+                error = None
+
+                '''
+                itterable_priming_data = zip(*[iter(priming_data)]*batch_size)
+                for i, data in enumerate(itterable_priming_data):
+
+                    self._pad_token
+                '''
+                for i in range(len(priming_data)):
+                    input = torch.tensor(self._tokenizer.encode(priming_data[i][:self._max_len], add_special_tokens=True)).to(self.device).unsqueeze(0)
+
+                    labels = torch.tensor([torch.argmax(training_data['targets'][0]['encoded_output'][i])]).to(self.device)
+
+                    outputs = self._model(input, labels=labels)
+                    loss, logits = outputs[:2]
+                    loss.backward()
+                    #if i % 24 == 0:
+                    #    print(torch.argmax(logits[0]), '----', labels[0])
+
+                    optimizer.step()
+                    self._model.zero_grad()
+
+                    running_loss += loss.item()
+                    error = running_loss/(i + 1)
+
+                print(f'Text encoder training error: {error}')
+                if best_error is None or best_error > error:
+                    best_error = error
+                    # Move to CPU to save GPU memory, move back to the origianl device if we end up using it
+                    best_model = copy.deepcopy(self._model).cpu()
+                    best_epoch = epoch
+
+                error_buffer.append(error)
+
+                if len(error_buffer) > 3:
+                    error_buffer.append(error)
+                    error_buffer = error_buffer[-3:]
+                    delta_mean = np.mean(error_buffer)
+                    if delta_mean < 0 or error < self.desired_error or best_epoch < epoch - 5:
+                        self._model = best_model.to(self.device)
+                        break
+
+                if started + self.max_training_time < time.time():
+                    self._model = best_model.to(self.device)
+                    break
+        else:
+            self._model_type = 'embeddings_generator'
+            self._model = DistilBertModel.from_pretrained('distilbert-base-uncased').to(self.device)
+
         self._prepared = True
 
 
     def encode(self, column_data):
         encoded_representation = []
-        print('Encoding sequence of length: ' + str(len(column_data)))
+        self._model.eval()
         with torch.no_grad():
             for text in column_data:
                 if text is None:
                     text = ''
-                input = torch.tensor(self._tokenizer.encode(text[:self._max_len], add_special_tokens=True)).unsqueeze(0)
-                last_hidden_states = self._model(input)
+                input = torch.tensor(self._tokenizer.encode(text[:self._max_len], add_special_tokens=True)).to(self.device).unsqueeze(0)
+                output = self._model(input)
 
-                embeddings = last_hidden_states[0][:,0,:].numpy()[0]
-
-                encoded_representation.append(embeddings)
+                if self._model_type == 'classifier':
+                    logits = output[0]
+                    predicted_targets = logits[0].tolist()
+                    encoded_representation.append(predicted_targets)
+                else:
+                    embeddings = output[0][:,0,:].cpu().numpy()[0]
+                    encoded_representation.append(embeddings)
 
         return self._pytorch_wrapper(encoded_representation)
 

--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -1,52 +1,71 @@
 import torch
-from pytorch_transformers import DistilBertModel, DistilBertForSequenceClassification, DistilBertTokenizer
+from lightwood.config.config import CONFIG
+from pytorch_transformers import DistilBertModel, DistilBertForSequenceClassification, DistilBertTokenizer, DistilBertForQuestionAnswering, GPT2Tokenizer, GPT2LMHeadModel, DistilBertForMaskedLM
 
 
 class DistilBertEncoder:
-    def __init__(self):
-        self._tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
-        self._model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased')
+    def __init__(self, is_target=False):
+        self._tokenizer = None
+        self._model = None
         self._pytorch_wrapper = torch.FloatTensor
         self._max_len = None
         self._max_ele = None
+        self._prepared = False
+
+    def prepare_encoder(self, priming_data):
+        print(CONFIG.CACHE_ENCODED_DATA)
+        if self._prepared:
+            raise Exception('You can only call "prepare_encoder" once for a given encoder.')
+
+        print('Priming text encoder !')
+        self._max_len = min(max([len(x) for x in priming_data]),768)
+
+        self._tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
+        #self._model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased')
+        self._model = DistilBertModel.from_pretrained('distilbert-base-uncased')
+
+        '''
+        for text in priming_data:
+            for i in range(0,100):
+                input = torch.tensor(self._tokenizer.encode(text[0:512])).unsqueeze(0)
+
+                outputs = self._model(input, masked_lm_labels=input)
+                loss, prediction_scores = outputs[:2]
+                print(loss)
+
+                outputs = self._model(input)
+                print(len(outputs))
+                #lhs = outputs[2]
+
+                predicted_token = self._tokenizer.convert_ids_to_tokens(outputs[0])[0]
+                print(predicted_token)
+                loss.backward()
+
+        tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+        model = GPT2LMHeadModel.from_pretrained('gpt2')
+
+        for text in priming_data:
+            input_ids = torch.tensor(tokenizer.encode(text[0:512])).unsqueeze(0)
+            outputs = model(input_ids, labels=input_ids)
+            print(tokenizer.decode(outputs, clean_up_tokenization_spaces=True, skip_special_tokens=True))
+        '''
+        print('Primed text encoder !')
+        self._prepared = True
+
 
     def encode(self, column_data):
         encoded_representation = []
-        tokenized_inputs = []
-        for text in column_data:
-            tokenized_input = torch.tensor([self._tokenizer.encode(text, add_special_tokens=True)])
-
-            #encoded_representation.append(list(tokenized_input[0]))
-            tokenized_input = torch.tensor(list(tokenized_input[0][0:512]))
-            tokenized_input.unsqueeze_(-1)
-            tokenized_input = tokenized_input.transpose(1,0)
-            tokenized_inputs.append(tokenized_input)
-
-        '''
-        if self._max_len is None:
-            self._max_len = max([len(x) for x in encoded_representation])
-        if self._max_ele is None:
-            self._max_ele = 0
-            for arr in encoded_representation:
-                for ele in arr:
-                    if ele > self._max_ele:
-                        self._max_ele = ele
-        for arr in encoded_representation:
-            while len(arr) < self._max_len:
-                arr.append(0)
-            while len(arr) > self._max_len:
-                arr.pop(self._max_len)
-            for i in range(len(arr)):
-                arr[i] = arr[i]/self._max_ele
-        return self._pytorch_wrapper(encoded_representation)
-        '''
-        # See this later
+        print('Encoding sequence of length: ' + str(len(column_data)))
         with torch.no_grad():
-            for tokenized_input in tokenized_inputs:
-                hidden_states = self._model(tokenized_input)
-                vec = hidden_states[0][0].tolist()
-                print(vec)
-                encoded_representation.append(vec)
+            for text in column_data:
+                if text is None:
+                    text = ''
+                input = torch.tensor(self._tokenizer.encode(text[:self._max_len], add_special_tokens=True)).unsqueeze(0)
+                last_hidden_states = self._model(input)
+
+                embeddings = last_hidden_states[0][:,0,:].numpy()[0]
+
+                encoded_representation.append(embeddings)
 
         return self._pytorch_wrapper(encoded_representation)
 

--- a/lightwood/encoders/text/helpers/rnn_helpers.py
+++ b/lightwood/encoders/text/helpers/rnn_helpers.py
@@ -193,9 +193,9 @@ class Lang:
 
     def getLeastOccurring(self, n=1):
         if n == 1:
-            return min(word2count, key=word2count.get)
+            return min(self.word2count, key=self.word2count.get)
         else:
-            sorted_word2count = sorted(word2count.items(), key=operator.itemgetter(1))
+            sorted_word2count = sorted(self.word2count.items(), key=operator.itemgetter(1))
             return [x[0] for x in sorted_word2count[:n]]
 
 

--- a/lightwood/encoders/text/helpers/rnn_helpers.py
+++ b/lightwood/encoders/text/helpers/rnn_helpers.py
@@ -89,6 +89,7 @@ import unicodedata
 import string
 import re
 import random
+import operator
 
 import torch
 import torch.nn as nn
@@ -166,11 +167,36 @@ class Lang:
     def addWord(self, word):
         if word not in self.word2index:
             self.word2index[word] = self.n_words
-            self.word2count[word] = 1
+            self.word2count[word] = 0
             self.index2word[self.n_words] = word
             self.n_words += 1
+
+        self.word2count[word] += 1
+
+    # @NOTE: Very slow, especially for a large language, can be made faster by making index2word a list
+    def removeWord(self, word):
+        word_index = self.word2index[word]
+        del self.word2index[word]
+        del self.word2count[word]
+        del self.index2word[word_index]
+
+        self.n_words -= 1
+
+        for index in [x for x in self.index2word.keys() if x > word_index]:
+            word = self.index2word[index]
+            new_index = index - 1
+
+            self.word2index[word] = new_index
+
+            del self.index2word[index]
+            self.index2word[new_index] = word
+
+    def getLeastOccurring(self, n=1):
+        if n == 1:
+            return min(word2count, key=word2count.get)
         else:
-            self.word2count[word] += 1
+            sorted_word2count = sorted(word2count.items(), key=operator.itemgetter(1))
+            return [x[0] for x in sorted_word2count[:n]]
 
 
 ######################################################################

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -15,9 +15,11 @@ class DefaultNet(torch.nn.Module):
         # How many devices we can train this network on
         self.available_devices = 1
         self.max_variance = None
+
         device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
         if CONFIG.USE_DEVICE is not None:
             device_str = CONFIG.USE_DEVICE
+        self.device = torch.device(device_str)
 
         if CONFIG.DETERMINISTIC:
             '''
@@ -35,9 +37,6 @@ class DefaultNet(torch.nn.Module):
                 self.available_devices = torch.cuda.device_count()
 
 
-
-        self.device = torch.device(device_str)
-
         self.dynamic_parameters = dynamic_parameters
         """
         Here we define the basic building blocks of our model, in forward we define how we put it all together along wiht an input
@@ -51,8 +50,10 @@ class DefaultNet(torch.nn.Module):
             self.input_size = len(input_sample)
             self.output_size = len(output_sample)
 
-            large_input = True if self.input_size > 1000 else False
-            large_output = True if self.output_size > 1000 else False
+            small_input = True if self.input_size < 50 else False
+            small_output = True if self.input_size < 50 else False
+            large_input = True if self.input_size > 2000 else False
+            large_output = True if self.output_size > 2000 else False
 
             # 2. Determine in/out proportions
             # @TODO: Maybe provide a warning if the output is larger, this really shouldn't usually be the case (outside of very specific things, such as text to image)
@@ -65,7 +66,10 @@ class DefaultNet(torch.nn.Module):
             else:
                 depth = 5
 
-            if (not large_input) and (not large_output):
+            if (small_input and small_output):
+                shape = rombus(self.input_size,self.output_size,depth+1,800)
+                print(shape)
+            elif (not large_input) and (not large_output):
                 shape = rombus(self.input_size,self.output_size,depth,self.input_size*2)
             elif large_input and large_output:
                 shape = rectangle(self.input_size,self.output_size,depth - 1)

--- a/pr.ref.md
+++ b/pr.ref.md
@@ -3,3 +3,8 @@
 * SNN paper: https://arxiv.org/pdf/1706.02515.pdf
 * SNN paper code (see 8 for initialization): https://github.com/bioinf-jku/SNNs/blob/master/SelfNormalizingNetworks_MLP_MNIST.ipynb
 * Docs on obtaining deterministic models: https://pytorch.org/docs/stable/notes/randomness.html
+
+
+A good BERT classifier example:
+
+https://github.com/huggingface/transformers/blob/master/examples/run_glue.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ xlrd >= 1.0.0
 requests >= 2.0.0
 ax-platform >= 0.1.3
 pyro-ppl >= 0.4.1
+pytorch-transformers == 1.2.0


### PR DESCRIPTION
Text encoder based on DistilBERT from huggingface (basically a BERT implementation but made to have fewer weights and thus quicker).

At the moment it behaves in two possible ways:

a) If the target is anything but a single categorical variable, it generates a vector of 768 embeddings for each value in  a text column. These seem to be pretty decent for training the mixer, they allowed for 84% accuracy on the imdb movie reviews dataset, similar to ludwig, where as the previous encoder got us to ~73% and was much slower

b) If the target is a single categorical variable, train a model to predict the target and feed the logits into the mixer (note, this only works for one-hot encoding, but we only use one-hot encoding for categorical output variables at the moment anyway). In theory this could be extended to more output types, but getting it to work well in practice is trickier.  I'm running some benchmarks on this approach now, it seems to perform decently on a sample of imdb movie reviews.

Additional changes:

* Increase mixer's network size if outputs & inputs are very small.
* Added a `training_data` optional argument to `prepare_encoder`.
* Added the ability to pass the encoded/decoded target to the input encoders when the datasource prepares all encoders.