### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/mindsdb/lightwood.svg?branch=master)](https://travis-ci.org/mindsdb/lightwood)
 [![PyPI version](https://badge.fury.io/py/lightwood.svg)](https://badge.fury.io/py/lightwood)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/lightwood)
 
 Lightwood is like Legos for Machine Learning, with two objectives:
 
@@ -13,7 +14,7 @@ Lightwood is like Legos for Machine Learning, with two objectives:
 Lightwood runs on Pytorch and gives you full control of what you can do.
 
 # Documentation
-Learn more  [Lightwood's docs](https://mindsdb.github.io/lightwood/API/)  
+Learn more  from the [Lightwood's docs](https://mindsdb.github.io/lightwood/API/).  
 
 # Quick start
 ```python

--- a/docs/docs/API.md
+++ b/docs/docs/API.md
@@ -57,7 +57,7 @@ config = {
                 'type': COLUMN_DATA_TYPES.NUMERIC
             },
             
-            # some encoders have attributes that can be specified on configuration
+            # some encoders have attributes that can be specified on the configuration
             # in this particular lets assume we have a photo of the product, we would like to encode this image and optimize for speed
             {
                 'name': 'product_photo',

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -11,14 +11,9 @@ Lightwood was inspired on [Keras](https://keras.io/)+[Ludwig](https://github.com
 ## Installing Lightwood
 
 
-### On Linux, OSX and all other operating systems
+### On Linux, OSX, Windows and all other operating systems
 ```bash
 pip3 install lightwood
-```
-
-### On Windows
-```
-pip install git+https://github.com/mindsdb/lightwood.git@master
 ```
 
 If this fails, please report the bug on github and try installing the current master branch:

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.13.2'
+__version__ = '0.13.3'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -59,24 +59,10 @@ def run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
 
     preds = {}
     for j in range(100):
-        pred = predictor.predict(when={'sqft':1600})['number_of_rooms']['predictions'][0]
-        print(pred)
+        pred = predictor.predict(when={'sqft': round(j * 10)})['number_of_rooms']['predictions'][0]
         if pred not in preds:
             preds[pred] = 0
-        else:
-            preds[pred] += 1
-
-
-    print(preds)
-
-
-    # {'3': 31, '2': 18, '1': 23, '0': 22, '<UNCOMMON>': 1}
-
-    # {'0': 35, '<UNCOMMON>': 6, '1': 14, '3': 29, '2': 11}
-
-    # {'0': 30, '3': 32, '1': 20, '2': 13, '<UNCOMMON>': 0}
-
-    # {'2': 12, '1': 17, '3': 27, '0': 38, '<UNCOMMON>': 1}
+        preds[pred] += 1
 
 for USE_CUDA in [False]:
     for CACHE_ENCODED_DATA in [False, True]:

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -7,9 +7,9 @@ import lightwood
 
 def run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
     lightwood.config.config.CONFIG.USE_CUDA = USE_CUDA
-    lightwood.config.config.CONFIG.USE_CUDA = CACHE_ENCODED_DATA
-    lightwood.config.config.CONFIG.USE_CUDA = SELFAWARE
-    lightwood.config.config.CONFIG.USE_CUDA = PLINEAR
+    lightwood.config.config.CONFIG.CACHE_ENCODED_DATA = CACHE_ENCODED_DATA
+    lightwood.config.config.CONFIG.SELFAWARE = SELFAWARE
+    lightwood.config.config.CONFIG.PLINEAR = PLINEAR
 
     ####################
     config = {'input_features': [

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -79,7 +79,7 @@ def run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
     # {'2': 12, '1': 17, '3': 27, '0': 38, '<UNCOMMON>': 1}
 
 for USE_CUDA in [False]:
-    for CACHE_ENCODED_DATA[False, True]:
-        for SELFAWARE[False, True]:
-            for PLINEAR[False, True]:
+    for CACHE_ENCODED_DATA in [False, True]:
+        for SELFAWARE in [False, True]:
+            for PLINEAR in [False, True]:
                 run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR)

--- a/tests/ci_tests/full_test.py
+++ b/tests/ci_tests/full_test.py
@@ -5,67 +5,81 @@ from lightwood import Predictor
 import lightwood
 
 
-####################
-config = {'input_features': [
-                    {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
-                    {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
-                    {'name': 'neighborhood', 'type': 'categorical','dropout':0.4},{'name': 'rental_price', 'type': 'numeric'}],
- 'output_features': [{'name': 'number_of_rooms', 'type': 'categorical',
-                  # 'weights':{
-                  #       '0': 0.8,
-                  #       '1': 0.6,
-                  #       '2': 0.5,
-                  #       '3': 0.7,
-                  #       '4': 1,
-                  # }
-}],
- 'mixer':{'class': lightwood.BUILTIN_MIXERS.NnMixer}}
+def run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
+    lightwood.config.config.CONFIG.USE_CUDA = USE_CUDA
+    lightwood.config.config.CONFIG.USE_CUDA = CACHE_ENCODED_DATA
+    lightwood.config.config.CONFIG.USE_CUDA = SELFAWARE
+    lightwood.config.config.CONFIG.USE_CUDA = PLINEAR
+
+    ####################
+    config = {'input_features': [
+                        {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
+                        {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
+                        {'name': 'neighborhood', 'type': 'categorical','dropout':0.4},{'name': 'rental_price', 'type': 'numeric'}],
+     'output_features': [{'name': 'number_of_rooms', 'type': 'categorical',
+                      # 'weights':{
+                      #       '0': 0.8,
+                      #       '1': 0.6,
+                      #       '2': 0.5,
+                      #       '3': 0.7,
+                      #       '4': 1,
+                      # }
+    }],
+     'mixer':{'class': lightwood.BUILTIN_MIXERS.NnMixer}}
 
 
-# AX doesn't seem to work on the travis version of windows, so don't test it there as of now
-if sys.platform not in ['win32','cygwin','windows']:
-    config['optimizer'] = lightwood.model_building.BasicAxOptimizer
-
-lightwood.config.config.CONFIG.USE_CUDA = False
-
-df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
-
-predictor = Predictor(config)
-
-def iter_function(epoch, error, test_error, test_error_gradient, test_accuracy):
-    print(
-        'epoch: {iter}, error: {error}, test_error: {test_error}, test_error_gradient: {test_error_gradient}, test_accuracy: {test_accuracy}'.format(
-            iter=epoch, error=error, test_error=test_error, test_error_gradient=test_error_gradient,
-            accuracy=predictor.train_accuracy, test_accuracy=test_accuracy))
+    # AX doesn't seem to work on the travis version of windows, so don't test it there as of now
+    if sys.platform not in ['win32','cygwin','windows']:
+        pass
+        #config['optimizer'] = lightwood.model_building.BasicAxOptimizer
 
 
-predictor.learn(from_data=df, callback_on_iter=iter_function, eval_every_x_epochs=2, stop_training_after_seconds=120)
 
-predictor.save('test.pkl')
-predictor = Predictor(load_from_path='test.pkl')
-
-predictor.learn(from_data=df, callback_on_iter=iter_function, eval_every_x_epochs=2, stop_training_after_seconds=120)
-
-predictor.save('test.pkl')
-predictor = Predictor(load_from_path='test.pkl')
-
-preds = {}
-for j in range(100):
-    pred = predictor.predict(when={  'sqft':1600})['number_of_rooms']['predictions'][0]
-    print(pred)
-    if pred not in preds:
-        preds[pred] = 0
-    else:
-        preds[pred] += 1
+    df=pd.read_csv("https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv")
 
 
-print(preds)
+    def iter_function(epoch, error, test_error, test_error_gradient, test_accuracy):
+        print(
+            'epoch: {iter}, error: {error}, test_error: {test_error}, test_error_gradient: {test_error_gradient}, test_accuracy: {test_accuracy}'.format(
+                iter=epoch, error=error, test_error=test_error, test_error_gradient=test_error_gradient,
+                accuracy=predictor.train_accuracy, test_accuracy=test_accuracy))
+
+    predictor = Predictor(config)
+    predictor.learn(from_data=df, callback_on_iter=iter_function, eval_every_x_epochs=2, stop_training_after_seconds=120)
+    predictor.save('test.pkl')
+
+    predictor = Predictor(load_from_path='test.pkl')
+
+    df = df.drop([x['name'] for x in config['output_features']], axis=1)
+    predictor.predict(when_data=df)
 
 
-# {'3': 31, '2': 18, '1': 23, '0': 22, '<UNCOMMON>': 1}
+    predictor.save('test.pkl')
+    predictor = Predictor(load_from_path='test.pkl')
 
-# {'0': 35, '<UNCOMMON>': 6, '1': 14, '3': 29, '2': 11}
+    preds = {}
+    for j in range(100):
+        pred = predictor.predict(when={'sqft':1600})['number_of_rooms']['predictions'][0]
+        print(pred)
+        if pred not in preds:
+            preds[pred] = 0
+        else:
+            preds[pred] += 1
 
-# {'0': 30, '3': 32, '1': 20, '2': 13, '<UNCOMMON>': 0}
 
-# {'2': 12, '1': 17, '3': 27, '0': 38, '<UNCOMMON>': 1}
+    print(preds)
+
+
+    # {'3': 31, '2': 18, '1': 23, '0': 22, '<UNCOMMON>': 1}
+
+    # {'0': 35, '<UNCOMMON>': 6, '1': 14, '3': 29, '2': 11}
+
+    # {'0': 30, '3': 32, '1': 20, '2': 13, '<UNCOMMON>': 0}
+
+    # {'2': 12, '1': 17, '3': 27, '0': 38, '<UNCOMMON>': 1}
+
+for USE_CUDA in [False]:
+    for CACHE_ENCODED_DATA[False, True]:
+        for SELFAWARE[False, True]:
+            for PLINEAR[False, True]:
+                run_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR)


### PR DESCRIPTION
* Updates the lightwood tests to cycle through a few options and try predicting both from the original dataframe and from a python3 dicitionary. Removed the second `learn` call, will add when we actually add some model-updating capabilities to lightwood. Currently it basically just re-trains the mixer.
* Made a few changes around handling missing columns when the cache is disabled so that it behaves the same way as when the cache is enabled
* @ZoranPandovski 's doc updates from https://github.com/mindsdb/lightwood/pull/85