### PR TITLE
Quantile pair setting based on selfaware confidence

### DIFF
--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -268,9 +268,6 @@ class Predictor:
         self._mixer.fit(train_ds=from_data_ds ,test_ds=test_data_ds, callback=callback_on_iter_w_acc, stop_training_after_seconds=stop_training_after_seconds, eval_every_x_epochs=eval_every_x_epochs)
         self.train_accuracy = self.calculate_accuracy(test_data_ds)
 
-        self._mixer.build_confidence_normalization_data(test_data_ds)
-        self._mixer.encoders = from_data_ds.encoders
-
         # Train some alternative mixers
         if CONFIG.HELPER_MIXERS and self.has_boosting_mixer and (CONFIG.FORCE_HELPER_MIXERS or len(from_data_ds) < 12 * pow(10,3)):
             try:

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -352,7 +352,7 @@ class Predictor:
             logging.error("Please train the model before calculating accuracy")
             return
         ds = from_data if isinstance(from_data, DataSource) else DataSource(from_data, self.config)
-        predictions = self._mixer.predict(ds, include_encoded_predictions=True)
+        predictions = self._mixer.predict(ds, include_extra_data=True)
         accuracies = {}
 
         for output_column in self._output_columns:

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -255,17 +255,18 @@ class NnMixer:
         corr_conf_correct_qi_arr = []
         selfaware_confidence_arr = []
 
-        self.quantiles
         for col in predictions:
             p = predictions[col]
             if 'every_confidence_range' in p:
                 for i in range(len(p['predictions'])):
                     set_qi = None
                     set_qi_conf = None
-                    for qi in range(int(len(p['every_confidence_range'])/2)):
+                    for qi in range(int((len(self.quantiles) - 1)/2)):
+                        a = p['every_confidence_range'][i][qi*2]
                         if p['every_confidence_range'][i][qi*2] < p['predictions'][i] < p['every_confidence_range'][i][qi*2 + 1]:
                             set_qi = qi
                             break
+
                     narrowest_correct_qi_arr.append(set_qi)
                     selfaware_confidence_arr.append(p['selfaware_confidences'][i])
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -185,6 +185,8 @@ class NnMixer:
                         continue
 
                     if epoch % eval_every_x_epochs == 0:
+                        if self.is_selfaware:
+                            self.adjust(test_ds)
                         test_error = self.error(test_ds)
                         subset_test_error = self.error(subset_test_ds, subset_id=subset_id)
                         logging.info(f'Subtest test error: {subset_test_error} on subset {subset_id}, overall test error: {test_error}')
@@ -257,11 +259,11 @@ class NnMixer:
         for col in predictions:
             p = predictions[col]
             if 'every_confidence_range' in p:
-                for i in range(p['predictions']):
+                for i in range(len(p['predictions'])):
                     set_qi = None
                     set_qi_conf = None
-                    for qi in range(int(p['every_confidence_range']/2)):
-                        if p['every_confidence_range'][i][qi*2] < p['predictions'] < p['every_confidence_range'][i][qi*2 + 1]:
+                    for qi in range(int(len(p['every_confidence_range'])/2)):
+                        if p['every_confidence_range'][i][qi*2] < p['predictions'][i] < p['every_confidence_range'][i][qi*2 + 1]:
                             set_qi = qi
                             set_qi_conf = p['every_quantile_confidences'][i][qi]
                             break

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -263,15 +263,10 @@ class NnMixer:
                     set_qi = None
                     set_qi_conf = None
                     for qi in range(int(len(p['every_confidence_range'])/2)):
-                        print(p['every_confidence_range'][i])
-                        print(qi)
                         if p['every_confidence_range'][i][qi*2] < p['predictions'][i] < p['every_confidence_range'][i][qi*2 + 1]:
                             set_qi = qi
-                            set_qi_conf = p['every_quantile_confidences'][i][qi]
                             break
-
                     narrowest_correct_qi_arr.append(set_qi)
-                    corr_conf_correct_qi_arr.append('every_quantile_confidences')
                     selfaware_confidence_arr.append(p['selfaware_confidences'][i])
 
         map_qi_mean_sc = {}
@@ -362,7 +357,7 @@ class NnMixer:
 
                 if include_extra_data:
                     predictions[output_column]['every_confidence_range'] = [x[1:] for x in decoded_predictions]
