### PR TITLE
Learning rate and boosting bugs

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.15.6'
+__version__ = '0.15.7'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.15.7'
+__version__ = '0.15.8'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -91,7 +91,6 @@ class DataSource(Dataset):
             self.subsets[subset_nr] = SubSet(self, subsets_indexes[subset_nr])
 
     def _clear_cache(self):
-        self.list_cache = {}
         self.encoded_cache = {}
         self.transformed_cache = None
 
@@ -215,15 +214,8 @@ class DataSource(Dataset):
             nr_rows = self.data_frame.shape[0]
             return [None] * nr_rows
 
-        if self.disable_cache:
-            return self.data_frame[column_name].tolist()
+        return self.data_frame[column_name].tolist()
 
-        elif column_name in self.list_cache:
-            return self.list_cache[column_name]
-
-        else:
-            self.list_cache[column_name] = self.data_frame[column_name].tolist()
-            return self.list_cache[column_name]
 
     def prepare_encoders(self):
         '''

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -258,7 +258,7 @@ class Predictor:
         else:
             best_parameters = {}
 
-        if CONFIG.HELPER_MIXERS and self.has_boosting_mixer and (FORCE_HELPER_MIXERS or len(from_data_ds) < 12 * pow(10,3)):
+        if CONFIG.HELPER_MIXERS and self.has_boosting_mixer and (CONFIG.FORCE_HELPER_MIXERS or len(from_data_ds) < 12 * pow(10,3)):
             try:
                 self._helper_mixers = self.train_helper_mixers(from_data_ds, test_data_ds)
             except Exception as e:

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -258,7 +258,7 @@ class Predictor:
         else:
             best_parameters = {}
 
-        if CONFIG.HELPER_MIXERS and self.has_boosting_mixer:
+        if CONFIG.HELPER_MIXERS and self.has_boosting_mixer and (FORCE_HELPER_MIXERS or len(from_data_ds) < 12 * pow(10,3)):
             try:
                 self._helper_mixers = self.train_helper_mixers(from_data_ds, test_data_ds)
             except Exception as e:

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -312,6 +312,11 @@ class Predictor:
                         log_reasure = time.time()
                         logging.info('Lightwood training, iteration {iter_i}, training error {error}'.format(iter_i=epoch, error=training_error))
 
+
+                    # Prime the model on each subset for a bit
+                    if subset_iteration == 1:
+                        break
+
                     # Once the training error is getting smaller, enable dropout to teach the network to predict without certain features
                     if subset_iteration == 2 and training_error < 0.4 and not from_data_ds.enable_dropout:
                         eval_every_x_epochs = max(1, int(eval_every_x_epochs/2) )
@@ -347,10 +352,6 @@ class Predictor:
                         continue
 
                     if epoch >= eval_next_on_epoch:
-                        # Prime the model on each subset for a bit
-                        if subset_iteration == 1:
-                            break
-
                         eval_next_on_epoch += eval_every_x_epochs
 
                         test_error = mixer.error(test_data_ds)
@@ -441,8 +442,9 @@ class Predictor:
 
         if CONFIG.HELPER_MIXERS and self.has_boosting_mixer:
             for output_column in main_mixer_predictions:
+                print(self._helper_mixers[output_column]['accuracy'], self.train_accuracy[output_column]['value'])
                 if self._helper_mixers is not None and output_column in self._helper_mixers:
-                    if self._helper_mixers[output_column]['accuracy'] > 1.05 * self.train_accuracy[output_column]['value']:
+                    if self._helper_mixers[output_column]['accuracy'] > 1.00 * self.train_accuracy[output_column]['value']:
                         helper_mixer_predictions = self._helper_mixers[output_column]['model'].predict(when_data_ds, output_column)
                         main_mixer_predictions[output_column] = {'predictions': list(helper_mixer_predictions[output_column])}
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -128,7 +128,7 @@ class Predictor:
                 continue
 
             real = list(map(str,test_ds.get_column_original_data(output_column)))
-            predicted =  predictions[output_column]
+            predicted =  predictions[output_column]['values']
 
             weight_map = None
             if 'weights' in train_ds.get_column_config(output_column):
@@ -442,11 +442,12 @@ class Predictor:
 
         if CONFIG.HELPER_MIXERS and self.has_boosting_mixer:
             for output_column in main_mixer_predictions:
-                print(self._helper_mixers[output_column]['accuracy'], self.train_accuracy[output_column]['value'])
                 if self._helper_mixers is not None and output_column in self._helper_mixers:
                     if self._helper_mixers[output_column]['accuracy'] > 1.00 * self.train_accuracy[output_column]['value']:
                         helper_mixer_predictions = self._helper_mixers[output_column]['model'].predict(when_data_ds, output_column)
-                        main_mixer_predictions[output_column] = {'predictions': list(helper_mixer_predictions[output_column])}
+                        main_mixer_predictions[output_column] = {'predictions': list(helper_mixer_predictions[output_column]['values'])}
+                        if 'confidences' in helper_mixer_predictions[output_column] and helper_mixer_predictions[output_column]['confidences'] is not None:
+                            main_mixer_predictions[output_column]['confidences'] = list(helper_mixer_predictions[output_column]['confidences'])
 
         return main_mixer_predictions
 
@@ -502,7 +503,7 @@ class Predictor:
         for output_column in self._output_columns:
 
             real = list(map(str,ds.get_column_original_data(output_column)))
-            predicted =  list(map(str,predictions[output_column]["predictions"]))
+            predicted =  list(map(str,predictions[output_column]['predictions']))
 
             weight_map = None
             if 'weights' in ds.get_column_config(output_column):

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -313,7 +313,8 @@ class Predictor:
                         logging.info('Lightwood training, iteration {iter_i}, training error {error}'.format(iter_i=epoch, error=training_error))
 
                     # Once the training error is getting smaller, enable dropout to teach the network to predict without certain features
-                    if subset_iteration == 2 and training_error < 0.5 and not from_data_ds.enable_dropout:
+                    if subset_iteration == 2 and training_error < 0.4 and not from_data_ds.enable_dropout:
+                        eval_every_x_epochs = max(1, int(eval_every_x_epochs/2) )
                         logging.info('Enabled dropout !')
                         from_data_ds.enable_dropout = True
                         lowest_error = None
@@ -335,7 +336,7 @@ class Predictor:
                         continue
 
                     # Once we are past the priming/warmup period, start training the selfaware network
-                    if subset_iteration == 2 and not mixer.is_selfaware and CONFIG.SELFAWARE and not mixer.stop_selfaware_training and training_error < 0.2:
+                    if subset_iteration == 2 and not mixer.is_selfaware and CONFIG.SELFAWARE and not mixer.stop_selfaware_training and training_error < 0.15:
                         logging.info('Started selfaware training !')
                         mixer.start_selfaware_training = True
                         lowest_error = None

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -14,6 +14,7 @@ class CONFIG:
     DETERMINISTIC = True
     SELFAWARE = True
     HELPER_MIXERS = True
+    FORCE_HELPER_MIXERS = False
     ENABLE_DROPOUT = True
 
     """Probabilistic FC layers"""

--- a/lightwood/encoders/text/__init__.py
+++ b/lightwood/encoders/text/__init__.py
@@ -3,6 +3,6 @@ from lightwood.encoders.text.infersent import InferSentEncoder
 from lightwood.encoders.text.distilbert import DistilBertEncoder
 from lightwood.encoders.text.tfidf import TfidfEncoder
 
-#default = TfidfEncoder
-default = DistilBertEncoder
+default = TfidfEncoder
+#default = DistilBertEncoder
 #default = InferSentEncoder

--- a/lightwood/encoders/text/__init__.py
+++ b/lightwood/encoders/text/__init__.py
@@ -3,6 +3,6 @@ from lightwood.encoders.text.infersent import InferSentEncoder
 from lightwood.encoders.text.distilbert import DistilBertEncoder
 from lightwood.encoders.text.tfidf import TfidfEncoder
 
-default = TfidfEncoder
-#default = DistilBertEncoder
+#default = TfidfEncoder
+default = DistilBertEncoder
 #default = InferSentEncoder

--- a/lightwood/encoders/text/tfidf.py
+++ b/lightwood/encoders/text/tfidf.py
@@ -21,7 +21,7 @@ class TfidfEncoder:
 
     def prepare_encoder(self, priming_data, training_data=None):
         self.tfidf_vectorizer = TfidfVectorizer(ngram_range=self.ngram_range, max_features=self.max_features)
-        self.tfidf_vectorizer.fit_transform(priming_data)
+        self.tfidf_vectorizer.fit_transform([str(x) for x in priming_data])
 
     def encode(self, column_data):
         transformed_data = self.tfidf_vectorizer.transform([str(x) for x in column_data])

--- a/lightwood/mixers/boost/boost.py
+++ b/lightwood/mixers/boost/boost.py
@@ -44,7 +44,7 @@ class BoostMixer():
                 self.targets[target_col_name]['model'].fit(X,Y,sample_weight=sample_weight)
 
             elif self.targets[target_col_name]['type'] == COLUMN_DATA_TYPES.NUMERIC:
-                self.targets[target_col_name]['model'] = GradientBoostingRegressor()
+                self.targets[target_col_name]['model'] = GradientBoostingRegressor(n_estimators=600)
                 self.targets[target_col_name]['model'].fit(X,Y)
 
             else:
@@ -60,9 +60,18 @@ class BoostMixer():
         if targets is None:
             targets = self.targets
         for target_col_name in self.targets:
+
             if self.targets[target_col_name]['model'] is None:
                 predictions[target_col_name] = None
+            else:
+                predictions[target_col_name] = {'values':None, 'confidences':None}
 
-            predictions[target_col_name] = self.targets[target_col_name]['model'].predict(X)
+                predictions[target_col_name]['values'] = self.targets[target_col_name]['model'].predict(X)
+                try:
+                    predictions[target_col_name]['confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
+
+                except Exception as e:
+                    pass
+
 
         return predictions

--- a/lightwood/mixers/boost/boost.py
+++ b/lightwood/mixers/boost/boost.py
@@ -1,5 +1,5 @@
 import numpy as np
-import xgboost as xgb
+from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
 
 from lightwood.constants.lightwood import COLUMN_DATA_TYPES
 
@@ -40,11 +40,11 @@ class BoostMixer():
                     for val in Y:
                         sample_weight.append(weight_map[val])
 
-                self.targets[target_col_name]['model'] = xgb.XGBClassifier()
+                self.targets[target_col_name]['model'] = GradientBoostingClassifier(n_estimators=600)
                 self.targets[target_col_name]['model'].fit(X,Y,sample_weight=sample_weight)
 
             elif self.targets[target_col_name]['type'] == COLUMN_DATA_TYPES.NUMERIC:
-                self.targets[target_col_name]['model'] = xgb.XGBRegressor()
+                self.targets[target_col_name]['model'] = GradientBoostingRegressor()
                 self.targets[target_col_name]['model'].fit(X,Y)
 
             else:

--- a/lightwood/mixers/helpers/ranger.py
+++ b/lightwood/mixers/helpers/ranger.py
@@ -6,7 +6,7 @@ from torch.optim.optimizer import Optimizer
 
 
 class Ranger(Optimizer):
-    def __init__(self, params, lr=0.001, alpha=0.5, k=6, N_sma_threshold=5, betas=(.95,0.999), eps=1e-5, weight_decay=0):
+    def __init__(self, params, lr=0.0005, alpha=0.5, k=5, N_sma_threshold=5, betas=(.9,0.999), eps=1e-5, weight_decay=0):
         #parameter checks
         if not 0.0 <= alpha <= 1.0:
             raise ValueError(f'Invalid slow update rate: {alpha}')

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -273,7 +273,7 @@ class NnMixer:
                     self.last_unaware_net = copy.deepcopy(self.net.net)
 
                     # Lower the learning rate once we start training the selfaware network
-                    self.optimizer_args['lr'] = self.optimizer.lr/8
+                    self.optimizer_args['lr'] = self.optimizer.lr/4
                     gc.collect()
                     if 'cuda' in str(self.net.device):
                         torch.cuda.empty_cache()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ xlrd >= 1.0.0
 requests >= 2.0.0
 ax-platform >= 0.1.9
 transformers >= 2.2.1
-xgboost >= 0.80
 pydub >= 0.20.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ if sys_platform in ['win32','cygwin','windows']:
     requirements = remove_requirements(requirements,'torchvision')
     requirements = remove_requirements(requirements,'torchvision')
 
-    requirements = remove_requirements(requirements,'xgboost')
     requirements = remove_requirements(requirements,'dask')
     requirements = remove_requirements(requirements,'cesium')
     requirements = remove_requirements(requirements,'pydub')


### PR DESCRIPTION
* XDG scrapped in favour of sklearn since the mixers were buggy (failing to take sample weights into the account for no apparent reason... I tried my hardest to make them work), it also seems like their performance wasn't necessarily better and they weren't working on windows (sklearn works)
* Sourcing confidence from booster when they are used for predictions and only calling them for small datasets (since they are very fast, they are slower than the neural network on larger datasets... and decreasing the nr of estimator means their performance goes down the drain, especially on large datasets)
* Evaluating the model more often once dropout is enabled, decreased the learning rate and decreased the wramup period in order to diminish the problems discussed (models that fit the training set to quickly and then the loss start oscillating in a sub-optimal area).

Overall not the final fix to the issue discussed, but it's enough to raise accuracy on 3 benchmark datasets (cifrar remains unaffected, currently running tests on IMDB movie review). Also got the wine datasets from "inf loss" to "very bad r2_score" (-0.3), which I will call a move in the right direction.