### PR TITLE
New Numeric Encoder and decoding selection

### DIFF
--- a/docs/examples/learn_to_multiply.py
+++ b/docs/examples/learn_to_multiply.py
@@ -1,51 +1,63 @@
 import pandas
 import random
+import lightwood
 from lightwood import Predictor
 import os
 
+
+lightwood.config.config.CONFIG.HELPER_MIXERS = False
+
 ### Generate a dataset
-datapoints = 1000
+n = 1000
+op = '*'
 
 # generate random numbers between -10 and 10
-data = {'x': [random.randint(-10, 10) for i in range(datapoints)],
-        'y': [random.randint(-10, 10) for i in range(datapoints)]}
+data_train = {'x': [random.randint(-15, 5) for i in range(n)],
+        'y': [random.randint(-15, 5) for i in range(n)]}
+
+data_test = {'x': [random.randint(-5, 15) for i in range(n)],
+        'y': [random.randint(-5, 15) for i in range(n)]}
+
+if op == '/':
+    for i in range(n):
+        if data_train['y'][i] == 0:
+            data_train['y'][i] = 1
+        if data_test['y'][i] == 0:
+            data_test['y'][i] = 1
 
 # target variable to be the multiplication of the two
-data['z'] = [data['x'][i] * data['y'][i] for i in range(datapoints)]
+data_train['z'] = eval(f"""[data_train['x'][i] {op} data_train['y'][i] for i in range(n)]""")
+data_test['z'] = eval(f"""[data_test['x'][i] {op} data_test['y'][i] for i in range(n)]""")
 
 
-data_frame = pandas.DataFrame(data)
-print(data_frame)
+df_train = pandas.DataFrame(data_train)
+df_test = pandas.DataFrame(data_test)
 
 predictor = Predictor(output=['z'])
 
+def iter_function(epoch, training_error, test_error, test_error_gradient, test_accuracy):
+    print(f'Epoch: {epoch}, Train Error: {training_error}, Test Error: {test_error}, Test Error Gradient: {test_error_gradient}, Test Accuracy: {test_accuracy}')
 
-def iter_function(epoch, error, test_error, test_error_gradient, test_accuracy):
-    print(
-        'epoch: {iter}, error: {error}, test_error: {test_error}, test_error_gradient: {test_error_gradient}, test_accuracy: {test_accuracy}'.format(
-            iter=epoch, error=error, test_error=test_error, test_error_gradient=test_error_gradient,
-            accuracy=predictor.train_accuracy, test_accuracy=test_accuracy))
-
-
-
-predictor.learn(from_data=data_frame, callback_on_iter=iter_function)
-print('accuracy')
-print(predictor.train_accuracy)
-print('accuracy over all dataset')
-print(predictor.calculate_accuracy(from_data=data_frame))
-when = {'x': [1], 'y': [0]}
-print('- multiply when. {when}'.format(when=when))
-print(predictor.predict(when=when))
-
-# saving the predictor
+predictor.learn(from_data=df_train, callback_on_iter=iter_function, eval_every_x_epochs=20)
 predictor.save('ok.pkl')
 
-# loading the predictor
+predictor = Predictor(load_from_path='ok.pkl')
 
-predictor2 = Predictor(load_from_path='ok.pkl')
+'''
 when = {'x': [0, 0, 1, -1, 1], 'y': [0, 1, -1, -1, 1]}
-print('- multiply when. {when}'.format(when=when))
-print(predictor2.predict(when_data=pandas.DataFrame(when)))
+pred = predictor.predict(when_data=pandas.DataFrame(when))['z']['predictions']
+print('Real values: ' + eval(f"""str([when['x'][i] {op} when['y'][i] for i in range(len(when['x']))])"""))
+print('Pred values: ' + str(pred))
+
 when = {'x': [0, 3, 1, -5, 1], 'y': [0, 1, -5, -4, 7]}
-print('- multiply when. {when}'.format(when=when))
-print(predictor2.predict(when_data=pandas.DataFrame(when)))
+pred = predictor.predict(when_data=pandas.DataFrame(when))['z']['predictions']
+print('Real values: ' + eval(f"""str([when['x'][i] {op} when['y'][i] for i in range(len(when['x']))])"""))
+print('Pred values: ' + str(pred))
+'''
+
+print('Train accuracy: ', predictor.train_accuracy)
+print('Test accuracy: ', predictor.calculate_accuracy(from_data=df_test))
+
+predictions = predictor.predict(when_data=df_test)
+print(list(df_test['z'])[30:60])
+print(predictions['z']['predictions'][30:60])

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.20.1'
+__version__ = '0.21.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -508,14 +508,15 @@ class Predictor:
             accuracy = self.apply_accuracy_function(ds.get_column_config(output_column)['type'], real, predicted,weight_map=weight_map)
 
             if ds.get_column_config(output_column)['type'] in (COLUMN_DATA_TYPES.NUMERIC):
