### PR TITLE
Fix missing logger error

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -1,4 +1,5 @@
 import random
+import logging
 import numpy as np
 import torch
 from torch.utils.data import DataLoader

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -118,7 +118,6 @@ if __name__ == "__main__":
     import random
     import string
     from sklearn.metrics import accuracy_score
-    import logging
 
     logging.getLogger().setLevel(logging.DEBUG)
 


### PR DESCRIPTION
This PR fixes missing logging error:
```
  File "/home/zoran/MyProjects/mindsdb-examples/mdb/lib/python3.7/site-packages/lightwood/encoders/categorical/autoencoder.py", line 57, in prepare_encoder
    logging.info('Preparing a categorical autoencoder, this might take a while')
NameError: name 'logging' is not defined
```
