### PR TITLE
use list.extend() and list.append() instead of list.__add__()

### DIFF
--- a/docs/examples/home_rentals.py
+++ b/docs/examples/home_rentals.py
@@ -43,7 +43,7 @@ for i in range(int(100-predictor.overall_certainty*100)):
     ret_val = predictor.predict(when={'number_of_bedrooms': 2, 'sqft': 2300})[
                 config['output_features'][0]['name']]['predictions'][0]
     if ret_val is not None:
-        ret += [ret_val]
+        ret.append(ret_val)
 
 
 

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -315,7 +315,7 @@ class DataSource(Dataset):
                 arg2 = custom_data[config['depends_on_column']]
             else:
                 arg2 = self.get_column_original_data(config['depends_on_column'])
-            args += [arg2]
+            args.append(arg2)
 
         if column_name in self.encoders:
             encoded_vals = self.encoders[column_name].encode(*args)

--- a/lightwood/encoders/datetime/datetime.py
+++ b/lightwood/encoders/datetime/datetime.py
@@ -30,7 +30,7 @@ class DatetimeEncoder(BaseEncoder):
                 vector = [date.year / 3000.0, date.month / 12.0, date.day / 31.0,
                           date.weekday() / 7.0, date.hour / 24.0, date.minute / 60.0, date.second / 60.0]
 
-            ret += [vector]
+            ret.append(vector)
 
         return self._pytorch_wrapper(ret)
 
@@ -39,7 +39,7 @@ class DatetimeEncoder(BaseEncoder):
         for vector in encoded_data.tolist():
 
             if sum(vector) == 0:
-                ret += [None]
+                ret.append(None)
 
             else:
                 dt = datetime.datetime(year=round(vector[0] * 3000), month=round(vector[1] * 12),
@@ -47,9 +47,11 @@ class DatetimeEncoder(BaseEncoder):
                                        minute=round(vector[5] * 60), second=round(vector[6] * 60))
 
                 if return_as_datetime is True:
-                    ret += [dt]
+                    ret.append(dt)
                 else:
-                    ret += [round(dt.timestamp())]
+                    ret.append(
+                        round(dt.timestamp())
+                    )
 
         return ret
 

--- a/lightwood/encoders/text/rnn.py
+++ b/lightwood/encoders/text/rnn.py
@@ -70,7 +70,7 @@ class RnnEncoder(BaseEncoder):
                     #encoder_outputs[ei] = encoder_output[0, 0]
 
                 # use the last hidden state as the encoded vector
-                ret += [encoder_hidden.tolist()[0][0]]
+                ret.append(encoder_hidden.tolist()[0][0])
 
         return self._pytorch_wrapper(ret)
 
@@ -98,7 +98,7 @@ class RnnEncoder(BaseEncoder):
 
                     decoder_input = topi.squeeze().detach()
 
-                ret += [' '.join(decoded_words)]
+                ret.append(' '.join(decoded_words))
 
         return ret
 

--- a/lightwood/encoders/time_series/cesium_ts.py
+++ b/lightwood/encoders/time_series/cesium_ts.py
@@ -183,10 +183,10 @@ class CesiumTsEncoder(BaseEncoder):
                     val1 = 1
 
                 if col in FEATURES_WITH_DEFAULT_NONE:
-                    vector_row += [val, val1]  # val1 is 1 if its null
+                    vector_row.extend([val, val1])  # val1 is 1 if its null
                 else:
-                    vector_row += [val]
-            ret += [vector_row]
+                    vector_row.append(val)
+            ret.append(vector_row)
         ret_tensor = self._pytorch_wrapper(ret)
         return ret_tensor
 

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -180,11 +180,11 @@ class RnnEncoder(BaseEncoder):
                     vector = [next_reading]
                     if j == 0:
                         encoded = hidden
-                    next_i += [next_reading]
+                    next_i.append(next_reading)
 
