### PR TITLE
Fix token filter so that unicode alphanumerics are also valid tokens

### DIFF
--- a/lightwood/helpers/text.py
+++ b/lightwood/helpers/text.py
@@ -3,7 +3,10 @@ import re
 
 
 def contains_alnum(text):
-    return re.search('[a-zA-Z0-9]', text)
+    for c in text:
+        if c.isalnum():
+            return True
+    return False
 
 
 def decontracted(phrase):


### PR DESCRIPTION
Before that change:
`tokenize_text(['кириллица']) => []`

Now it should properly handle non-ascii alphanumeric strings.