### PR TITLE
Fix get_devices() using CUDA when it's not available

### DIFF
--- a/lightwood/helpers/device.py
+++ b/lightwood/helpers/device.py
@@ -4,7 +4,10 @@ from lightwood.config.config import CONFIG
 
 
 def get_devices():
-    device_str = "cuda" if CONFIG.USE_CUDA else "cpu"
+    if CONFIG.USE_CUDA and torch.cuda.is_available():
+        device_str = "cuda"
+    else:
+        device_str = "cpu"
     if CONFIG.USE_DEVICE is not None:
         device_str = CONFIG.USE_DEVICE
     device = torch.device(device_str)


### PR DESCRIPTION
Solves [this issue](https://github.com/mindsdb/mindsdb/issues/732).