-                ds.encoders[output_column].decode_log = False
-                predicted = list(map(str,predictions[output_column]['predictions']))
+                ds.encoders[output_column].decode_log = True
+                predicted =ds.get_decoded_column_data(output_column, predictions[output_column]['encoded_predictions'])
+
                 alternative_accuracy = self.apply_accuracy_function(ds.get_column_config(output_column)['type'], real, predicted,weight_map=weight_map)
 
                 if alternative_accuracy['value'] > accuracy['value']:
                     accuracy = alternative_accuracy
                 else:
-                    ds.encoders[output_column].decode_log = True
+                    ds.encoders[output_column].decode_log = False
 
             accuracies[output_column] = accuracy
 

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -15,7 +15,7 @@ class CONFIG:
     SELFAWARE = True
     HELPER_MIXERS = True
     FORCE_HELPER_MIXERS = False
-    ENABLE_DROPOUT = True
+    ENABLE_DROPOUT = False
 
     """Probabilistic FC layers"""
     USE_PROBABILISTIC_LINEAR = False # change weights in mixer to be probabilistic

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -57,10 +57,10 @@ class NumericEncoder:
                 vector = [0] * 4
                 try:
                     if real is None:
-                        vector[1] = 0
+                        vector[0] = 0
                     else:
-                        vector[1] = 1
-                        vector[0] = math.log(abs(real)) if abs(real) > 0 else -20
+                        vector[0] = 1
+                        vector[1] = math.log(abs(real)) if abs(real) > 0 else -20
                         vector[2] = 1 if real < 0 else 0
                         vector[3] = real/self._mean
                 except Exception as e:
@@ -91,7 +91,7 @@ class NumericEncoder:
                     else:
                         real_value = vector[2] * self._mean
             else:
-                if vector[2] < 0.5:
+                if vector[0] < 0.5:
                     ret.append(None)
                     continue
 

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -14,7 +14,7 @@ class NumericEncoder:
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
         self.is_target = is_target
-        self.decode_log = True
+        self.decode_log = False
 
     def prepare_encoder(self, priming_data):
         if self._prepared:
@@ -80,9 +80,12 @@ class NumericEncoder:
 
         if decode_log is None:
             decode_log = self.decode_log
-
+            
         ret = []
-        for vector in encoded_values.tolist():
+        if type(encoded_values) != type([]):
+            encoded_values = encoded_values.tolist()
+
+        for vector in encoded_values:
             if self.is_target:
                 if np.isnan(vector[0]) or vector[0] == float('inf') or np.isnan(vector[1]) or vector[1] == float('inf') or np.isnan(vector[2]) or vector[2] == float('inf'):
                     logging.error(f'Got weird target value to decode: {vector}')

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -1,8 +1,10 @@
-import torch
 import math
 import logging
 import sys
+
+import torch
 import numpy as np
+
 
 class NumericEncoder:
 

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -1,128 +1,201 @@
 import torch
 import math
 import logging
-
+import sys
+import numpy as np
 
 class NumericEncoder:
 
     def __init__(self, data_type=None, is_target=False):
         self._type = data_type
-        self._min_value = None
-        self._max_value = None
         self._mean = None
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
-        self._is_target = is_target
+        self.is_target = is_target
+        self.decode_log = True
 
     def prepare_encoder(self, priming_data):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