-                    predictions[output_column]['every_quantile_confidences'] = [self.quantiles[i*2+2] - self.quantiles[i*2+1] for i in range(int((len(self.quantiles) - 1)/2))]
+
             else:
                 predictions[output_column] = {'predictions': decoded_predictions}
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -65,33 +65,40 @@ class NnMixer:
         :param ds:
         :return:
         """
-        if not self.is_selfaware:
-            return False
+        self.net = self.net.eval()
 
         ds.encoders = self.encoders
         ds.transformer = self.transformer
 
         data_loader = DataLoader(ds, batch_size=self.batch_size, shuffle=True, num_workers=0)
+
         loss_confidence_arr = []
 
-        self.net = self.net.eval()
-        with torch.no_grad():
-            for i, data in enumerate(data_loader, 0):
-                inputs, labels = data
-                inputs = inputs.to(self.net.device)
-                labels = labels.to(self.net.device)
-                outputs, awareness = self.net(inputs)
+        for i, data in enumerate(data_loader, 0):
+            inputs, labels = data
+            inputs = inputs.to(self.net.device)
+            labels = labels.to(self.net.device)
 
-                loss = None
-                for k, criterion in enumerate(self.criterion_arr):
-                    if len(loss_confidence_arr) <= k:
-                        loss_confidence_arr.append([])
-                        self.max_confidence_per_output.append(None)
+            with torch.no_grad():
+                if self.is_selfaware:
+                    outputs, awareness = self.net(inputs)
+                else:
+                    outputs = self.net(inputs)
 
-                        confidences = criterion.estimate_confidence(outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]])
-                        loss_confidence_arr[k].extend(confidences)
+            loss = None
+            for k, criterion in enumerate(self.criterion_arr):
+                if len(loss_confidence_arr) <= k:
+                    loss_confidence_arr.append([])
+                    self.max_confidence_per_output.append(None)
 
-            for k, _ in enumerate(self.criterion_arr):
+                try:
+                    confidences = criterion.estimate_confidence(outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]])
+                    loss_confidence_arr[k].extend(confidences)
+                except:
+                    pass
+
+        for k, _ in enumerate(self.criterion_arr):
+            if len(loss_confidence_arr[k]) > 0:
                 loss_confidence_arr[k] = np.array(loss_confidence_arr[k])
                 nf_pct = np.percentile(loss_confidence_arr[k], 95)
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -263,6 +263,8 @@ class NnMixer:
                     set_qi = None
                     set_qi_conf = None
                     for qi in range(int(len(p['every_confidence_range'])/2)):
+                        print(p['every_confidence_range'][i])
+                        print(qi)
                         if p['every_confidence_range'][i][qi*2] < p['predictions'][i] < p['every_confidence_range'][i][qi*2 + 1]:
                             set_qi = qi
                             set_qi_conf = p['every_quantile_confidences'][i][qi]
@@ -359,7 +361,7 @@ class NnMixer:
                     ,'quantile_confidences': [self.quantiles[self.quantiles_pair[1]] - self.quantiles[self.quantiles_pair[0]] for x in decoded_predictions]}
 
                 if include_extra_data:
-                    predictions[output_column]['every_confidence_range'] = [x for x in decoded_predictions[1:]]
+                    predictions[output_column]['every_confidence_range'] = [x[1:] for x in decoded_predictions]
                     predictions[output_column]['every_quantile_confidences'] = [self.quantiles[i*2+2] - self.quantiles[i*2+1] for i in range(int((len(self.quantiles) - 1)/2))]
             else:
                 predictions[output_column] = {'predictions': decoded_predictions}

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -241,6 +241,8 @@ class NnMixer:
                         if stop_training:
                             if self.is_selfaware:
                                 self.update_model(best_selfaware_model)
+                                self._mixer.build_confidence_normalization_data(train_ds)
+                                self._mixer.encoders = from_data_ds.encoders
                                 self.adjust(test_ds)
                             else:
                                 self.update_model(best_model)

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -356,9 +356,9 @@ class NnMixer:
                     ,'confidence_range': [[x[self.quantiles_pair[0]],x[self.quantiles_pair[1]]] for x in decoded_predictions]
                     ,'quantile_confidences': [self.quantiles[self.quantiles_pair[1]] - self.quantiles[self.quantiles_pair[0]] for x in decoded_predictions]}
 
-                    if include_extra_data:
-                        predictions[output_column]['every_confidence_range'] = [x for x in decoded_predictions[1:]]
-                        predictions[output_column]['every_quantile_confidences'] = [self.quantiles[i*2+2] - self.quantiles[i*2+1] for i in range(int((len(self.quantiles) - 1)/2))]
+                if include_extra_data:
+                    predictions[output_column]['every_confidence_range'] = [x for x in decoded_predictions[1:]]
+                    predictions[output_column]['every_quantile_confidences'] = [self.quantiles[i*2+2] - self.quantiles[i*2+1] for i in range(int((len(self.quantiles) - 1)/2))]
             else:
                 predictions[output_column] = {'predictions': decoded_predictions}
 

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -45,7 +45,7 @@ class NnMixer:
 
         self.max_confidence_per_output = []
         self.monitor = None
-        self.quantiles = [0.5,  0.02,0.98,  0.005,0.995,  0.05,0.95,  0.1,0.9,  0.2,0.8]
+        self.quantiles = [0.5,  0.2,0.8,  0.1,0.9,  0.05,0.95,  0.02,0.98,  0.005,0.995]
         self.quantiles_pair = [5,6]
 
         for k in CONFIG.MONITORING:
@@ -135,7 +135,6 @@ class NnMixer:
                 subset_test_error_delta_buff = []
                 best_model = None
                 best_selfaware_model = None
-                quantile_adjustment_attempts = 0
 
                 #iterate over the iter_fit and see what the epoch and mixer error is
                 for epoch, training_error in enumerate(self.iter_fit(subset_train_ds, initialize=first_run, subset_id=subset_id)):
@@ -184,11 +183,6 @@ class NnMixer:
                         test_error_delta_buff = []
                         subset_test_error_delta_buff = []
                         continue
-
-                    # Adjust the values for the quantiles
-                    if subset_iteration > 1 and epoch % (eval_every_x_epochs/2) == 0 and quantile_adjustment_attempts < 10:
-                        self.evaluate_quantiles(test_ds)
-                        quantile_adjustment_attempts += 1
 
                     if epoch % eval_every_x_epochs == 0:
                         test_error = self.error(test_ds)
@@ -245,12 +239,53 @@ class NnMixer:
                         if stop_training:
                             if self.is_selfaware:
                                 self.update_model(best_selfaware_model)
+                                self.adjust(test_ds)
                             else:
                                 self.update_model(best_model)
+                                self.adjust(test_ds)
                             logging.info('Finished training model !')
                             break
 
-    def predict(self, when_data_source, include_encoded_predictions=False):
+    def adjust(self, test_data_source):
+        predictions = self.predict(test_data_source, include_extra_data=True)
+
+        narrowest_correct_qi_arr = []
+        corr_conf_correct_qi_arr = []
+        selfaware_confidence_arr = []
+
+        self.quantiles
+        for col in predictions:
+            p = predictions[col]
+            if 'every_confidence_range' in p:
+                for i in range(p['predictions']):
+                    set_qi = None
+                    set_qi_conf = None
+                    for qi in range(int(p['every_confidence_range']/2)):
+                        if p['every_confidence_range'][i][qi*2] < p['predictions'] < p['every_confidence_range'][i][qi*2 + 1]:
+                            set_qi = qi
+                            set_qi_conf = p['every_quantile_confidences'][i][qi]
+                            break
+
+                    narrowest_correct_qi_arr.append(set_qi)
+                    corr_conf_correct_qi_arr.append('every_quantile_confidences')
+                    selfaware_confidence_arr.append(p['selfaware_confidences'][i])
+
+        map_qi_mean_sc = {}
+        for i in range(len(narrowest_correct_qi_arr)):
+            qi = narrowest_correct_qi_arr[i]
+            if qi not in map_qi_mean_sc:
+                map_qi_mean_sc[qi] = []
+            map_qi_mean_sc[qi].append(selfaware_confidence_arr[i])
+
+        for qi in map_qi_mean_sc:
+            map_qi_mean_sc[qi] = np.mean(map_qi_mean_sc[qi])
+
+        print('\n\n\n--------------------------------------\n\n\n')
+        print(map_qi_mean_sc)
+        print('\n\n\n--------------------------------------\n\n\n')
+
+
+    def predict(self, when_data_source, include_extra_data=False):
         """
         :param when_data_source:
         :return:
