### PR TITLE
use concat mode if is_target

### DIFF
--- a/lightwood/encoders/encoder_base.py
+++ b/lightwood/encoders/encoder_base.py
@@ -14,7 +14,7 @@ class BaseEncoder:
     def encode(self, column_data):
         raise NotImplementedError
 
-    def decoder(self, encoded_data):
+    def decode(self, encoded_data):
         raise NotImplementedError
 
     def to(self, device, available_devices):

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -8,20 +8,15 @@ from lightwood.helpers.torch import concat_vectors_and_pad, average_vectors
 
 
 class ShortTextEncoder(BaseEncoder):
-    def __init__(self, is_target=False, combine=None):
+    def __init__(self, is_target=False):
         super().__init__(is_target)
         self._pytorch_wrapper = torch.FloatTensor
         self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
 
-        if combine is None:
-            if is_target:
-                self._combine = 'concat'
-            else:
-                self._combine = 'mean'
+        if is_target:
+            self._combine = 'concat'
         else:
-            if combine not in ['concat', 'mean']:
-                self._unexpected_combine()
-        
+            self._combine = 'mean'
         
         # Defined in self.prepare_encoder()
         self._combine_fn = None

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -10,7 +10,6 @@ from lightwood.helpers.torch import concat_vectors_and_pad, average_vectors
 class ShortTextEncoder(BaseEncoder):
     def __init__(self, is_target=False):
         super().__init__(is_target)
-        self._pytorch_wrapper = torch.FloatTensor
         self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
 
         if is_target:

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -8,16 +8,16 @@ from lightwood.helpers.torch import concat_vectors_and_pad, average_vectors
 
 
 class ShortTextEncoder(BaseEncoder):
-    def __init__(self, is_target=False, combine='mean'):
+    def __init__(self, is_target=False):
         super().__init__(is_target)
         self._pytorch_wrapper = torch.FloatTensor
         self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
 
-        if combine not in ['mean', 'concat']:
-            self._unexpected_combine()
+        if is_target:
+            self._combine = 'concat'
+        else:
+            self._combine = 'mean'
         
-        self._combine = combine
-
         # Defined in self.prepare_encoder()
         self._combine_fn = None
     

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -96,6 +96,6 @@ class ShortTextEncoder(BaseEncoder):
             return output
 
         elif self._mode == 'mean':
-            raise ValueError('decode is only defined for combine="concat"')
+            raise ValueError('decode is only defined for mode="concat"')
         else:
             self._unexpected_mode()

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -8,15 +8,20 @@ from lightwood.helpers.torch import concat_vectors_and_pad, average_vectors
 
 
 class ShortTextEncoder(BaseEncoder):
-    def __init__(self, is_target=False):
+    def __init__(self, is_target=False, combine=None):
         super().__init__(is_target)
         self._pytorch_wrapper = torch.FloatTensor
         self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
 
-        if is_target:
-            self._combine = 'concat'
+        if combine is None:
+            if is_target:
+                self._combine = 'concat'
+            else:
+                self._combine = 'mean'
         else:
-            self._combine = 'mean'
+            if combine not in ['concat', 'mean']:
+                self._unexpected_combine()
+        
         
         # Defined in self.prepare_encoder()
         self._combine_fn = None
@@ -30,8 +35,7 @@ class ShortTextEncoder(BaseEncoder):
         max_words_per_sent = 0
         for sent in no_null_sentences:
             tokens = tokenize_text(sent)
-            if len(tokens) > max_words_per_sent:
-                max_words_per_sent = len(tokens)
+            max_words_per_sent = max(max_words_per_sent, len(tokens))
             for tok in tokens:
                 unique_tokens.add(tok)
 

