### PR TITLE
Remove botorch from dependencies

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.13.6'
+__version__ = '0.13.7'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-botorch == 0.1.4
 NLTK >= 3
 python-dateutil <2.8.1,>=2.1
 dask<2.4.0,>=1.0.0


### PR DESCRIPTION
Ax-platform has a new version release a few days ago that has fixed the issue with botorch. So, we don't need to install the specific botorch version.