@@ -320,6 +355,10 @@ class NnMixer:
                     'predictions': [x[0] for x in decoded_predictions]
                     ,'confidence_range': [[x[self.quantiles_pair[0]],x[self.quantiles_pair[1]]] for x in decoded_predictions]
                     ,'quantile_confidences': [self.quantiles[self.quantiles_pair[1]] - self.quantiles[self.quantiles_pair[0]] for x in decoded_predictions]}
+
+                    if include_extra_data:
+                        predictions[output_column]['every_confidence_range'] = [x for x in decoded_predictions[1:]]
+                        predictions[output_column]['every_quantile_confidences'] = [self.quantiles[i*2+2] - self.quantiles[i*2+1] for i in range(int((len(self.quantiles) - 1)/2))]
             else:
                 predictions[output_column] = {'predictions': decoded_predictions}
 
@@ -329,7 +368,7 @@ class NnMixer:
             if loss_confidence_arr[k] is not None:
                 predictions[output_column]['loss_confidences'] = loss_confidence_arr[k]
 
-            if include_encoded_predictions:
+            if include_extra_data:
                 predictions[output_column]['encoded_predictions'] = output_trasnformed_vectors[output_column]
 
         logging.info('Model predictions and decoding completed')
@@ -396,67 +435,6 @@ class NnMixer:
         self.net = self.net.train()
 
         return error
