### PR TITLE
Categorical target support in time series

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -364,6 +364,7 @@ class DataSource(Dataset):
                 previous_cols.append(column_name)
                 input_encoder_training_data['previous'].append({'data': column_data,
                                                                 'name': column_name,
+                                                                'original_type': config['original_type'],
                                                                 'output_type': config['type']
                                                                 })
 

--- a/lightwood/data_schemas/predictor_config.py
+++ b/lightwood/data_schemas/predictor_config.py
@@ -11,6 +11,7 @@ feature_schema = Schema({
     Optional('dropout'): float,
     Optional('weights'): dict,
     Optional('secondary_type'): And(str, Use(str.lower), lambda s: s in COLUMN_DATA_TYPES.get_attributes().values()),
+    Optional('original_type'): And(str, Use(str.lower), lambda s: s in COLUMN_DATA_TYPES.get_attributes().values()),
     Optional('additional_info'): dict
 })
 


### PR DESCRIPTION
- Adds `CatNormalizer()` to one-hot encode categorical target column when fed into the RNN TS network.
- Improved / simplified logic in `setup_nn()` method