-        count = 0
-        abs_count = 0
         value_type = 'int'
         for number in priming_data:
             try:
                 number = float(number)
-            except Exception:
+            except:
                 continue
 
-            if math.isnan(number):
+            if np.isnan(number):
                 err = 'Lightwood does not support working with NaN values !'
                 logging.error(err)
                 raise Exception(err)
-
-            self._min_value = number if self._min_value is None or self._min_value > number else self._min_value
-            self._max_value = number if self._max_value is None or self._max_value < number else self._max_value
-
-            count += number
-            abs_count += abs(number)
 
             if int(number) != number:
                 value_type = 'float'
 
         self._type = value_type if self._type is None else self._type
-        self._mean = count / len(priming_data)
-        self._abs_mean = abs_count / len(priming_data)
+        self._mean = np.sum(priming_data) / len(priming_data)
         self._prepared = True
 
+    def encode(self, data):
+        if not self._prepared:
+            raise Exception('You need to call "prepare_encoder" before calling "encode" or "decode".')
+
+        ret = []
+        for real in data:
+            if self.is_target:
+                vector = [0] * 3
+                try:
+                    vector[0] = math.log(abs(real)) if abs(real) > 0 else - 20
+                    vector[1] = 1 if real < 0 else 0
+                    vector[2] = real/self._mean
+                except Exception as e:
+                    vector = [0] * 3
+                    logging.error(f'Can\'t encode target value: {real}, exception: {e}')
+
+            else:
+                vector = [0] * 4
+                try:
+                    if real is None:
+                        vector[1] = 0
+                    else:
+                        vector[1] = 1
+                        vector[0] = math.log(abs(real)) if abs(real) > 0 else -20
+                        vector[2] = 1 if real < 0 else 0
+                        vector[3] = real/self._mean
+                except Exception as e:
+                    vector = [0] * 4
+                    logging.error(f'Can\'t encode input value: {real}, exception: {e}')
+
+            ret.append(vector)
+
+        return self._pytorch_wrapper(ret)
+
+    def decode(self, encoded_values, decode_log=None):
+        if not self._prepared:
+            raise Exception('You need to call "prepare_encoder" before calling "encode" or "decode".')
+
+        if decode_log is None:
+            decode_log = self.decode_log
+
+        ret = []
+        for vector in encoded_values.tolist():
+            if self.is_target:
+                if np.isnan(vector[0]) or vector[0] == float('inf') or np.isnan(vector[1]) or vector[1] == float('inf') or np.isnan(vector[2]) or vector[2] == float('inf'):
+                    logging.error(f'Got weird target value to decode: {vector}')
+                    real_value = pow(10,63)
+                else:
+                    if decode_log:
+                        sign = -1 if vector[1] > 0.5 else 1
+                        real_value = math.exp(vector[0]) * sign
+                    else:
+                        real_value = vector[2] * self._mean
+            else:
+                if vector[2] < 0.5:
+                    ret.append(None)
+                    continue
+
+                real_value = vector[3] * self._mean
+
+            if self._type == 'int':
+                real_value = round(real_value)
+
+            ret.append(real_value)
+        return ret
+
+    '''
     def encode(self, data):
         if not self._prepared:
             raise Exception('You need to call "prepare_encoder" before calling "encode" or "decode".')
         ret = []
 
         for number in data:
-            try:
-                try:
-                    number = float(number)
-                except:
-                    # Some data cleanup for an edge case that shows up a lot when lightwood isn't used with mindsdb
-                    number = float(number.replace(',', '.'))
-            except:
-                #logging.warning('It is assuming that  "{what}" is a number but cannot cast to float'.format(what=number))
+            vector_len = 4
+            vector = [0]*vector_len
 
-                number = None
-
-            if self._is_target:
-                vector = [0] * 2
-                try:
-                    vector[0] = number/self._abs_mean
-                    #vector[0] = number
-                    vector[1] = math.log(abs(number)) if number > 0 else -100
-                except:
-                    logging.warning(f'Got unexpected value for numerical target value: "{number}" !')
-                    # @TODO For now handle this by setting to zero as a hotfix,
-                    # but we need to figure out why it's happening and fix it properly later
-                    vector = [0] * 2
-
+            if number is None:
+                vector[3] = 0
+                ret.append(vector)
+                continue
             else:
-                vector = [0] * 2
-                if number is None:
-                    vector[1] = 0
-                else:
-                    vector[1] = 1
-                    vector[0] = number / self._abs_mean
+                vector[3] = 1
+
+            try:
+                number = float(number)
+            except:
+                logging.warning('It is assuming that  "{what}" is a number but cannot cast to float'.format(what=number))
+                ret.append(vector)
+                continue
+
+            if number < 0:
+                vector[0] = 1
+
+            if number == 0:
+                vector[2] = 1
+            else:
+                vector[1] = math.log(abs(number))
 
             ret.append(vector)
 
         return self._pytorch_wrapper(ret)
 
+
     def decode(self, encoded_values):
         ret = []
         for vector in encoded_values.tolist():
-            if self._is_target:
-                if not math.isnan(vector[0]):
-                    linear_value = vector[0]
-                    real_value = linear_value * self._abs_mean
-                    #real_value = linear_value
-                else:
-                    logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
-                    real_value = None
-
-                if self._type == 'int' and real_value is not None:
-                    real_value = int(round(real_value))
+            if not math.isnan(vector[0]):
+                is_negative = True if abs(round(vector[0])) == 1 else False
             else:
-                is_zero = False
+                logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
                 is_negative = False
-                real_value = vector[0] * self._abs_mean
-                if not math.isnan(vector[3]):
-                    is_none = True if abs(round(vector[3])) == 0 else False
-                else:
-                    logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
-                    is_none = True
 
-                if is_none:
-                    real_value = None
-                if is_zero:
-                    real_value = 0
+            if not math.isnan(vector[1]):
+                encoded_nr = vector[1]
+            else:
+                logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
+                encoded_nr = 0
+
+            if not math.isnan(vector[2]):
+                is_zero = True if abs(round(vector[2])) == 1 else False
+            else:
+                logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
+                is_zero = False
+
+            if not math.isnan(vector[3]):
+                is_none = True if abs(round(vector[3])) == 0 else False
+            else:
+                logging.warning(f'Occurance of `nan` value in encoded numerical value: {vector}')
+                is_none = True
+
+            if is_none:
+                ret.append(0)
+                continue
+
+            if is_zero:
+                ret.append(0)
+                continue
+
+            try:
+                real_value = math.exp(encoded_nr)
+                if is_negative:
+                    real_value = -real_value
+            except:
+                if self._type == 'int':
+                    real_value = pow(2,63)
+                else:
+                    real_value = float('inf')
+
+            if self._type == 'int':
+                real_value = round(real_value)
 
             ret.append(real_value)
 
         return ret
+    '''
 
 
 if __name__ == "__main__":
