### PR TITLE
Some small fixes 

### DIFF
--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -98,6 +98,8 @@ class CategoricalAutoEncoder(BaseEncoder):
         self._prepared = True
 
     def encode(self, column_data):
+        if not column_data:
+            column_data = ['']
         oh_encoded_tensor = self.onehot_encoder.encode(column_data)
         if not self.use_autoencoder:
             return oh_encoded_tensor

--- a/lightwood/encoders/datetime/datetime.py
+++ b/lightwood/encoders/datetime/datetime.py
@@ -5,8 +5,8 @@ from lightwood.encoders.encoder_base import BaseEncoder
 
 
 class DatetimeEncoder(BaseEncoder):
-    def __init__(self, sinusoidal=False):
-        super(DatetimeEncoder, self).__init__()
+    def __init__(self, is_target=False, sinusoidal=False):
+        super().__init__(is_target)
         self.sinusoidal = sinusoidal
         self.fields = ['year', 'month', 'day', 'weekday', 'hour', 'minute', 'second']
         self.constants = {'year': 3000.0, 'month': 12.0, 'day': 31.0, 'weekday': 7.0,

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -13,7 +13,7 @@ from torch import optim
 
 class RnnEncoder(BaseEncoder):
 
-    def __init__(self, encoded_vector_size=4, train_iters=100, stop_on_error=0.01, learning_rate=0.01,
+    def __init__(self, encoded_vector_size=100, train_iters=100, stop_on_error=0.01, learning_rate=0.01,
                  is_target=False, ts_n_dims=1):
         super().__init__(is_target)
         self.device, _ = get_devices()

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -23,6 +23,7 @@ class RnnEncoder(BaseEncoder):
         self._train_iters = train_iters  # training epochs
         self._pytorch_wrapper = torch.FloatTensor
         self._prepared = False
+        self._is_setup = False
         self._max_ts_length = 0
         self._sos = 0.0  # start of sequence for decoding
         self._eos = 0.0  # end of input sequence -- padding value for batches
@@ -48,10 +49,13 @@ class RnnEncoder(BaseEncoder):
         self._decoder = DecoderRNNNumerical(output_size=total_dims, hidden_size=self._encoded_vector_size).to(self.device)
         self._parameters = list(self._encoder.parameters()) + list(self._decoder.parameters())
         self._optimizer = optim.AdamW(self._parameters, lr=self._learning_rate, weight_decay=1e-4)
+        self._is_setup = True
 
     def to(self, device, available_devices):
-        self.device = device
-        self._encoder = self._encoder.to(self.device)
+        if self._is_setup:
+            self.device = device
+            self._encoder = self._encoder.to(self.device)
+            self._decoder = self._decoder.to(self.device)
         return self
 
     def prepare(self, priming_data, previous_target_data=None, feedback_hoop_function=None, batch_size=256):


### PR DESCRIPTION
- Added `is_target` to datetime encoder initializer
- Explicitly defined some functions that were lambdas and, as such, unpickable
- Handle edge case in categorical autoencoder
- Add RNN time series decoder to its `.to()` method (see #284), increased default hidden size 