### PR TITLE
New nr encoder

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.18.0'
+__version__ = '0.18.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -13,7 +13,7 @@ class CONFIG:
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
     SELFAWARE = True
-    HELPER_MIXERS = True
+    HELPER_MIXERS = False#True
     FORCE_HELPER_MIXERS = False
     ENABLE_DROPOUT = True
 

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -64,17 +64,16 @@ class NumericEncoder:
                 number = None
 
             if self._is_target:
-                [actual_number,log(abs(number)) if abs(number)>0 else -100]
-
-                vector = [0] * 3
+                vector = [0] * 2
                 try:
-                    vector[0] = number # Alternative: abs(number)/self._abs_mean
+                    vector[0] = number/self._abs_mean
+                    #vector[0] = number
                     vector[1] = math.log(abs(number)) if number > 0 else -100
                 except:
                     logging.warning(f'Got unexpected value for numerical target value: "{number}" !')
                     # @TODO For now handle this by setting to zero as a hotfix,
                     # but we need to figure out why it's happening and fix it properly later
-                    vector = [0] * 3
+                    vector = [0] * 2
 
             else:
                 vector = [0] * 2
@@ -94,12 +93,13 @@ class NumericEncoder:
             if self._is_target:
                 if not math.isnan(vector[0]):
                     linear_value = vector[0]
-                    real_value = linear_value # lienar_value * self._abs_mean under alternative encoding
+                    real_value = linear_value * self._abs_mean
+                    #real_value = linear_value
                 else:
                     logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
                     real_value = None
 
-                if self._type == 'int':
+                if self._type == 'int' and real_value is not None:
                     real_value = int(round(real_value))
             else:
                 is_zero = False

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -64,15 +64,12 @@ class NumericEncoder:
                 number = None
 
             if self._is_target:
+                [actual_number,log(abs(number)) if abs(number)>0 else -100]
+
                 vector = [0] * 3
                 try:
-                    if number < 0:
-                        vector[0] = 1
-                    if number == 0:
-                        vector[2] = 1
-                    else:
-                        vector[1] = math.log(abs(number)) #abs(number)/self._max_value
-
+                    vector[0] = number # Alternative: abs(number)/self._abs_mean
+                    vector[1] = math.log(abs(number)) if number > 0 else -100
                 except:
                     logging.warning(f'Got unexpected value for numerical target value: "{number}" !')
                     # @TODO For now handle this by setting to zero as a hotfix,
@@ -96,41 +93,14 @@ class NumericEncoder:
         for vector in encoded_values.tolist():
             if self._is_target:
                 if not math.isnan(vector[0]):
-                    is_negative = True if abs(round(vector[0])) == 1 else False
+                    linear_value = vector[0]
+                    real_value = linear_value # lienar_value * self._abs_mean under alternative encoding
                 else:
                     logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
-                    is_negative = False
-
-                if not math.isnan(vector[1]):
-                    encoded_nr = vector[1]
-                else:
-                    logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
-                    encoded_nr = 0
-
-                if not math.isnan(vector[2]):
-                    is_zero = True if abs(round(vector[2])) == 1 else False
-                else:
-                    logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
-                    is_zero = False
-                is_none = False
-
-                try:
-                    real_value = math.exp(encoded_nr) #encoded_nr * self._max_value
-                    if is_negative:
-                        real_value = -real_value
-                except:
-                    if self._type == 'int':
-                        real_value = pow(2, 63)
-                    else:
-                        real_value = float('inf')
-
-                if is_none:
                     real_value = None
-                if is_zero:
-                    real_value = 0
 
                 if self._type == 'int':
-                    real_value = round(real_value)
+                    real_value = int(round(real_value))
             else:
                 is_zero = False
                 is_negative = False


### PR DESCRIPTION
New simplified numeric encoding for targets.

## Accuracy

Using a % error based accuracy score that's roughly this: `1 - abs((y_true - y_pred) / y_true)` (where y_true and y_pred are arrays and the operations are done element-wise).

On the home rentals dataset.

With helper mixers disabled (otherwise we get better accuracy with those and the neural network is ignored, the helper mixers predicted the un-encoded values so the encoding is not relevant there)

* master:  -1.4 pct accuracy score
* new encoding with the log representation (as per this PR): -0.5 pct accuracy score
* new encoding without the log representation: 0.6 pct accuracy score
* gradient boosting regressor: 0.95 pct accuracy score

Note 1 : with the ranged loss the last accuracy improves to ~0.8 I believe, which is close to the gradient boosting regressor

Note 2: I normalized the linear value by dividing with the absolute mean, without normalization the network isn't able to predict anything, the value get to be too high

# My tentative conclusions

Overall with or without log we get better accuracy with this encoder.
Conceptually I understand why you want the log encoding @torrmal , but in practice on both home rentals and the bike dataset it seems to do worst... even using a % error, which is what the log encoding should be optimzing our model for, I'd suggest:

a) Drop the log encoding (add a flag to enable it and figure out when to do so)

OR

b) Add more numeric benchmarks and decide on the accuracy scores we want to use for each in order to text log vs linear vs log+linear on each