### PR TITLE
Simple scheduling

### DIFF
--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -250,6 +250,7 @@ class NnMixer:
                                 self.adjust(test_ds)
                             else:
                                 self.update_model(best_model)
+                            self.iter_fit(test_ds, initialize=first_run, max_epochs=1)
                             self.encoders = train_ds.encoders
                             logging.info('Finished training model !')
                             break

--- a/lightwood/mixers/nn/nn.py
+++ b/lightwood/mixers/nn/nn.py
@@ -190,6 +190,10 @@ class NnMixer:
                         subset_test_error_delta_buff = []
                         continue
 
+                    if training_error < 0.1:
+                        self.optimizer_args['lr'] = 0.0001
+                        self.optimizer = self.optimizer_class(self.net.parameters(), **self.optimizer_args)
+
                     if epoch % eval_every_x_epochs == 0:
                         test_error = self.error(test_ds)
                         subset_test_error = self.error(subset_test_ds, subset_id=subset_id)
@@ -240,13 +244,7 @@ class NnMixer:
                             if self.is_selfaware:
                                 self.build_confidence_normalization_data(train_ds)
                                 self.adjust(test_ds)
-<<<<<<< HEAD
-                            else:
-                                self.update_model(best_model)
-                            self.iter_fit(test_ds, initialize=first_run, max_epochs=1)
-=======
 
->>>>>>> simpler_copy
                             self.encoders = train_ds.encoders
                             logging.info('Finished training model !')
                             break


### PR DESCRIPTION
Although one advantage Radam offers is that we should no longer need a scheduler (or, at least, be able to perform decently without one in most cases), it seems that lowering the learning rate once the error sinks helps gets better models on certain datasets (I will hold off on speculating as to why).

Running more benchmarks though, it seems that this doesn't improve performance as expected.
