### PR TITLE
fix None comparison

### DIFF
--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -56,17 +56,16 @@ class NumericEncoder(EncoderBase):
                 except:
                     real = None
             if self.is_target:
-                vector = [0] * (3 + 2*self.extra_outputs)
-                try:
-                    if real is not None and self._mean > 0:
-                        vector[0] = 1 if real < 0 else 0
-                        vector[1] = math.log(abs(real)) if abs(real) > 0 else - 20
-                        vector[2] = real / self._mean
-                    else:
-                        # Note: This part here is just to have targets equal in size
-                        # to the prediction size, these appended zeros won't be used anywhere
-                        vector = [0] * (3 + 2 * self.extra_outputs)
-                        logging.error(f'Can\'t encode target value: {real}')
+                if real is not None and self._mean > 0:
+                    vector = [0] * (3 + 2 * self.extra_outputs)
+                    vector[0] = 1 if real < 0 else 0
+                    vector[1] = math.log(abs(real)) if abs(real) > 0 else - 20
+                    vector[2] = real / self._mean
+                else:
+                    # Note: This part here is just to have targets equal in size
+                    # to the prediction size, these appended zeros won't be used anywhere
+                    vector = [0] * (3 + 2 * self.extra_outputs)
+                    logging.error(f'Can\'t encode target value: {real}')
 
             else:
                 vector = [0] * 4

--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -58,13 +58,15 @@ class NumericEncoder(EncoderBase):
             if self.is_target:
                 vector = [0] * (3 + 2*self.extra_outputs)
                 try:
-                    vector[0] = 1 if real < 0 else 0
-                    vector[1] = math.log(abs(real)) if abs(real) > 0 else - 20
-                    vector[2] = real/self._mean
-                    # Note: This part here is just to have targets equall in size to the prediction size, these appended zeros won't be used anywhere
-                except Exception as e:
-                    vector = [0] * (3 + 2*self.extra_outputs)
-                    logging.error(f'Can\'t encode target value: {real}, exception: {e}')
+                    if real is not None and self._mean > 0:
+                        vector[0] = 1 if real < 0 else 0
+                        vector[1] = math.log(abs(real)) if abs(real) > 0 else - 20
+                        vector[2] = real / self._mean
+                    else:
+                        # Note: This part here is just to have targets equal in size
+                        # to the prediction size, these appended zeros won't be used anywhere
+                        vector = [0] * (3 + 2 * self.extra_outputs)
+                        logging.error(f'Can\'t encode target value: {real}')
 
             else:
                 vector = [0] * 4


### PR DESCRIPTION
this message used to spam the console a lot, I removed the "exception:" part in the error message and if-else is now used instead of try-except.
`ERROR:root:Can't encode target value: None, exception: '<' not supported between instances of 'NoneType' and 'int'`