### PR TITLE
Gradient boosting quantiles

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.19.3'
+__version__ = '0.20.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -428,7 +428,6 @@ class Predictor:
         :param when: a dictionary
         :return: a complete dataframe
         """
-        print('HERE !')
         if when is not None:
             when_dict = {key: [when[key]] for key in when}
             when_data = pandas.DataFrame(when_dict)
@@ -446,7 +445,6 @@ class Predictor:
 
                         main_mixer_predictions[output_column] = helper_mixer_predictions[output_column]
 
-        print(main_mixer_predictions)
         return main_mixer_predictions
 
     @staticmethod

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -113,7 +113,7 @@ class Predictor:
     def train_helper_mixers(self, train_ds, test_ds):
         from lightwood.mixers.boost.boost import BoostMixer
 
-        boost_mixer = BoostMixer()
+        boost_mixer = BoostMixer(quantiles=CONFIG.QUANTILES)
         boost_mixer.train(train_ds)
 
         # @TODO: IF we add more mixers in the future, add the best on for each column to this map !
@@ -442,9 +442,8 @@ class Predictor:
                 if self._helper_mixers is not None and output_column in self._helper_mixers:
                     if self._helper_mixers[output_column]['accuracy'] > 1.00 * self.train_accuracy[output_column]['value']:
                         helper_mixer_predictions = self._helper_mixers[output_column]['model'].predict(when_data_ds, output_column)
-                        main_mixer_predictions[output_column] = {'predictions': list(helper_mixer_predictions[output_column]['values'])}
-                        if 'confidences' in helper_mixer_predictions[output_column] and helper_mixer_predictions[output_column]['confidences'] is not None:
-                            main_mixer_predictions[output_column]['confidences'] = list(helper_mixer_predictions[output_column]['confidences'])
+
+                        main_mixer_predictions[output_column] = helper_mixer_predictions
 
         return main_mixer_predictions
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -126,7 +126,7 @@ class Predictor:
                 continue
 
             real = list(map(str,test_ds.get_column_original_data(output_column)))
-            predicted =  predictions[output_column]['values']
+            predicted =  predictions[output_column]['predictions']
 
             weight_map = None
             if 'weights' in test_ds.get_column_config(output_column):
@@ -259,6 +259,7 @@ class Predictor:
                 self._helper_mixers = self.train_helper_mixers(from_data_ds, test_data_ds)
             except Exception as e:
                 logging.warning(f'Failed to train helper mixers with error: {e}')
+
 
         mixer = mixer_class(best_parameters)
         self._mixer = mixer
@@ -427,7 +428,7 @@ class Predictor:
         :param when: a dictionary
         :return: a complete dataframe
         """
-
+        print('HERE !')
         if when is not None:
             when_dict = {key: [when[key]] for key in when}
             when_data = pandas.DataFrame(when_dict)
@@ -441,10 +442,11 @@ class Predictor:
             for output_column in main_mixer_predictions:
                 if self._helper_mixers is not None and output_column in self._helper_mixers:
                     if self._helper_mixers[output_column]['accuracy'] > 1.00 * self.train_accuracy[output_column]['value']:
-                        helper_mixer_predictions = self._helper_mixers[output_column]['model'].predict(when_data_ds, output_column)
+                        helper_mixer_predictions = self._helper_mixers[output_column]['model'].predict(when_data_ds, [output_column])
 
-                        main_mixer_predictions[output_column] = helper_mixer_predictions
+                        main_mixer_predictions[output_column] = helper_mixer_predictions[output_column]
 
+        print(main_mixer_predictions)
         return main_mixer_predictions
 
     @staticmethod

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -29,3 +29,5 @@ class CONFIG:
         ,'batch_loss': False
         ,'network_heatmap': False
     }
+
+    QUANTILES = [0.05,0.95]

--- a/lightwood/mixers/boost/boost.py
+++ b/lightwood/mixers/boost/boost.py
@@ -6,8 +6,9 @@ from lightwood.constants.lightwood import COLUMN_DATA_TYPES
 
 class BoostMixer():
 
-    def __init__(self):
+    def __init__(self, quantiles=None):
         self.targets = None
+        self.quantiles = quantiles
 
     def train(self, data_source):
         output_features = data_source.configuration['output_features']
@@ -46,6 +47,11 @@ class BoostMixer():
             elif self.targets[target_col_name]['type'] == COLUMN_DATA_TYPES.NUMERIC:
                 self.targets[target_col_name]['model'] = GradientBoostingRegressor(n_estimators=600)
                 self.targets[target_col_name]['model'].fit(X,Y)
+                if self.quantiles is not None:
+                    self.targets[target_col_name]['quantile_models'] = []
+                    for i, quantile in enumerate(self.quantiles):
+                        self.targets[target_col_name]['quantile_models'][i] = GradientBoostingRegressor(n_estimators=600, loss='quantile',alpha=[quantile])
+                        self.targets[target_col_name]['quantile_models'][i].fit(X,Y)
 
             else:
                 self.targets[target_col_name]['model'] = None
@@ -66,9 +72,16 @@ class BoostMixer():
             else:
                 predictions[target_col_name] = {'values':None, 'confidences':None}
 
