### PR TITLE
Hotfix to quantile arrays

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.26.0'
+__version__ = '0.27.0'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -372,10 +372,10 @@ class NnMixer:
             if awareness_arr is not None:
                 predictions[output_column]['selfaware_confidences'] = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
 
-            predictions[output_column]['confidence_range'] = []
-            predictions[output_column]['quantile_confidences'] = []
-
             if self.out_types[k] in (COLUMN_DATA_TYPES.NUMERIC):
+                predictions[output_column]['confidence_range'] = []
+                predictions[output_column]['quantile_confidences'] = []
+                
                 for i, pred in enumerate(decoded_predictions):
                     if 'selfaware_confidences' in predictions[output_column]:
                         sc = predictions[output_column]['selfaware_confidences'][i]


### PR DESCRIPTION
There was a minor bug that causes the (empty) arrays `confidence_range` and `quantile_confidences` to be created in the predictions for a non numeric target. Mindsdb isn't expecting this (it expects the arrays to always be full, which is always the case for numeric targets) and it caused crashes during the model analyses.
