### PR TITLE
fix for "ValueError: max() arg is an empty sequence"

### DIFF
--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -98,7 +98,9 @@ class NnMixer:
             if len(loss_confidence_arr[k]) > 0:
                 loss_confidence_arr[k] = np.array(loss_confidence_arr[k])
                 nf_pct = np.percentile(loss_confidence_arr[k], 95)
-                self.max_confidence_per_output[k] = max(loss_confidence_arr[k][loss_confidence_arr[k] < nf_pct])
+                filtered_loss_confidence_arr = loss_confidence_arr[k][loss_confidence_arr[k] < nf_pct]
+                if len(filtered_loss_confidence_arr):
+                    self.max_confidence_per_output[k] = max(filtered_loss_confidence_arr)
 
         return True
 


### PR DESCRIPTION
With the latest version(1.14), im getting following error while training as given below:
```
ERROR:mindsdb-logger-8f5545f6-6b64-11ea-8e56-42010a8a0002:libs/controllers/transaction.py:126 - Could not load module ModelInterface

ERROR:mindsdb-logger-8f5545f6-6b64-11ea-8e56-42010a8a0002:libs/controllers/transaction.py:127 - Traceback (most recent call last):
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/mindsdb/libs/controllers/transaction.py", line 123, in _call_phase_module
    return module(self.session, self)(**kwargs)
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/mindsdb/libs/phases/base_module.py", line 54, in _call_
    ret = self.run(**kwargs)
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/mindsdb/libs/phases/model_interface/model_interface.py", line 32, in run
    self.transaction.model_backend.train()
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/mindsdb/libs/backends/lightwood.py", line 195, in train
    self.predictor.learn(from_data=train_df, test_data=test_df, stop_training_after_seconds=self.transaction.lmd['stop_training_in_x_seconds'], callback_on_iter=self.callback_on_iter, eval_every_x_epochs=eval_every_x_epochs)
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/lightwood/api/predictor.py", line 422, in learn
    self._mixer.build_confidence_normalization_data(test_data_ds)
  File "/opt/anaconda3/envs/suren_mdb_env/lib/python3.7/site-packages/lightwood/mixers/nn/nn.py", line 101, in build_confidence_normalization_data
    self.max_confidence_per_output[k] = max(loss_confidence_arr[k][loss_confidence_arr[k] < nf_pct])
ValueError: max() arg is an empty sequence
```