### PR TITLE
Time series MinMax normalization

### DIFF
--- a/lightwood/encoders/time_series/helpers/rnn_helpers.py
+++ b/lightwood/encoders/time_series/helpers/rnn_helpers.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler
 
+
 def float_matrix_from_strlist(series):
     # edge case for when series == "dim 1 data"
     if isinstance(series, str):
@@ -98,37 +99,6 @@ class EncoderRNNNumerical(nn.Module):
 
     def initHidden(self, device):
         return torch.zeros(1, 1, self.hidden_size, device=device)
-
-
-class TanhNormalizer:
-    """ Ref: https://stackoverflow.com/questions/43061120/tanh-estimator-normalization-in-python """
-    def __init__(self, factor=10):
-        self.mu = None
-        self.std = None
-        self.factor = factor
-
-    def fit(self, x):
-        x = float_matrix_from_strlist(x)
-
-        self.mu = np.mean(x, dtype=np.float64)
-        self.std = np.std(x, dtype=np.float64)  # might .mul() by constant for better generalization
-
-    def transform(self, x):
-        output = 0.5 * (np.tanh(0.01 * (x - self.mu) / self.std) + 1)
-        eps = np.finfo(float).eps
-        output = np.where(output == 0, eps, output)  # bound encodings == 0 or 1 to avoid error with arctanh
-        output = np.where(output == 1, 1.0-eps, output)
-        return output * self.factor
-
-    def fit_transform(self, x):
-        self.fit(x)
-        return self.transform(x)
-
-    def inverse_transform(self, y):
-        return (self.mu + (100 * self.std * np.arctanh(2*(y / self.factor) - 1)))
-
-    def inverse_transform_tensor(self, y):
-        return (self.mu + (100 * self.std * torch.atanh(2*(y / self.factor) - 1)))
 
 
 class MinMaxNormalizer:

--- a/lightwood/encoders/time_series/helpers/rnn_helpers.py
+++ b/lightwood/encoders/time_series/helpers/rnn_helpers.py
@@ -2,23 +2,14 @@ import logging
 
 import torch
 import torch.nn as nn
+import numpy as np
 
 
-def tensor_from_series(series, device, n_dims, pad_value, max_len):
-    """
-    :param series: list of lists, corresponds to time series: [[x1_1, ..., x1_n], [x2_1, ..., x2_n], ...]
-                   the series is zero-padded on each axis so that all dimensions have equal length
-    :param device: computing device that PyTorch backend uses
-    :param n_dims: will zero-pad dimensions until series_dimensions == n_dims
-    :param pad_value: value to pad each dimension in the time series, if needed
-    :param max_len: length to pad or truncate each time_series
-    :return: series as a tensor ready for model consumption, shape (1, ts_length, n_dims)
-    """
+def float_matrix_from_strlist(series):
     # edge case for when series == "dim 1 data"
-    if type(series) != type([]):
+    if not isinstance(series, list):
         series = [str(series).split(' ')]
 
-    # conversion to float
     float_series = []
     for dimn in series:
         dimn_series = []
@@ -29,6 +20,21 @@ def tensor_from_series(series, device, n_dims, pad_value, max_len):
                 logging.warning(f'Weird element encountered in timeseries: {ele} !')
                 dimn_series.append(0)
         float_series.append(dimn_series)
+    return float_series
+
+
+def tensor_from_series(series, device, n_dims, pad_value, max_len, normalizer=None):
+    """
+    :param series: list of lists, corresponds to time series: [[x1_1, ..., x1_n], [x2_1, ..., x2_n], ...]
+                   the series is zero-padded on each axis so that all dimensions have equal length
+    :param device: computing device that PyTorch backend uses
+    :param n_dims: will zero-pad dimensions until series_dimensions == n_dims
+    :param pad_value: value to pad each dimension in the time series, if needed
+    :param max_len: length to pad or truncate each time_series
+    :return: series as a tensor ready for model consumption, shape (1, ts_length, n_dims)
+    """
+    # conversion to float
+    float_series = float_matrix_from_strlist(series)
 
     # timestep padding and truncating
     for i in range(len(float_series)):
