### PR TITLE
Confidence bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,19 @@ matrix:
       env:
         DEPLOYMENT_ENV="true"
 
+    - name: "Python 3.6 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.6
+      node: 11.15.0
+      dist: xenial
+
+    - name: "Python 3.8 on Ubuntu 16.0.4"
+      os: linux
+      python: 3.8
+      node: 11.15.0
+      dist: xenial
+
+
     - name: "Python 3.7.2 on OSX"
       os: osx
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,6 @@ matrix:
       env:
         DEPLOYMENT_ENV="true"
 
-    - name: "Python 3.6 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.6
-      node: 11.15.0
-      dist: xenial
-
-    - name: "Python 3.8 on Ubuntu 16.0.4"
-      os: linux
-      python: 3.8
-      node: 11.15.0
-      dist: xenial
-
-
     - name: "Python 3.7.2 on OSX"
       os: osx
       language: shell

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.19.0'
+__version__ = '0.19.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -98,7 +98,12 @@ class NnMixer:
             if len(loss_confidence_arr[k]) > 0:
                 loss_confidence_arr[k] = np.array(loss_confidence_arr[k])
                 nf_pct = np.percentile(loss_confidence_arr[k], 95)
-                self.max_confidence_per_output[k] = max(loss_confidence_arr[k][loss_confidence_arr[k] < nf_pct])
+
+                losses_bellow_95th_percentile = loss_confidence_arr[k][loss_confidence_arr[k] < nf_pct]
+                if len(losses_bellow_95th_percentile) < 1:
+                    losses_bellow_95th_percentile = loss_confidence_arr[k]
+                    
+                self.max_confidence_per_output[k] = max(losses_bellow_95th_percentile)
 
         return True
 


### PR DESCRIPTION
See description of bug here: https://github.com/mindsdb/lightwood/pull/137

This basically handles the same issue as #137 but source `max_confidence` as the maximum overall confidence in the array, rather than the maximum out of those values smaller the 9th percentile.

Also, merged in here, removal of 3.6 and 3.8 travis tests envs to hopefully have more machine-power to allow travis tests on windows and osx to more easily pass (to be seen if this actually works).