-
-    def evaluate_quantiles(self, ds):
-        self.net = self.net.eval()
-
-        if self._nonpersistent['sampler'] is None:
-            data_loader = DataLoader(ds, batch_size=self.batch_size, sampler=self._nonpersistent['sampler'], num_workers=0)
-        else:
-            data_loader = DataLoader(ds, batch_size=self.batch_size, shuffle=True, num_workers=0)
-
-
-        quantile_errors = {}
-        quantile_mean_diff = {}
-
-        for i, data in enumerate(data_loader, 0):
-            inputs, labels = data
-            inputs = inputs.to(self.net.device)
-            labels = labels.to(self.net.device)
-
-            with torch.no_grad():
-                if self.is_selfaware:
-                    outputs, awareness = self.net(inputs)
-                else:
-                    outputs = self.net(inputs)
-
-            for k, criterion in enumerate(self.criterion_arr):
-                if type(criterion) == QuantileLoss:
-                    target_loss = criterion(outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]], labels[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]])
-
-                    if k not in quantile_errors:
-                        quantile_errors[k] = []
-                        quantile_mean_diff[k] = []
-
-                    quantile_errors[k].append(float(target_loss.item()))
-
-                    quantile_prediction = outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]]
-
-                    lg_start = self.quantiles_pair[0] * 2 + 1
-                    lg_end =  self.quantiles_pair[1] * 2 + 1
-                    li_start = self.quantiles_pair[0] * 2 + 2
-                    li_end = self.quantiles_pair[1] * 2 + 2
-
-                    if ds.encoders[self.output_column_names[k]].decode_log == True:
-                        diff = (quantile_prediction[:, lg_end] - quantile_prediction[:, lg_start])/quantile_prediction[:, lg_end]
-                    else:
-                        diff = (quantile_prediction[:, li_end] - quantile_prediction[:, li_start])/quantile_prediction[:, li_end]
-
-                    diff = float(diff.mean())
-                    quantile_mean_diff[k].append((diff if diff > 0 else 1))
-
-        for k in quantile_errors:
-            loss_avg = sum(quantile_errors[k])/len(quantile_errors[k])
-            diff_avg = sum(quantile_mean_diff[k])/len(quantile_mean_diff[k])
-
-            if loss_avg > 1 and diff_avg > 0.4 and self.quantiles[1] < 0.4 and self.quantiles_pair[1] < 10:
-                self.quantiles_pair[0] += 2
-                self.quantiles_pair[1] += 2
-            elif loss_avg < 0.2 and diff_avg < 0.1 and self.quantiles[1] < 0.99 and self.quantiles_pair[1] > 2:
-                self.quantiles_pair[0] -= 2
-                self.quantiles_pair[1] -= 2
-
-            self.criterion_arr[k] = QuantileLoss(quantiles=self.quantiles)
 
     def get_model_copy(self):
         """

--- a/scraps/bayesian_nn/bayesian_nn.py
+++ b/scraps/bayesian_nn/bayesian_nn.py
@@ -103,7 +103,7 @@ class BayesianNnMixer:
 
         return lifted_module()
 
-    def predict(self, when_data_source, include_encoded_predictions=False):
+    def predict(self, when_data_source, include_extra_data=False):
         """
         :param when_data_source:
         :return:

--- a/scraps/mixer_with_gym_incomplete.py
+++ b/scraps/mixer_with_gym_incomplete.py
@@ -49,7 +49,7 @@ class NnMixer:
         self.encoders = ds.encoders
         return ret
 
-    def predict(self, when_data_source, include_encoded_predictions = False):
+    def predict(self, when_data_source, include_extra_data = False):
         """
         :param when_data_source:
         :return:
@@ -107,7 +107,7 @@ class NnMixer:
             if awareness_arr is not None:
                 predictions[output_column]['confidences'] = confidence_trasnformed_vectors[output_column]
 
-            if include_encoded_predictions:
+            if include_extra_data:
                 predictions[output_column]['encoded_predictions'] = output_trasnformed_vectors[output_column]
 
         logging.info('Model predictions and decoding completed')


### PR DESCRIPTION
Setting the quantile pair we are using based on the selfaware confidence.

We record the mean selfaware confidence for which a given quantile pair was correct (contained the real value) and compare the quantile confidence of a prediction with that mean.

We use the smallest quantile pair for which the associated selfaware confidence mean is bigger or equal to the selfaware confidence of the prediction. 

Removed the old quantile pair determination logic in favour of this one.