### PR TITLE
Fix tokenizers error

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.22.2'
+__version__ = '0.22.3'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ torchvision >= 0.5.0
 torch >= 1.4.0
 xlrd >= 1.0.0
 requests >= 2.0.0
-transformers >= 2.2.1, < 2.5.0
+transformers==2.4.1
 tsfresh >= 0.14.1


### PR DESCRIPTION
This PR changes the transformers to be fixed to the 2.4.1 version, to avoid the issue reported with installing tokenizers ``ERROR: Could not build wheels for tokenizers which use PEP 517 and cannot be installed directly``