### PR TITLE
Multiple output categories fix

### DIFF
--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -534,13 +534,13 @@ class NnMixer:
                     output_weights = torch.Tensor(ds.output_weights).to(self.net.device)
                 else:
                     output_weights = None
-                for output_type in self.out_types:
+                for k, output_type in enumerate(self.out_types):
                     if output_type == COLUMN_DATA_TYPES.CATEGORICAL:
-                        self.criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights))
-                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights,reduce=False))
+                        self.criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]] ))
+                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]],reduce=False))
                     elif output_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
-                        self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights))
-                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights, reduce=False))
+                        self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]]))
+                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]], reduce=False))
                     elif output_type == COLUMN_DATA_TYPES.NUMERIC:
                         self.criterion_arr.append(QuantileLoss(quantiles=self.quantiles))
                         self.unreduced_criterion_arr.append(QuantileLoss(quantiles=self.quantiles, reduce=False))
@@ -619,6 +619,7 @@ class NnMixer:
                 loss = None
                 for k, criterion in enumerate(self.criterion_arr):
                     target_loss = criterion(outputs[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]], labels[:,ds.out_indexes[k][0]:ds.out_indexes[k][1]])
+
                     if loss is None:
                         loss = target_loss
                     else:

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -534,13 +534,24 @@ class NnMixer:
                     output_weights = torch.Tensor(ds.output_weights).to(self.net.device)
                 else:
                     output_weights = None
+
                 for k, output_type in enumerate(self.out_types):
                     if output_type == COLUMN_DATA_TYPES.CATEGORICAL:
-                        self.criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]] ))
-                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]],reduce=False))
+                        if output_weights is None:
+                            weights_slice = None
+                        else:
+                            weights_slice = output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]]
+
+                        self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))
+                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice,reduce=False))
                     elif output_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
-                        self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]]))
-                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]], reduce=False))
+                        if output_weights is None:
+                            weights_slice = None
+                        else:
+                            weights_slice = output_weights[ds.out_indexes[k][0]:ds.out_indexes[k][1]]
+
+                        self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice))
+                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduce=False))
                     elif output_type == COLUMN_DATA_TYPES.NUMERIC:
                         self.criterion_arr.append(QuantileLoss(quantiles=self.quantiles))
                         self.unreduced_criterion_arr.append(QuantileLoss(quantiles=self.quantiles, reduce=False))

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -223,7 +223,7 @@ class NnMixer:
                             stop_training = True
 
                         # If the trauining subset is overfitting on it's associated testing subset
-                        if (subset_delta_mean <= 0 and len(subset_test_error_delta_buff) > 4) or (time.time() - started_subset) > stop_training_after_seconds/len(train_ds.subsets.keys()):
+                        if (subset_delta_mean <= 0 and len(subset_test_error_delta_buff) > 4) or (time.time() - started_subset) > stop_training_after_seconds/len(train_ds.subsets.keys()) or subset_test_error < 0.001:
                             logging.info('Finished fitting on {subset_id} of {no_subsets} subset'.format(subset_id=subset_id, no_subsets=len(train_ds.subsets.keys())))
 
                             if self.is_selfaware:

--- a/tests/ci_tests/ci_tests.py
+++ b/tests/ci_tests/ci_tests.py
@@ -33,8 +33,7 @@ def run_full_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
     lightwood.config.config.CONFIG.USE_CUDA = USE_CUDA
     lightwood.config.config.CONFIG.PLINEAR = PLINEAR
 
-    config = {'input_features': [
-                        {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
+    config = {'input_features': [{'name': 'sqft', 'type': 'numeric'},
                         {'name': 'days_on_market', 'type': 'numeric'},
                         {'name': 'neighborhood', 'type': 'categorical','dropout':0.4}],
      'output_features': [{'name': 'number_of_rooms', 'type': 'categorical',
@@ -45,7 +44,13 @@ def run_full_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
                              '3': 0.7,
                              '4': 1,
                        }
-    },{'name': 'rental_price', 'type': 'numeric'},{'name': 'location', 'type': 'categorical'}],
+    },{'name': 'number_of_bathrooms', 'type': 'categorical',
+                      'weights':{
+                            '0': 0.8,
+                            '1': 0.6,
+                            '2': 4
+                      }
+   },{'name': 'rental_price', 'type': 'numeric'},{'name': 'location', 'type': 'categorical'}],
     'data_source': {'cache_transformed_data':CACHE_ENCODED_DATA},
     'mixer':{'class': lightwood.BUILTIN_MIXERS.NnMixer, 'selfaware': SELFAWARE}}
 

--- a/tests/ci_tests/ci_tests.py
+++ b/tests/ci_tests/ci_tests.py
@@ -35,8 +35,8 @@ def run_full_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
 
     config = {'input_features': [
                         {'name': 'number_of_bathrooms', 'type': 'numeric'}, {'name': 'sqft', 'type': 'numeric'},
-                        {'name': 'location', 'type': 'categorical'}, {'name': 'days_on_market', 'type': 'numeric'},
-                        {'name': 'neighborhood', 'type': 'categorical','dropout':0.4},{'name': 'rental_price', 'type': 'numeric'}],
+                        {'name': 'days_on_market', 'type': 'numeric'},
+                        {'name': 'neighborhood', 'type': 'categorical','dropout':0.4}],
      'output_features': [{'name': 'number_of_rooms', 'type': 'categorical',
                        'weights':{
                              '0': 0.8,
@@ -45,7 +45,7 @@ def run_full_test(USE_CUDA, CACHE_ENCODED_DATA, SELFAWARE, PLINEAR):
                              '3': 0.7,
                              '4': 1,
                        }
-    }],
+    },{'name': 'rental_price', 'type': 'numeric'},{'name': 'location', 'type': 'categorical'}],
     'data_source': {'cache_transformed_data':CACHE_ENCODED_DATA},
     'mixer':{'class': lightwood.BUILTIN_MIXERS.NnMixer, 'selfaware': SELFAWARE}}
 


### PR DESCRIPTION
* Fixed a bug with the way we transfered the output weights to the loss function where lightwood was trying to predict multiple categorical output
* Improved the CI test to try and predict numerical + categorical + categorical-weighted + categorical-weighted ... this should cover more weird edge cases around multiple-value predictions
* Added a quick fix in the mixer to stop training if the test loss is < 0.001