-                predictions[target_col_name]['values'] = self.targets[target_col_name]['model'].predict(X)
+                predictions[target_col_name]['predictions'] = self.targets[target_col_name]['model'].predict(X)
                 try:
-                    predictions[target_col_name]['confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
+                    predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
+
+                    if 'quantile_models' in self.targets[target_col_name]:
+                        lower_quantiles = self.targets[target_col_name]['quantile_models'][0].predict(X)
+                        upper_quantiles = self.targets[target_col_name]['quantile_models'][1].predict(X)
+
+                        predictions[target_col_name]['confidence_range'] = [[lower_quantiles[i],upper_quantiles[i]] for i in range(len(decoded_predictions))]
+                        predictions[target_col_name]['quantile_confidences'] = [self.quantiles[1] - self.quantiles[0] for i in range(len(decoded_predictions))]
 
                 except Exception as e:
                     pass

--- a/lightwood/mixers/boost/boost.py
+++ b/lightwood/mixers/boost/boost.py
@@ -71,19 +71,21 @@ class BoostMixer():
                 predictions[target_col_name] = None
             else:
                 predictions[target_col_name] = {}
-                predictions[target_col_name]['predictions'] = self.targets[target_col_name]['model'].predict(X)
+                predictions[target_col_name]['predictions'] = [x for x in self.targets[target_col_name]['model'].predict(X)]
+
                 try:
                     predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
-
-                    if 'quantile_models' in self.targets[target_col_name]:
-                        lower_quantiles = self.targets[target_col_name]['quantile_models'][0].predict(X)
-                        upper_quantiles = self.targets[target_col_name]['quantile_models'][1].predict(X)
-
-                        predictions[target_col_name]['confidence_range'] = [[lower_quantiles[i],upper_quantiles[i]] for i in range(len(decoded_predictions))]
-                        predictions[target_col_name]['quantile_confidences'] = [self.quantiles[1] - self.quantiles[0] for i in range(len(decoded_predictions))]
-
                 except Exception as e:
                     pass
+
+                if 'quantile_models' in self.targets[target_col_name]:
+                    lower_quantiles = self.targets[target_col_name]['quantile_models'][0].predict(X)
+                    upper_quantiles = self.targets[target_col_name]['quantile_models'][1].predict(X)
+
+                    predictions[target_col_name]['confidence_range'] = [[lower_quantiles[i],upper_quantiles[i]] for i in range(len(lower_quantiles))]
+                    predictions[target_col_name]['quantile_confidences'] = [self.quantiles[1] - self.quantiles[0] for i in range(len(lower_quantiles))]
+
+
 
 
         return predictions

--- a/lightwood/mixers/boost/boost.py
+++ b/lightwood/mixers/boost/boost.py
@@ -48,9 +48,9 @@ class BoostMixer():
                 self.targets[target_col_name]['model'] = GradientBoostingRegressor(n_estimators=600)
                 self.targets[target_col_name]['model'].fit(X,Y)
                 if self.quantiles is not None:
-                    self.targets[target_col_name]['quantile_models'] = []
+                    self.targets[target_col_name]['quantile_models'] = {}
                     for i, quantile in enumerate(self.quantiles):
-                        self.targets[target_col_name]['quantile_models'][i] = GradientBoostingRegressor(n_estimators=600, loss='quantile',alpha=[quantile])
+                        self.targets[target_col_name]['quantile_models'][i] = GradientBoostingRegressor(n_estimators=600, loss='quantile',alpha=quantile)
                         self.targets[target_col_name]['quantile_models'][i].fit(X,Y)
 
             else:
@@ -70,8 +70,7 @@ class BoostMixer():
             if self.targets[target_col_name]['model'] is None:
                 predictions[target_col_name] = None
             else:
-                predictions[target_col_name] = {'values':None, 'confidences':None}
-
+                predictions[target_col_name] = {}
                 predictions[target_col_name]['predictions'] = self.targets[target_col_name]['model'].predict(X)
                 try:
                     predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]


### PR DESCRIPTION
Added quantile prediction for the gradient booster in order for them to give use quantile intervals.

Quantiles are currently hardcoded in the config so that in the future we can use the same quantiles for the nn mixer.

Here's some results with the 0.95 and 0.05 quantiles:

```
Out of the intervals 251 were correct (real value was within the interval) and 63 were incorrect (real value was outside the interval)
Out of the intervals 314 contained only positive values and 0 contained at least one negative value (gross prediction error, since all the targets are positive)
The mean range of the intervals was 108.23336156530779
The standard deviation for the ranges was 161.41387342773075
```

Here's some results with the 0.85 and 0.15 quantiles:

```
Out of the intervals 197 were correct (real value was within the interval) and 117 were incorrect (real value was outside the interval)
Out of the intervals 314 contained only positive values and 0 contained at least one negative value (gross prediction error, since all the targets are positive)
The mean range of the intervals was 40.28855500050578
The standard deviation for the ranges was 60.9251888281234
```

So basically the quantiles are not quite on the mark,

For the .95 - .05 quantile combo we'd expect 90% of the real values to fall within the boundaries but we only get this for 80% of them.

For the .85 - .15 quantile combo we'd expect 70% of the real values to fall within the boundaries but only get 62%.

Still, the general trend seems to hold and the ranges are much smaller and usually close to the target even if the target is not within them.