### PR TITLE
Hotfix for DistilBert call to DefaultNet

### DIFF
--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -178,7 +178,7 @@ class DistilBertEncoder(BaseEncoder):
             batch_size = 10
 
             self._head = DefaultNet(dynamic_parameters={}, shape=funnel(
-                768, sum([len(x['encoded_output'][0]) for x in training_data['targets']]), depth=5), selfaware=False)
+                768, sum([len(x['encoded_output'][0]) for x in training_data['targets']]), depth=5))
 
             no_decay = ['bias', 'LayerNorm.weight']
             optimizer_grouped_parameters = [

--- a/tests/unit_tests/encoders/text/test_distilbert.py
+++ b/tests/unit_tests/encoders/text/test_distilbert.py
@@ -9,54 +9,53 @@ from lightwood import COLUMN_DATA_TYPES
 
 class TestDistilBERT(unittest.TestCase):
     def test_encode_and_decode(self):
-        pass
-        # random.seed(2)
-        # priming_data = []
-        # primting_target = []
-        # test_data = []
-        # test_target = []
-        # for i in range(0, 300):
-        #     if random.randint(1, 5) == 3:
-        #         test_data.append(str(i) + ''.join(['n'] * i))
-        #         # test_data.append(str(i))
-        #         test_target.append(i)
-        #     # else:
-        #     priming_data.append(str(i) + ''.join(['n'] * i))
-        #     # priming_data.append(str(i))
-        #     primting_target.append(i)
+        random.seed(2)
+        priming_data = []
+        primting_target = []
+        test_data = []
+        test_target = []
+        for i in range(0, 300):
+            if random.randint(1, 5) == 3:
+                test_data.append(str(i) + ''.join(['n'] * i))
+                # test_data.append(str(i))
+                test_target.append(i)
+            # else:
+            priming_data.append(str(i) + ''.join(['n'] * i))
+            # priming_data.append(str(i))
+            primting_target.append(i)
 
-        # output_1_encoder = NumericEncoder(is_target=True)
-        # output_1_encoder.prepare_encoder(primting_target)
+        output_1_encoder = NumericEncoder(is_target=True)
+        output_1_encoder.prepare_encoder(primting_target)
 
-        # encoded_data_1 = output_1_encoder.encode(primting_target)
-        # encoded_data_1 = encoded_data_1.tolist()
+        encoded_data_1 = output_1_encoder.encode(primting_target)
+        encoded_data_1 = encoded_data_1.tolist()
 
-        # enc = DistilBertEncoder()
+        enc = DistilBertEncoder()
 
-        # enc.prepare_encoder(priming_data,
-        #                     training_data={'targets': [
-        #                         {'output_type': COLUMN_DATA_TYPES.NUMERIC,'encoded_output': encoded_data_1},
-        #                         {'output_type': COLUMN_DATA_TYPES.NUMERIC, 'encoded_output': encoded_data_1}
-        #                     ]})
+        enc.prepare_encoder(priming_data,
+                            training_data={'targets': [
+                                {'output_type': COLUMN_DATA_TYPES.NUMERIC,'encoded_output': encoded_data_1},
+                                {'output_type': COLUMN_DATA_TYPES.NUMERIC, 'encoded_output': encoded_data_1}
+                            ]})#
 
-        # encoded_predicted_target = enc.encode(test_data).tolist()
+        encoded_predicted_target = enc.encode(test_data).tolist()
 
-        # predicted_targets_1 = output_1_encoder.decode(torch.tensor([x[:3] for x in encoded_predicted_target]))
-        # predicted_targets_2 = output_1_encoder.decode(torch.tensor([x[3:] for x in encoded_predicted_target]))
+        predicted_targets_1 = output_1_encoder.decode(torch.tensor([x[:3] for x in encoded_predicted_target]))
+        predicted_targets_2 = output_1_encoder.decode(torch.tensor([x[3:] for x in encoded_predicted_target]))
 
-        # for predicted_targets in [predicted_targets_1, predicted_targets_2]:
-        #     real = list(test_target)
-        #     pred = list(predicted_targets)
+        for predicted_targets in [predicted_targets_1, predicted_targets_2]:
+            real = list(test_target)
+            pred = list(predicted_targets)
 
-        #     # handle nan
-        #     for i in range(len(pred)):
-        #         try:
-        #             float(pred[i])
-        #         except:
-        #             pred[i] = 0
+            # handle nan
+            for i in range(len(pred)):
+                try:
+                    float(pred[i])
+                except:
+                    pred[i] = 0
 
-        #     print(real[0:25], '\n', pred[0:25])
-        #     encoder_accuracy = r2_score(real, pred)
+            print(real[0:25], '\n', pred[0:25])
+            encoder_accuracy = r2_score(real, pred)
 
-        #     print(f'Categorial encoder accuracy for: {encoder_accuracy} on testing dataset')
-        #     # assert(encoder_accuracy > 0.5)
+            print(f'Categorial encoder accuracy for: {encoder_accuracy} on testing dataset')
+            # assert(encoder_accuracy > 0.5)


### PR DESCRIPTION
Should fix [#671](https://github.com/mindsdb/mindsdb/issues/671)

- Removes `selfaware` argument passing in call to DefaultNet
- Restores DistilBert unit test to catch issues like this next time (for now, without asserting an accuracy threshold)