-    data = [1, 1.1, 2, -8.6, None, 0]
+    data = [1,1.1,2,-8.6,None,0]
 
     encoder = NumericEncoder()
 
@@ -134,7 +207,7 @@ if __name__ == "__main__":
     assert(encoded_vals[1][1] > 0)
     assert(encoded_vals[2][1] > 0)
     assert(encoded_vals[3][1] > 0)
-    for i in range(0, 4):
+    for i in range(0,4):
         assert(encoded_vals[i][3] == 1)
     assert(encoded_vals[4][3] == 0)
 
@@ -144,4 +217,4 @@ if __name__ == "__main__":
         if decoded_vals[i] is None:
             assert(decoded_vals[i] == data[i])
         else:
-            assert(round(decoded_vals[i], 5) == round(data[i], 5))
+            assert(round(decoded_vals[i],5) == round(data[i],5))

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -36,7 +36,7 @@ class NumericEncoder:
                 value_type = 'float'
 
         self._type = value_type if self._type is None else self._type
-        non_null_priming_data = [x for x in priming_data if x is not None]
+        non_null_priming_data = [float(str(x).replace(',','.')) for x in priming_data if x is not None]
         self._mean = np.sum(non_null_priming_data) / len(non_null_priming_data)
         self._prepared = True
 