@@ -40,6 +46,9 @@ def tensor_from_series(series, device, n_dims, pad_value, max_len):
     for _ in range(max(0, n_dims - len(float_series))):
         float_series.append([pad_value] * max_len)
 
+    # normalize and transpose
+    if normalizer:
+        float_series = normalizer.transform(np.array(float_series))
     tensor = torch.transpose(torch.tensor(float_series, dtype=torch.float, device=device), 0, 1)
 
     # add batch dimension
@@ -82,3 +91,34 @@ class EncoderRNNNumerical(nn.Module):
 
     def initHidden(self, device):
         return torch.zeros(1, 1, self.hidden_size, device=device)
+
+
+class TanhNormalizer:
+    """ Ref: https://stackoverflow.com/questions/43061120/tanh-estimator-normalization-in-python """
+    def __init__(self):
+        self.mu = None
+        self.std = None
+
+    def fit(self, x):
+        if isinstance(x, list) and isinstance(x[0], str):
+            x = [float_matrix_from_strlist(i) for i in x]
+
+        self.mu = np.mean(x, dtype=np.float64)
+        self.std = np.std(x, dtype=np.float64)  # might .mul() by constant for better generalization
+
+    def transform(self, x):
+        output = 0.5 * (np.tanh(0.01 * (x - self.mu) / self.std) + 1)
+        eps = np.finfo(float).eps
+        output = np.where(output == 0, eps, output)  # bound encodings == 0 or 1 to avoid error with arctanh
+        output = np.where(output == 1, 1.0-eps, output)
+        return output
+
+    def fit_transform(self, x):
+        self.fit(x)
+        return self.transform(x)
+
+    def inverse_transform(self, y):
+        return self.mu + (100 * self.std * np.arctanh(2*y - 1))
+
+    def inverse_transform_tensor(self, y):
+        return self.mu + (100 * self.std * torch.atanh(2*y - 1))

--- a/lightwood/encoders/time_series/helpers/rnn_helpers.py
+++ b/lightwood/encoders/time_series/helpers/rnn_helpers.py
@@ -8,11 +8,12 @@ from sklearn.preprocessing import MinMaxScaler
 
 
 def float_matrix_from_strlist(series):
-    # edge case for when series == "dim 1 data"
-    if isinstance(series, str):
+    if isinstance(series, numbers.Number):
+        return series
+    elif isinstance(series, str):
         series = [str(series).split(' ')]
     elif isinstance(series[0], numbers.Number):
-        pass
+        return series
     elif isinstance(series[0], str):
         series = [str(s).split(' ') for s in series]
 
