### PR TITLE
Quicker ts-string to array transformation for the RNN encoder

### DIFF
--- a/lightwood/encoders/time_series/helpers/rnn_helpers.py
+++ b/lightwood/encoders/time_series/helpers/rnn_helpers.py
@@ -14,10 +14,6 @@ def tensor_from_series(series, device, n_dims, pad_value, max_len):
     :param max_len: length to pad or truncate each time_series
     :return: series as a tensor ready for model consumption, shape (1, ts_length, n_dims)
     """
-    # edge case for when series == "dim 1 data"
-    if type(series) != type([]):
-        series = [str(series).split(' ')]
-
     # conversion to float
     float_series = []
     for dimn in series:

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -171,6 +171,11 @@ class RnnEncoder(BaseEncoder):
         if not self._prepared:
             raise Exception('You need to call "prepare_encoder" before calling "encode" or "decode".')
 
+        for i in len(column_data):
+            # Check and conversion for backwards compatibility while mindsdb_native can still give timeseries as strings
+            if isinstance(column_data[i], str):
+                column_data[i] = priming_data[i].split(' ')
+
         ret = []
         next = []
 

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -48,10 +48,11 @@ class RnnEncoder(BaseEncoder):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
-        # determine time_series length
-        for str_row in priming_data:
-            l = len(str_row.split(" "))
-            self._max_ts_length = max(l, self._max_ts_length)
+        # Convert to array and determine max length:
+        for i in len(priming_data):
+            if isinstance(priming_data[i], str):
+                priming_data[i] = priming_data[i].split(' ')
+            self._max_ts_length = max(len(priming_data[i]), self._max_ts_length)
 
         # decrease for small datasets
         if batch_size >= len(priming_data):

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -50,6 +50,7 @@ class RnnEncoder(BaseEncoder):
 
         # Convert to array and determine max length:
         for i in len(priming_data):
+            # Check and conversion for backwards compatibility while mindsdb_native can still give timeseries as strings
             if isinstance(priming_data[i], str):
                 priming_data[i] = priming_data[i].split(' ')
             self._max_ts_length = max(len(priming_data[i]), self._max_ts_length)


### PR DESCRIPTION
The RNN encoder transforms strings like `[1 2 3 4]` into `[1, 2, 3, 4]` sooner in the encoder and priming functions.

This also means it can be more easily removed once we make mindsdb_native only pass arrays to lightwood for timeseries columns.