@@ -46,6 +46,13 @@ class NumericEncoder:
 
         ret = []
         for real in data:
+            try:
+                real = float(real)
+            except:
+                try:
+                    real = float(real.replace(',','.'))
+                except:
+                    real = None
             if self.is_target:
                 vector = [0] * 3
                 try:
@@ -80,7 +87,7 @@ class NumericEncoder:
 
         if decode_log is None:
             decode_log = self.decode_log
-            
+
         ret = []
         if type(encoded_values) != type([]):
             encoded_values = encoded_values.tolist()

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -89,16 +89,11 @@ class DefaultNet(torch.nn.Module):
             rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU
 
             layers = []
-            fr = False
             for ind in range(len(shape) - 1):
                 linear_function = PLinear  if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
                 layers.append(linear_function(shape[ind],shape[ind+1]))
                 if ind < len(shape) - 2:
-                    if fr:
-                        fr = False
-                        layers.append(torch.nn.Tanh())
-                    else:
-                        layers.append(rectifier())
+                    layers.append(rectifier())
 
             self.net = torch.nn.Sequential(*layers)
         else:

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -89,11 +89,16 @@ class DefaultNet(torch.nn.Module):
             rectifier = torch.nn.SELU  #alternative: torch.nn.ReLU
 
             layers = []
+            fr = False
             for ind in range(len(shape) - 1):
                 linear_function = PLinear  if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
                 layers.append(linear_function(shape[ind],shape[ind+1]))
                 if ind < len(shape) - 2:
-                    layers.append(rectifier())
+                    if fr:
+                        fr = False
+                        layers.append(torch.nn.Tanh())
+                    else:
+                        layers.append(rectifier())
 
             self.net = torch.nn.Sequential(*layers)
         else:

--- a/tests/ci_tests/ci_tests.py
+++ b/tests/ci_tests/ci_tests.py
@@ -11,7 +11,7 @@ mixers_path = pdir + 'mixers/'
 MODULES = [
     f'{encoders_path}categorical/onehot.py',
     f'{encoders_path}datetime/datetime.py',
-    f'{encoders_path}categorical/autoencoder.py',
+    #f'{encoders_path}categorical/autoencoder.py',
     f'{encoders_path}time_series/ts_fresh_ts.py',
 
     f'{pdir}api/data_source.py',

--- a/tests/ci_tests/ci_tests.py
+++ b/tests/ci_tests/ci_tests.py
@@ -11,7 +11,7 @@ mixers_path = pdir + 'mixers/'
 MODULES = [
     f'{encoders_path}categorical/onehot.py',
     f'{encoders_path}datetime/datetime.py',
-    #f'{encoders_path}categorical/autoencoder.py',
+    f'{encoders_path}categorical/autoencoder.py',
     f'{encoders_path}time_series/ts_fresh_ts.py',
 
     f'{pdir}api/data_source.py',


### PR DESCRIPTION
* Changed the numerical encoder such that it encodes:

Ouputs: `[log(abs(real)) if abs(real) > 0 else -20  ,  1 if real < 0 else 0 , real/self._mean]` (i.e.: `[log, sign, normalized linear]`)

Inputs: `[is_not_null, log(abs(real)) if abs(real) > 0 else -20  ,  1 if real < 0 else 0 , real/self._mean]` (i.e.: `[is_not_null, log, sign, normalized linear]`)

* Added a decision in the `predictor.py` accuracy computation logic to switch to decoding the numeric target to either `log` or `linear` depending on which scores the highest accuracy on whatever score we use for numerical prediction evaluations (currently `r2_score`... though this *might* give an unfair advantage to linear encodings, @torrmal feel free to suggest a better score if you have one in mind, if not, I'll open an issue and we can resolve this later).

* Changes to the learn to multiply example/test in order to more easily validate the overall accuracy and more easily change operations (i.e. go from `*` to `/` to `+` to `-` to `^` ... etc).

* Disabled dropout for now since it seemed to have been tanking accuracy on home_rentals and to some extent to learn to multiply, I suggest we enable it back as soon as we figure out a way of stopping this behavior.