-                next += [next_i[0][0].cpu()]
+                next.append([next_i[0][0].cpu()])
 
-            ret += [encoded[0][0].cpu()]
+            ret.append([encoded[0][0].cpu()])
 
         if get_next_count is None:
             return self._pytorch_wrapper(torch.stack(ret))
@@ -223,6 +223,6 @@ class RnnEncoder(BaseEncoder):
         for _, val in enumerate(encoded_data):
             hidden = torch.unsqueeze(torch.unsqueeze(val, dim=0), dim=0).to(self.device)
             reconstruction = self._decode_one(hidden, steps).cpu().squeeze().T.tolist()
-            ret += [reconstruction]
+            ret.append(reconstruction)
 
         return self._pytorch_wrapper(ret)

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -182,9 +182,9 @@ class RnnEncoder(BaseEncoder):
                         encoded = hidden
                     next_i.append(next_reading)
 
-                next.append([next_i[0][0].cpu()])
+                next.append(next_i[0][0].cpu())
 
-            ret.append([encoded[0][0].cpu()])
+            ret.append(encoded[0][0].cpu())
 
         if get_next_count is None:
             return self._pytorch_wrapper(torch.stack(ret))

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -352,7 +352,7 @@ class NnMixer:
             for feature in transformed_output_vectors:
                 if feature not in output_trasnformed_vectors:
                     output_trasnformed_vectors[feature] = []
-                output_trasnformed_vectors[feature] += [transformed_output_vectors[feature]]
+                output_trasnformed_vectors[feature].append(transformed_output_vectors[feature])
 
         predictions = {}
         for k, output_column in enumerate(list(output_trasnformed_vectors.keys())):

--- a/scraps/bayesian_nn/bayesian_nn.py
+++ b/scraps/bayesian_nn/bayesian_nn.py
@@ -144,7 +144,7 @@ class BayesianNnMixer:
                 for feature in transformed_output_vectors:
                     if feature not in output_trasnformed_vectors:
                         output_trasnformed_vectors[feature] = []
-                    output_trasnformed_vectors[feature] += [transformed_output_vectors[feature]]
+                    output_trasnformed_vectors[feature].append(transformed_output_vectors[feature])
 
             for output_column in output_trasnformed_vectors:
 

--- a/scraps/mixer_with_gym_incomplete.py
+++ b/scraps/mixer_with_gym_incomplete.py
@@ -91,14 +91,16 @@ class NnMixer:
                     if feature not in confidence_trasnformed_vectors:
                         confidence_trasnformed_vectors[feature] = []
                     # @TODO: Very simple algorithm to get a confidence from the awareness, not necessarily what we want for the final version
-                    confidence_trasnformed_vectors[feature] += [1 - sum(np.abs(transformed_confidence_vectors[feature]))/len(transformed_confidence_vectors[feature])]
+                    confidence_trasnformed_vectors[feature].append(
+                        [1 - sum(np.abs(transformed_confidence_vectors[feature])) / len(transformed_confidence_vectors[feature])]
+                    )
 
             output_vector = outputs[i]
             transformed_output_vectors = when_data_source.transformer.revert(output_vector,feature_set = 'output_features')
             for feature in transformed_output_vectors:
                 if feature not in output_trasnformed_vectors:
                     output_trasnformed_vectors[feature] = []
-                output_trasnformed_vectors[feature] += [transformed_output_vectors[feature]]
+                output_trasnformed_vectors[feature].append(transformed_output_vectors[feature])
 
         predictions = {}
         for output_column in output_trasnformed_vectors:


### PR DESCRIPTION
`list.__add__(a, b)` is `O(len(a) + len(b))`
`list.extend(a, b)` is `O(len(b))`
`list.append()` is `O(1)`

using `list.__add__` might slow down lightwood a lot, especially when there is a for loop like this:

```
ret = []
for x in L:
    ret += [x]
```
because this is `O(n^2)`