--- a/lightwood/encoders/text/short.py
+++ b/lightwood/encoders/text/short.py
@@ -18,7 +18,6 @@ class ShortTextEncoder(BaseEncoder):
             (not is_target) -> 'mean'
         """
         super().__init__(is_target)
-        self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
 
         if mode is None:
             if is_target:
@@ -28,12 +27,16 @@ class ShortTextEncoder(BaseEncoder):
         else:
             if mode not in ['concat', 'mean']:
                 self._unexpected_mode()
-            else:
-                self._mode = mode
-
+            
+            if is_target and mode != 'concat':
+                raise ValueError('mode must be "concat" when is_target=True')
+            
+            self._mode = mode
 
         # Defined in self.prepare_encoder()
         self._combine_fn = None
+
+        self.cae = CategoricalAutoEncoder(is_target, max_encoded_length=100)
     
     def _unexpected_mode(self):
         raise ValueError('unexpected combine value (must be "mean" or "concat")')

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -48,9 +48,9 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target == is_target
 
         if is_target:
-            enc._combine == 'concat'
+            assert enc._combine == 'concat'
         else:
-            enc._combine == 'mean'
+            assert enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)
@@ -80,9 +80,9 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target == is_target
 
         if is_target:
-            enc._combine == 'concat'
+            assert enc._combine == 'concat'
         else:
-            enc._combine == 'mean'
+            assert enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
 

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -20,14 +20,17 @@ class TestShortTextEncoder(unittest.TestCase):
         assert tokenize_text("don't wouldn't") == ['do', 'not', 'would', 'not']
 
     def test_onehot_target(self):
-        priming_data = generate_sentences(2, 6, 99)
+        # Vocab size 99 is expected to be encoded with OneHotEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=True)
         enc.prepare_encoder(priming_data)
 
         assert not enc.cae.use_autoencoder
-        assert enc.is_target == True
+        assert enc.is_target is True
+
+        # _combine is expected to be 'concat' when is_target is True
         assert enc._combine == 'concat'
 
         encoded_data = enc.encode(test_data)
@@ -42,14 +45,17 @@ class TestShortTextEncoder(unittest.TestCase):
             assert x_sent == y_sent
 
     def test_non_onehot_target(self):
-        priming_data = generate_sentences(2, 6, 800)
+        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=True)
         enc.prepare_encoder(priming_data)
 
         assert enc.cae.use_autoencoder
-        assert enc.is_target == True
+        assert enc.is_target is True
+
+        # _combine is expected to be 'concat' when is_target is True
         assert enc._combine == 'concat'
 
         encoded_data = enc.encode(test_data)
@@ -64,7 +70,8 @@ class TestShortTextEncoder(unittest.TestCase):
             assert x_sent == y_sent
 
     def test_onehot_non_target(self):
-        priming_data = generate_sentences(2, 6, 99)
+        # Vocab size 99 is expected to be encoded with OneHotEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=False)
@@ -72,16 +79,21 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert not enc.cae.use_autoencoder
         assert enc.is_target == False
+
+        # _combine is expected to be 'mean' when is_target is False
         assert enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
+
+        assert len(test_data) == len(encoded_data)
+
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
         
-        assert len(test_data) == len(encoded_data)
 
     def test_non_onehot_non_target(self):
-        priming_data = generate_sentences(2, 6, 800)
+        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=False)
@@ -89,13 +101,16 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert enc.cae.use_autoencoder
         assert enc.is_target == False
+
+        # _combine is expected to be 'mean' when is_target is False
         assert enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
+
+        assert len(test_data) == len(encoded_data)
+
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
-        
-        assert len(test_data) == len(encoded_data)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -31,7 +31,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target is True
 
         # _combine is expected to be 'concat' when is_target is True
-        assert enc._combine == 'concat'
+        assert enc._mode == 'concat'
 
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)
@@ -56,7 +56,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target is True
 
         # _combine is expected to be 'concat' when is_target is True
-        assert enc._combine == 'concat'
+        assert enc._mode == 'concat'
 
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)
@@ -81,7 +81,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
-        assert enc._combine == 'mean'
+        assert enc._mode == 'mean'
 
         encoded_data = enc.encode(test_data)
 
@@ -102,7 +102,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
-        assert enc._combine == 'mean'
+        assert enc._mode == 'mean'
 
         encoded_data = enc.encode(test_data)
 
@@ -121,7 +121,7 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert not enc.cae.use_autoencoder
         assert enc.is_target is False
-        assert enc._combine == 'concat'
+        assert enc._mode == 'concat'
         
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)
@@ -144,7 +144,7 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert enc.cae.use_autoencoder
         assert enc.is_target is False
-        assert enc._combine == 'concat'
+        assert enc._mode == 'concat'
 
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -38,7 +38,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            test_data,
+            [' '.join(x) for x in tokenize_text(test_data)],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -62,7 +62,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            test_data,
+            [' '.join(x) for x in tokenize_text(test_data)],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -124,7 +124,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            test_data,
+            [' '.join(x) for x in tokenize_text(test_data)],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -146,7 +146,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            test_data,
+            [' '.join(x) for x in tokenize_text(test_data)],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -20,26 +20,37 @@ class TestShortTextEncoder(unittest.TestCase):
         assert tokenize_text("don't wouldn't") == ['do', 'not', 'would', 'not']
 
     def test_concat(self):
-        self._test_concat(onehot=True)
-        self._test_concat(onehot=False)
+        self._test_concat(True, True)
+        self._test_concat(False, False)
+        self._test_concat(True, False)
+        self._test_concat(False, True)
     
     def test_mean(self):
-        self._test_mean(onehot=True)
-        self._test_mean(onehot=False)
+        self._test_mean(True, True)
+        self._test_mean(False, False)
+        self._test_mean(True, False)
+        self._test_mean(False, True)
 
-    def _test_concat(self, onehot):
+    def _test_concat(self, onehot, is_target):
         vocab_size = 99 if onehot else 800
         
         priming_data = generate_sentences(2, 6, vocab_size)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
-        enc = ShortTextEncoder(combine='concat')
+        enc = ShortTextEncoder(is_target=is_target)
         enc.prepare_encoder(priming_data)
 
         if onehot:
             assert not enc.cae.use_autoencoder
         else:
             assert enc.cae.use_autoencoder
+
+        assert enc.is_target == is_target
+
+        if is_target:
+            enc._combine == 'concat'
+        else:
+            enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
         decoded_data = enc.decode(encoded_data)
@@ -52,19 +63,26 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
 
-    def _test_mean(self, onehot):
+    def _test_mean(self, onehot, is_target):
         vocab_size = 99 if onehot else 800
 
         priming_data = generate_sentences(2, 6, vocab_size)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
-        enc = ShortTextEncoder(combine='mean')
+        enc = ShortTextEncoder(is_target=is_target)
         enc.prepare_encoder(priming_data)
 
         if onehot:
             assert not enc.cae.use_autoencoder
         else:
             assert enc.cae.use_autoencoder
+        
+        assert enc.is_target == is_target
+
+        if is_target:
+            enc._combine == 'concat'
+        else:
+            enc._combine == 'mean'
 
         encoded_data = enc.encode(test_data)
 

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -19,8 +19,7 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert tokenize_text("don't wouldn't") == ['do', 'not', 'would', 'not']
 
-    def test_onehot_target_auto_mode(self):
-        # Vocab size 99 is expected to be encoded with OneHotEncoder
+    def test_smallvocavb_target_auto_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
@@ -44,15 +43,14 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
 
-    def test_non_onehot_target_auto_mode(self):
-        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+    def test_non_smallvocavb_target_auto_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=True)
         enc.prepare_encoder(priming_data)
 
-        assert enc.cae.use_autoencoder
+        assert not enc.cae.use_autoencoder
         assert enc.is_target is True
 
         # _combine is expected to be 'concat' when is_target is True
@@ -69,8 +67,7 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
 
-    def test_onehot_non_target_auto_mode(self):
-        # Vocab size 99 is expected to be encoded with OneHotEncoder
+    def test_smallvocavb_non_target_auto_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
@@ -90,8 +87,7 @@ class TestShortTextEncoder(unittest.TestCase):
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
         
-    def test_non_onehot_non_target_auto_mode(self):
-        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+    def test_non_smallvocavb_non_target_auto_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
@@ -111,8 +107,7 @@ class TestShortTextEncoder(unittest.TestCase):
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
 
-    def test_onehot_non_target_manual_mode(self):
-        # Vocab size 99 is expected to be encoded with OneHotEncoder
+    def test_smallvocavb_non_target_manual_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
@@ -134,8 +129,7 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
         
-    def test_non_onehot_non_target_manual_mode(self):
-        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+    def test_non_smallvocavb_non_target_manual_mode(self):
         priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -38,7 +38,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            [' '.join(x) for x in tokenize_text(test_data)],
+            [' '.join(tokenize_text(x)) for x in test_data],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -62,7 +62,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            [' '.join(x) for x in tokenize_text(test_data)],
+            [' '.join(tokenize_text(x)) for x in test_data],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -124,7 +124,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            [' '.join(x) for x in tokenize_text(test_data)],
+            [' '.join(tokenize_text(x)) for x in test_data],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent
@@ -146,7 +146,7 @@ class TestShortTextEncoder(unittest.TestCase):
         assert len(test_data) == len(encoded_data) == len(decoded_data)
 
         for x_sent, y_sent in zip(
-            [' '.join(x) for x in tokenize_text(test_data)],
+            [' '.join(tokenize_text(x)) for x in test_data],
             [' '.join(x) for x in decoded_data]
         ):
             assert x_sent == y_sent

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -68,7 +68,7 @@ class TestShortTextEncoder(unittest.TestCase):
             assert x_sent == y_sent
 
     def test_smallvocavb_non_target_auto_mode(self):
-        priming_data = generate_sentences(2, 6, vocab_size=99)
+        priming_data = generate_sentences(2, 6, vocab_size=50)
         test_data = random.sample(priming_data, len(priming_data) // 5)
 
         enc = ShortTextEncoder(is_target=False)

--- a/tests/unit_tests/encoders/text/test_short_text_encoder.py
+++ b/tests/unit_tests/encoders/text/test_short_text_encoder.py
@@ -19,7 +19,7 @@ class TestShortTextEncoder(unittest.TestCase):
 
         assert tokenize_text("don't wouldn't") == ['do', 'not', 'would', 'not']
 
-    def test_onehot_target(self):
+    def test_onehot_target_auto_mode(self):
         # Vocab size 99 is expected to be encoded with OneHotEncoder
         priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
@@ -44,7 +44,7 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
 
-    def test_non_onehot_target(self):
+    def test_non_onehot_target_auto_mode(self):
         # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
         priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
@@ -69,7 +69,7 @@ class TestShortTextEncoder(unittest.TestCase):
         ):
             assert x_sent == y_sent
 
-    def test_onehot_non_target(self):
+    def test_onehot_non_target_auto_mode(self):
         # Vocab size 99 is expected to be encoded with OneHotEncoder
         priming_data = generate_sentences(2, 6, vocab_size=99)
         test_data = random.sample(priming_data, len(priming_data) // 5)
@@ -78,7 +78,7 @@ class TestShortTextEncoder(unittest.TestCase):
         enc.prepare_encoder(priming_data)
 
         assert not enc.cae.use_autoencoder
-        assert enc.is_target == False
+        assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
         assert enc._combine == 'mean'
@@ -90,8 +90,7 @@ class TestShortTextEncoder(unittest.TestCase):
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
         
-
-    def test_non_onehot_non_target(self):
+    def test_non_onehot_non_target_auto_mode(self):
         # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
         priming_data = generate_sentences(2, 6, vocab_size=800)
         test_data = random.sample(priming_data, len(priming_data) // 5)
@@ -100,7 +99,7 @@ class TestShortTextEncoder(unittest.TestCase):
         enc.prepare_encoder(priming_data)
 
         assert enc.cae.use_autoencoder
-        assert enc.is_target == False
+        assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
         assert enc._combine == 'mean'
@@ -111,6 +110,52 @@ class TestShortTextEncoder(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             enc.decode(encoded_data)
+
+    def test_onehot_non_target_manual_mode(self):
+        # Vocab size 99 is expected to be encoded with OneHotEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=99)
+        test_data = random.sample(priming_data, len(priming_data) // 5)
+
+        enc = ShortTextEncoder(is_target=False, mode='concat')
+        enc.prepare_encoder(priming_data)
+
+        assert not enc.cae.use_autoencoder
+        assert enc.is_target is False
+        assert enc._combine == 'concat'
+        
+        encoded_data = enc.encode(test_data)
+        decoded_data = enc.decode(encoded_data)
+        
+        assert len(test_data) == len(encoded_data) == len(decoded_data)
+
+        for x_sent, y_sent in zip(
+            test_data,
+            [' '.join(x) for x in decoded_data]
+        ):
+            assert x_sent == y_sent
+        
+    def test_non_onehot_non_target_manual_mode(self):
+        # Vocab size 800 is expected to be encoded with CategoricalAutoEncoder
+        priming_data = generate_sentences(2, 6, vocab_size=800)
+        test_data = random.sample(priming_data, len(priming_data) // 5)
+
+        enc = ShortTextEncoder(is_target=False, mode='concat')
+        enc.prepare_encoder(priming_data)
+
+        assert enc.cae.use_autoencoder
+        assert enc.is_target is False
+        assert enc._combine == 'concat'
+
+        encoded_data = enc.encode(test_data)
+        decoded_data = enc.decode(encoded_data)
+        
+        assert len(test_data) == len(encoded_data) == len(decoded_data)
+
+        for x_sent, y_sent in zip(
+            test_data,
+            [' '.join(x) for x in decoded_data]
+        ):
+            assert x_sent == y_sent
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
related to https://github.com/mindsdb/lightwood/issues/218
- fix typo: `BaseEncoder.decoder()` in renamed to `BaseEncoder.decode()`
- `ShortTextEncoder` uses `"concat"` mode if `is_target is True` and tests for this are added too