### PR TITLE
Fix covid crash

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.18.1'
+__version__ = '0.19.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -307,9 +307,9 @@ class Predictor:
                     first_run = False
 
                     # Log this every now and then so that the user knows it's running
-                    if (int(time.time()) - log_reasure) > 30:
+                    if (int(time.time()) - log_reasure) > 0:
                         log_reasure = time.time()
-                        logging.info('Lightwood training, iteration {iter_i}, training error {error}'.format(iter_i=epoch, error=training_error))
+                        logging.info(f'Lightwood training, iteration {epoch}, training error {training_error}')
 
 
                     # Prime the model on each subset for a bit
@@ -356,6 +356,7 @@ class Predictor:
                         test_error = mixer.error(test_data_ds)
                         subset_test_error = mixer.error(subset_test_ds, subset_id=subset_id)
                         logging.info(f'Subtest test error: {subset_test_error} on subset {subset_id}')
+
                         if lowest_error is None or test_error < lowest_error:
                             lowest_error = test_error
                             if mixer.is_selfaware:

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -307,7 +307,7 @@ class Predictor:
                     first_run = False
 
                     # Log this every now and then so that the user knows it's running
-                    if (int(time.time()) - log_reasure) > 0:
+                    if (int(time.time()) - log_reasure) > 30:
                         log_reasure = time.time()
                         logging.info(f'Lightwood training, iteration {epoch}, training error {training_error}')
 

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -13,7 +13,7 @@ class CONFIG:
     # Enable deterministic cuda flag and use seeds everywhere (static or based on features of the dataset)
     DETERMINISTIC = True
     SELFAWARE = True
-    HELPER_MIXERS = False#True
+    HELPER_MIXERS = True
     FORCE_HELPER_MIXERS = False
     ENABLE_DROPOUT = True
 

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -13,7 +13,8 @@ class DefaultNet(torch.nn.Module):
         # How many devices we can train this network on
         self.available_devices = 1
         self.max_variance = None
-        self.ds = ds
+        if ds is not None:
+            self.out_indexes = ds.out_indexes
 
         device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
         if CONFIG.USE_DEVICE is not None:
@@ -104,8 +105,9 @@ class DefaultNet(torch.nn.Module):
                     self.output_size = layer.out_features
 
         if self.selfaware:
-            awareness_net_shape = [(self.input_size + self.output_size), max([int((self.input_size + self.output_size) * 1.5), 300]), len(self.ds.out_indexes)]
+            awareness_net_shape = [(self.input_size + self.output_size), max([int((self.input_size + self.output_size) * 1.5), 300]), len(self.out_indexes)]
             awareness_layers = []
+
 
             for ind in range(len(awareness_net_shape) - 1):
                 awareness_layers.append(torch.nn.Linear(awareness_net_shape[ind], awareness_net_shape[ind + 1]))

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -249,10 +249,6 @@ class NnMixer:
 
         self.net = self.net.train()
 
-        # To avoid weird behavior with nan values just return a very large number instead
-        if np.isnan(error):
-            return pow(10,12)
-
         return error
 
     def get_model_copy(self):
@@ -260,6 +256,7 @@ class NnMixer:
         get the actual mixer model
         :return: self.net
         """
+        self.optimizer.zero_grad()
         return copy.deepcopy(self.net)
 
     def update_model(self, model):

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -249,6 +249,10 @@ class NnMixer:
 
         self.net = self.net.train()
 
+        # To avoid weird behavior with nan values just return a very large number instead
+        if np.isnan(error):
+            return pow(10,12)
+
         return error
 
     def get_model_copy(self):
@@ -427,6 +431,7 @@ class NnMixer:
                 if awareness_loss is not None:
                     awareness_loss.backward(retain_graph=True)
 
+                running_loss += loss.item()
                 loss.backward()
 
                 # @NOTE: Decrease 900 if you want to plot gradients more often, I find it's too expensive to do so


### PR DESCRIPTION
* No longer passing the data source inside the `DefaultNet` since this was causing some issues (related to trying to deep copy the autoencoder which is part of the data source), instead just taking the entities we need (in this case the output indexes) from it.
* Re-enabled helper mixers (flag was turned off by mistake)
* Fixed a glaring error where running_loss was not updated in `iter_fit`