@@ -42,7 +43,7 @@ def tensor_from_series(series, device, n_dims, pad_value, max_len=None, normaliz
     # conversion to float
     float_series = float_matrix_from_strlist(series)
     if max_len is None:
-        max_len = len(float_series[0])
+        max_len = len(float_series[0]) if isinstance(float_series, list) else float_series.shape[1]
 
     # timestep padding and truncating
     for i in range(len(float_series)):

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -147,9 +147,9 @@ class RnnEncoder(BaseEncoder):
         """
         self._encoder.eval()
         with torch.no_grad():
+            # n_timesteps inferred from query
             data_tensor = tensor_from_series(data, self.device, self._n_dims,
-                                             self._eos, max_len=None,
-                                             normalizer=self._normalizer)
+                                             self._eos, normalizer=self._normalizer)
             steps = data_tensor.shape[1]
             encoder_hidden = self._encoder.initHidden(self.device)
             encoder_hidden = encoder_hidden if initial_hidden is None else initial_hidden
@@ -239,10 +239,8 @@ class RnnEncoder(BaseEncoder):
         ret = []
         for _, val in enumerate(encoded_data):
             hidden = torch.unsqueeze(torch.unsqueeze(val, dim=0), dim=0).to(self.device)
-            reconstruction = self._decode_one(hidden, steps).cpu().squeeze().T.tolist()
-
-            reconstruction = np.array(reconstruction).reshape(1, -1)
-            reconstruction = self._normalizer.inverse_transform(np.array(reconstruction))
+            reconstruction = self._decode_one(hidden, steps).cpu().squeeze().T.numpy()
+            reconstruction = self._normalizer.inverse_transform(reconstruction.reshape(1, -1))
 
             ret.append(reconstruction)
 

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -49,8 +49,7 @@ class RnnEncoder(BaseEncoder):
         if self._prepared:
             raise Exception('You can only call "prepare_encoder" once for a given encoder.')
 
-        if self._normalizer:
-            self._normalizer.fit(priming_data)
+        self._normalizer.fit(priming_data)
 
         # determine time_series length
         for str_row in priming_data:
@@ -199,10 +198,7 @@ class RnnEncoder(BaseEncoder):
                         encoded = hidden
                     next_i.append(next_reading)
 
-                if self._normalizer:
-                    next_value = torch.Tensor(self._normalizer.inverse_transform(next_i[0][0].cpu()))
-                else:
-                    next_value = next_i[0][0].cpu()
+                next_value = torch.Tensor(self._normalizer.inverse_transform(next_i[0][0].cpu()))
                 next.append(next_value)
 
             ret.append(encoded[0][0].cpu())
@@ -245,9 +241,8 @@ class RnnEncoder(BaseEncoder):
             hidden = torch.unsqueeze(torch.unsqueeze(val, dim=0), dim=0).to(self.device)
             reconstruction = self._decode_one(hidden, steps).cpu().squeeze().T.tolist()
 
-            if self._normalizer:
-                reconstruction = np.array(reconstruction).reshape(1, -1)
-                reconstruction = self._normalizer.inverse_transform(np.array(reconstruction))
+            reconstruction = np.array(reconstruction).reshape(1, -1)
+            reconstruction = self._normalizer.inverse_transform(np.array(reconstruction))
 
             ret.append(reconstruction)
 

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -25,11 +25,60 @@ class TestRnnEncoder(unittest.TestCase):
         reconstructed = normalizer.inverse_transform(normalizer.fit_transform(data))
         self.assertTrue(np.allclose(data, reconstructed, atol=0.1))
 
+    def test_overfit_singledimensional(self):
+        series = ['1 2 3 4 5', '2 3 4 5 6', '3 4 5 6 7', '4 5 6 7 8']  # format given by native
+        data = series * 20
+        batch_size = 32
+        timesteps = 5
+        n_dims = 1
+
+        encoder = RnnEncoder(encoded_vector_size=10, train_iters=100, ts_n_dims=n_dims)
+        encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
+        encoded = encoder.encode(data)
+        decoded = encoder.decode(encoded, steps=timesteps).tolist()
+
+        unequal = 0
+        equal = 0
+        data = float_matrix_from_strlist(data)
+
+        # [print([round(dd,2) for dd in d]) for d in decoded]
+        # [print(d) for d in data]
+
+        self.assertEqual(len(data), len(decoded))
+        self.assertEqual(len(data[0]), len(decoded[0]))
+        for i in range(len(data)):
+            for n in range(timesteps):
+                if int(decoded[i][n]) == int(data[i][n]):
+                    equal += 1
+                else:
+                    unequal += 1
+
+        print(f'Decoder got {equal} correct and {unequal} incorrect')
+        # Not much else we can do here, trains slowly, it's the nature of the type of network and travis is really slow
+        self.assertGreater(equal, unequal)
+
+        query = ['1 2 3', '2 3 4', '3 4 5', '4 5 6']
+        answer = [4, 5, 6, 7]
+        error_margin = 1
+        encoded_data, preds = encoder.encode(query, get_next_count=1)
+        decoded_data = encoder.decode(encoded_data, steps=len(query[0][0])).tolist()
+
+        # check prediction
+        preds = preds.squeeze().tolist()
+        for ans, pred in zip(answer, preds):
+            self.assertGreater(error_margin, abs(pred - ans))
+
+        # check reconstruction
+        float_query = float_matrix_from_strlist(query)
+        for qry, dec in zip(float_query, decoded_data):
+            for truth, pred in zip(qry, dec):
+                self.assertGreater(error_margin, abs(truth - pred))
+
     def test_overfit_multidimensional(self):
         pass
         # series = [[['1', '2', '3', '4', '5', '6'], ['2', '3', '4', '5', '6', '7'],
         #            ['3', '4', '5', '6', '7', '8'], ['4', '5', '6', '7', '8', '9']]]
-        # data = 20 * series
+        # data = series * 20
         # n_dims = max([len(q) for q in data])
         # timesteps = max([len(q[0]) for q in data])
         # batch_size = 1
@@ -38,7 +87,6 @@ class TestRnnEncoder(unittest.TestCase):
         # encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
         # encoded = encoder.encode(data)
         # decoded = encoder.decode(encoded, steps=timesteps)
-
         # equal = 0
         # unequal = 0
         # self.assertEqual(len(data), len(decoded))
@@ -50,22 +98,18 @@ class TestRnnEncoder(unittest.TestCase):
         #             equal += 1
         #         else:
         #             unequal += 1
-
         # print(f'Decoder got {equal} correct and {unequal} incorrect')
         # # Not much else we can do here, trains slowly, it's the nature of the type of network and travis is really slow
         # self.assertGreater(equal, unequal)
-
         # query = [[['1', '2', '3'], ['2', '3', '4'], ['3', '4', '5'], ['4', '5', '6']]]
         # answer = [4, 5, 6, 7]
         # error_margin = 1
         # encoded_data, preds = encoder.encode(query, get_next_count=1)
         # decoded_data = encoder.decode(encoded_data, steps=len(query[0][0])).tolist()
-
         # # check prediction
         # preds = torch.reshape(preds, (1, n_dims)).tolist()[-1]
         # for ans, pred in zip(answer, preds):
         #     self.assertGreater(error_margin, abs(pred - ans))
-
         # # check reconstruction
         # float_query = [list(map(float, q)) for q in query[0]]
         # for qry, dec in zip(float_query, decoded_data[0]):

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -32,7 +32,7 @@ class TestRnnEncoder(unittest.TestCase):
         timesteps = 5
         n_dims = 1
 
-        encoder = RnnEncoder(encoded_vector_size=10, train_iters=50, ts_n_dims=n_dims)
+        encoder = RnnEncoder(encoded_vector_size=15, train_iters=50, ts_n_dims=n_dims)
         encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
         encoded = encoder.encode(data)
         decoded = encoder.decode(encoded, steps=timesteps).squeeze(1).tolist()

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -4,7 +4,7 @@ import torch
 
 from lightwood.helpers.device import get_devices
 from lightwood.encoders.time_series import RnnEncoder
-from lightwood.encoders.time_series.helpers.rnn_helpers import tensor_from_series
+from lightwood.encoders.time_series.helpers.rnn_helpers import *
 
 
 class TestRnnEncoder(unittest.TestCase):
@@ -14,6 +14,16 @@ class TestRnnEncoder(unittest.TestCase):
         target = [[1.0, 2.0, 3.0, 4.0, 0.0], [2.0, 3.0, 4.0, 5.0, 0.0], [3.0, 0.0, 5.0, 6.0, 0.0]]
         result = tensor_from_series(series, get_devices()[0], n_dims=5, pad_value=0.0, max_len=3).tolist()[0]
         self.assertEqual(result, target)
+
+    def test_normalizer(self):
+        data = [[-100.0, -5.0, 0.0, 5.0, 100.0],
+                [-1000.0, -50.0, 0.0, 50.0, 1000.0],
+                [-500.0, -405.0, -400.0, -395.0, -300.0],
+                [300.0, 395.0, 400.0, 405.0, 500.0],
+                [0.0, 1e3, 1e6, 1e9, 1e12]]
+        normalizer = TanhNormalizer()
+        reconstructed = normalizer.inverse_transform(normalizer.fit_transform(data))
+        self.assert_(np.allclose(data, reconstructed, atol=0.1))
 
     def test_overfit_multidimensional(self):
         pass

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -21,7 +21,7 @@ class TestRnnEncoder(unittest.TestCase):
                 [-500.0, -405.0, -400.0, -395.0, -300.0],
                 [300.0, 395.0, 400.0, 405.0, 500.0],
                 [0.0, 1e3, 1e6, 1e9, 1e12]]
-        normalizer = TanhNormalizer()
+        normalizer = MinMaxNormalizer()
         reconstructed = normalizer.inverse_transform(normalizer.fit_transform(data))
         self.assertTrue(np.allclose(data, reconstructed, atol=0.1))
 
@@ -35,20 +35,17 @@ class TestRnnEncoder(unittest.TestCase):
         encoder = RnnEncoder(encoded_vector_size=10, train_iters=50, ts_n_dims=n_dims)
         encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
         encoded = encoder.encode(data)
-        decoded = encoder.decode(encoded, steps=timesteps).tolist()
+        decoded = encoder.decode(encoded, steps=timesteps).squeeze(1).tolist()
 
         unequal = 0
         equal = 0
         data = float_matrix_from_strlist(data)
 
-        # [print([round(dd,2) for dd in d]) for d in decoded]
-        # [print(d) for d in data]
-
         self.assertEqual(len(data), len(decoded))
         self.assertEqual(len(data[0]), len(decoded[0]))
         for i in range(len(data)):
             for n in range(timesteps):
-                if int(decoded[i][n]) == int(data[i][n]):
+                if round(decoded[i][n], 0) == round(data[i][n], 0):
                     equal += 1
                 else:
                     unequal += 1
@@ -61,7 +58,7 @@ class TestRnnEncoder(unittest.TestCase):
         answer = [4, 5, 6, 7]
         error_margin = 2
         encoded_data, preds = encoder.encode(query, get_next_count=1)
-        decoded_data = encoder.decode(encoded_data, steps=4).tolist()
+        decoded_data = encoder.decode(encoded_data, steps=4).squeeze(1).tolist()
 
         # check prediction
         preds = preds.squeeze().tolist()

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -23,7 +23,7 @@ class TestRnnEncoder(unittest.TestCase):
                 [0.0, 1e3, 1e6, 1e9, 1e12]]
         normalizer = TanhNormalizer()
         reconstructed = normalizer.inverse_transform(normalizer.fit_transform(data))
-        self.assert_(np.allclose(data, reconstructed, atol=0.1))
+        self.assertTrue(np.allclose(data, reconstructed, atol=0.1))
 
     def test_overfit_multidimensional(self):
         pass
@@ -34,7 +34,7 @@ class TestRnnEncoder(unittest.TestCase):
         # timesteps = max([len(q[0]) for q in data])
         # batch_size = 1
 
-        # encoder = RnnEncoder(encoded_vector_size=10, train_iters=400, ts_n_dims=n_dims, max_timesteps=timesteps)
+        # encoder = RnnEncoder(encoded_vector_size=10, train_iters=400, ts_n_dims=n_dims)
         # encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
         # encoded = encoder.encode(data)
         # decoded = encoder.decode(encoded, steps=timesteps)

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -1,7 +1,5 @@
 import unittest
 
-import torch
-
 from lightwood.helpers.device import get_devices
 from lightwood.encoders.time_series import RnnEncoder
 from lightwood.encoders.time_series.helpers.rnn_helpers import *
@@ -25,92 +23,68 @@ class TestRnnEncoder(unittest.TestCase):
         reconstructed = normalizer.inverse_transform(normalizer.fit_transform(data))
         self.assertTrue(np.allclose(data, reconstructed, atol=0.1))
 
-    def test_overfit_singledimensional(self):
-        series = [[[1, 2, 3, 4, 5]], [[2, 3, 4, 5, 6]], [[3, 4, 5, 6, 7]], [[4, 5, 6, 7, 8]]]
-        data = series * 20
-        batch_size = 1
-        n_dims = max([len(q) for q in data])
-        timesteps = max([len(q[0]) for q in data])
+    def test_overfit(self):
+        single_dim_ts = [[[1, 2, 3, 4, 5]],
+                     [[2, 3, 4, 5, 6]],
+                     [[3, 4, 5, 6, 7]],
+                     [[4, 5, 6, 7, 8]]]
 
-        encoder = RnnEncoder(encoded_vector_size=15, train_iters=50, ts_n_dims=n_dims)
-        encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
-        encoded = encoder.encode(data)
-        decoded = encoder.decode(encoded, steps=timesteps).tolist()
+        multi_dim_ts = [[[1, 2, 3, 4, 5, 6],
+                         [2, 3, 4, 5, 6, 7],
+                         [3, 4, 5, 6, 7, 8],
+                         [4, 5, 6, 7, 8, 9]]]
 
-        unequal = 0
-        equal = 0
+        single_qry_ans = ([[[1, 2, 3]], [[2, 3, 4]], [[3, 4, 5]], [[4, 5, 6]]],  # query
+                          [4, 5, 6, 7])                                          # answer
 
-        self.assertEqual(len(data), len(decoded))
-        self.assertEqual(len(data[0]), len(decoded[0]))
-        for i in range(len(data)):
-            for n in range(timesteps):
-                if round(decoded[i][0][n], 0) == round(data[i][0][n], 0):
-                    equal += 1
-                else:
-                    unequal += 1
+        multi_qry_ans = ([[[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]],  # query
+                             [4, 5, 6, 7])                                # answer
 
-        print(f'Decoder got {equal} correct and {unequal} incorrect')
-        # Not much else we can do here, trains slowly, it's the nature of the type of network and travis is really slow
-        self.assertGreater(equal, unequal)
+        for series, example in zip([single_dim_ts, multi_dim_ts], [single_qry_ans, multi_qry_ans]):
 
-        query = [[[1, 2, 3]], [[2, 3, 4]], [[3, 4, 5]], [[4, 5, 6]]]
-        answer = [4, 5, 6, 7]
-        error_margin = 1
-        encoded_data, preds = encoder.encode(query, get_next_count=1)
-        decoded_data = encoder.decode(encoded_data, steps=4).squeeze(1).tolist()
+            data = series * 100
+            n_dims = max([len(q) for q in data])
+            timesteps = max([len(q[0]) for q in data])
+            batch_size = 1
 
-        # check prediction
-        preds = preds.squeeze().tolist()
+            encoder = RnnEncoder(encoded_vector_size=15, train_iters=10, ts_n_dims=n_dims)
+            encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
+            encoded = encoder.encode(data)
+            decoded = encoder.decode(encoded, steps=timesteps).tolist()
 
-        for ans, pred in zip(answer, preds):
-            self.assertGreater(error_margin, abs(pred - ans))
+            equal = 0
+            unequal = 0
+            self.assertEqual(len(data), len(decoded))
+            self.assertEqual(len(data[0]), len(decoded[0]))
+            self.assertEqual(len(data[0][0]), len(decoded[0][0]))
 
-        # check reconstruction
-        for qry, dec in zip(query[0], decoded_data):
-            for truth, pred in zip(qry, dec):
-                self.assertGreater(error_margin, abs(truth - pred))
+            for i in range(len(data)):
+                for d in range(n_dims):
+                    for t in range(timesteps):
+                        if round(decoded[i][d][t], 0) == round(data[i][d][t], 0):
+                            equal += 1
+                        else:
+                            unequal += 1
 
-    def test_overfit_multidimensional(self):
-        series = [[[1, 2, 3, 4, 5, 6], [2, 3, 4, 5, 6, 7], [3, 4, 5, 6, 7, 8], [4, 5, 6, 7, 8, 9]]]
-        data = 20 * series
-        n_dims = max([len(q) for q in data])
-        timesteps = max([len(q[0]) for q in data])
-        batch_size = 1
+            print(f'Decoder got {equal} correct and {unequal} incorrect')
+            self.assertGreaterEqual(equal, unequal)
 
-        encoder = RnnEncoder(encoded_vector_size=10, train_iters=150, ts_n_dims=n_dims)
-        encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
-        encoded = encoder.encode(data)
-        decoded = encoder.decode(encoded, steps=timesteps).tolist()
+            error_margin = 1
+            query, answer = example
+            encoded_data, preds = encoder.encode(query, get_next_count=1)
+            decoded_data = encoder.decode(encoded_data, steps=len(query[0][0])).tolist()
 
-        equal = 0
-        unequal = 0
-        self.assertEqual(len(data), len(decoded))
-        self.assertEqual(len(data[0]), len(decoded[0]))
-        for i in range(len(data[0])):
-            self.assertEqual(len(data[0][i]), len(decoded[0][i]))
-            for n in range(len(data[0][i])):
-                if round(decoded[0][i][n], 0) == round(data[0][i][n], 0):
-                    equal += 1
-                else:
-                    unequal += 1
+            # check prediction
+            if len(data[0]) > 1:
+                preds = torch.reshape(preds, (1, n_dims)).tolist()[-1]
+            else:
+                preds = preds.squeeze().tolist()
 
-        print(f'Decoder got {equal} correct and {unequal} incorrect')
-        # Not much else we can do here, trains slowly, it's the nature of the type of network and travis is really slow
-        self.assertGreaterEqual(equal, unequal)
+            for ans, pred in zip(answer, preds):
+                self.assertGreater(error_margin, abs(pred - ans))
 
-        query = [[[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]]
-        answer = [4, 5, 6, 7]
-        error_margin = 1
-        encoded_data, preds = encoder.encode(query, get_next_count=1)
-        decoded_data = encoder.decode(encoded_data, steps=len(query[0][0])).tolist()
-
-        # check prediction
-        preds = torch.reshape(preds, (1, n_dims)).tolist()[-1]
-        for ans, pred in zip(answer, preds):
-            self.assertGreater(error_margin, abs(pred - ans))
-
-        # check reconstruction
-        float_query = [list(map(float, q)) for q in query[0]]
-        for qry, dec in zip(float_query, decoded_data[0]):
-            for truth, pred in zip(qry, dec):
-                self.assertGreater(error_margin, abs(truth - pred))
+            # check reconstruction
+            float_query = [list(map(float, q)) for q in query[0]]
+            for qry, dec in zip(float_query, decoded_data[0]):
+                for truth, pred in zip(qry, dec):
+                    self.assertGreater(error_margin, abs(truth - pred))

--- a/tests/unit_tests/encoders/time_series/test_rnn.py
+++ b/tests/unit_tests/encoders/time_series/test_rnn.py
@@ -28,11 +28,11 @@ class TestRnnEncoder(unittest.TestCase):
     def test_overfit_singledimensional(self):
         series = ['1 2 3 4 5', '2 3 4 5 6', '3 4 5 6 7', '4 5 6 7 8']  # format given by native
         data = series * 20
-        batch_size = 32
+        batch_size = 1
         timesteps = 5
         n_dims = 1
 
-        encoder = RnnEncoder(encoded_vector_size=10, train_iters=100, ts_n_dims=n_dims)
+        encoder = RnnEncoder(encoded_vector_size=10, train_iters=50, ts_n_dims=n_dims)
         encoder.prepare_encoder(data, feedback_hoop_function=lambda x: print(x), batch_size=batch_size)
         encoded = encoder.encode(data)
         decoded = encoder.decode(encoded, steps=timesteps).tolist()
@@ -59,17 +59,19 @@ class TestRnnEncoder(unittest.TestCase):
 
         query = ['1 2 3', '2 3 4', '3 4 5', '4 5 6']
         answer = [4, 5, 6, 7]
-        error_margin = 1
+        error_margin = 2
         encoded_data, preds = encoder.encode(query, get_next_count=1)
-        decoded_data = encoder.decode(encoded_data, steps=len(query[0][0])).tolist()
+        decoded_data = encoder.decode(encoded_data, steps=4).tolist()
 
         # check prediction
         preds = preds.squeeze().tolist()
+
         for ans, pred in zip(answer, preds):
             self.assertGreater(error_margin, abs(pred - ans))
 
         # check reconstruction
         float_query = float_matrix_from_strlist(query)
+
         for qry, dec in zip(float_query, decoded_data):
             for truth, pred in zip(qry, dec):
                 self.assertGreater(error_margin, abs(truth - pred))


### PR DESCRIPTION
This PR introduces a MinMaxScaler into the Lightwood RNN time series encoder. For now it operates over any and all data, but soon it will only be applied for numerical columns (timestamps will get a different treatment). 

It doesn't say that much, but the unit test synthetic dataset now converges an order of magnitude quicker with better accuracy when decoding. We are currently adding timeseries datasets to the benchmarking suite to confirm that this is an improvement across the board.

NOTE: this PR assumes the data will be provided as numeric arrays. It will stay as a draft until this is accomplished in MindsDB Native.

Changes:
- Add MinMaxNormalizer
- Fixed couple of encoding bugs
- Unified test that considers both single-dimensional and multi-dimensional inputs