### PR TITLE
Additional info

### DIFF
--- a/lightwood/data_schemas/predictor_config.py
+++ b/lightwood/data_schemas/predictor_config.py
@@ -10,7 +10,8 @@ feature_schema = Schema({
     Optional('depends_on_column'): str,
     Optional('dropout'): float,
     Optional('weights'): dict,
-    Optional('secondary_type'): And(str, Use(str.lower), lambda s: s in COLUMN_DATA_TYPES.get_attributes().values())
+    Optional('secondary_type'): And(str, Use(str.lower), lambda s: s in COLUMN_DATA_TYPES.get_attributes().values()),
+    Optional('additional_info'): dict
 })
 
 mixer_schema = Schema({


### PR DESCRIPTION
Added and `additional_info` parameter to the feature_schema to allow for quickly prototpying working with new keys sent by native without have to release a new lightwood every time.