### PR TITLE
Stop importing old encoders

### DIFF
--- a/lightwood/encoders/__init__.py
+++ b/lightwood/encoders/__init__.py
@@ -11,17 +11,9 @@ from lightwood.encoders.text.vocab import VocabularyEncoder
 from lightwood.encoders.text.rnn import RnnEncoder as TextRnnEncoder
 from lightwood.encoders.categorical.onehot import OneHotEncoder
 from lightwood.encoders.categorical.autoencoder import CategoricalAutoEncoder
-from lightwood.encoders.time_series.ts_fresh_ts import TsFreshTsEncoder
 from lightwood.encoders.time_series.rnn import RnnEncoder as TsRnnEncoder
 # from lightwood.encoders.audio.amplitude_ts import AmplitudeTsEncoder
 from lightwood.encoders.categorical.multihot import MultiHotEncoder
-
-try:
-    from lightwood.encoders.time_series.cesium_ts import CesiumTsEncoder
-    export_cesium = True
-except:
-    export_cesium = False
-    print('Failed to export cesium timeseires encoder')
 
 
 class DateTime:
@@ -51,11 +43,7 @@ class Categorical:
     CategoricalAutoEncoder = CategoricalAutoEncoder
 
 class TimeSeries:
-    TsFreshTsEncoder = TsFreshTsEncoder
     TsRnnEncoder = TsRnnEncoder
-    if export_cesium:
-        CesiumTsEncoder = CesiumTsEncoder
-
 
 class BuiltinEncoders:
     DateTime = DateTime

--- a/lightwood/encoders/time_series/__init__.py
+++ b/lightwood/encoders/time_series/__init__.py
@@ -1,7 +1,11 @@
-from lightwood.encoders.time_series.ts_fresh_ts import TsFreshTsEncoder
 from lightwood.encoders.time_series.rnn import RnnEncoder
 
 # Optional encoders
+try:
+    from lightwood.encoders.time_series.ts_fresh_ts import TsFreshTsEncoder
+except:
+    pass
+
 try:
     from lightwood.encoders.time_series.cesium_ts import CesiumTsEncoder
     CesiumTsEncoder = CesiumTsEncoder

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -2,3 +2,4 @@ dask<2.4.0,>=1.0.0
 cesium >= 0.9.12
 pydub >= 0.20.0
 ax-platform >= 0.1.9
+tsfresh >= 0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ torch >= 1.4.0
 xlrd >= 1.0.0
 requests >= 2.0.0
 transformers >= 2.10.0
-tsfresh >= 0.14.1
 flair >= 0.5

--- a/tests/unit_tests/encoders/time_series/test_cesium_ts.py
+++ b/tests/unit_tests/encoders/time_series/test_cesium_ts.py
@@ -1,3 +1,4 @@
+'''
 import lightwood
 import unittest
 import math
@@ -26,3 +27,4 @@ if lightwood.encoders.export_cesium:
             ]).encode(data)
 
             print(ret)
+'''

--- a/tests/unit_tests/encoders/time_series/test_ts_fresh_ts.py
+++ b/tests/unit_tests/encoders/time_series/test_ts_fresh_ts.py
@@ -1,3 +1,4 @@
+'''
 import math
 import unittest
 from lightwood.encoders.time_series import TsFreshTsEncoder
@@ -12,3 +13,4 @@ class TestTsFreshTs(unittest.TestCase):
 
         self.assertTrue(len(ret) == len(data))
         self.assertTrue(len(ret) < 60)
+'''


### PR DESCRIPTION
Stop importing encoders that are no longer used, especially ones that require a special dependency.

Removed for now:
* cesium
* tsfresh