### PR TITLE
Few row fixes

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.23.0'
+__version__ = '0.23.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -228,7 +228,12 @@ class Predictor:
                 mixer_params = self.config['mixer']['attrs']
 
         # Initialize data sources
-        nr_subsets = 3
+        if len(from_data_ds) > 100:
+            nr_subsets = 3
+        else:
+            # Don't use k-fold cross validation for very small input sizes
+            nr_subsets = 1
+
         from_data_ds.prepare_encoders()
         from_data_ds.create_subsets(nr_subsets)
         try:

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -432,14 +432,15 @@ class NnMixer:
 
                     quantile_prediction = outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]]
 
-                    lg_start = self.quantiles_pair[0] * 2 + 2
-                    lg_end =  self.quantiles_pair[1] * 2 + 2
-                    li_start = self.quantiles_pair[0] * 2 + 3
-                    li_end = self.quantiles_pair[1] * 2 + 3
+                    lg_start = self.quantiles_pair[0] * 2 + 1
+                    lg_end =  self.quantiles_pair[1] * 2 + 1
+                    li_start = self.quantiles_pair[0] * 2 + 2
+                    li_end = self.quantiles_pair[1] * 2 + 2
+
                     if ds.encoders[self.output_column_names[k]].decode_log == True:
-                        diff = (quantile_prediction[lg_end] - quantile_prediction[lg_start])/quantile_prediction[lg_end]
+                        diff = (quantile_prediction[:, lg_end] - quantile_prediction[:, lg_start])/quantile_prediction[:, lg_end]
                     else:
-                        diff = (quantile_prediction[li_end] - quantile_prediction[li_start])/quantile_prediction[li_end]
+                        diff = (quantile_prediction[:, li_end] - quantile_prediction[:, li_start])/quantile_prediction[:, li_end]
 
                     diff = float(diff.mean())
                     quantile_mean_diff[k].append((diff if diff > 0 else 1))


### PR DESCRIPTION
Solves #116  by only using 1 subset (so basically not using k-fold cross-validation) in the cases where the training data has <= 100 rows.

Granted, this number could be as low as 30 in theory, but in practice, I think we'd want our test sets to have > 1 example, we'll rarely have datasets this small anyway.

Fixed an issue where the quantile differences for choosing which quantiles to predict with were not computed as intended.