### PR TITLE
include_extra_data on predictor call

### DIFF
--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -159,7 +159,9 @@ class Predictor:
 
         when_data_ds.eval()
 
-        return self._mixer.predict(when_data_ds)
+        kwargs = {'include_extra_data': self.config.get('include_extra_data', False)}
+
+        return self._mixer.predict(when_data_ds, **kwargs)
 
     def calculate_accuracy(self, from_data):
         """


### PR DESCRIPTION
- Simple argument passing so that Native can ask for extra data. In particular, we need the score for each label in classification tasks (currently only NnMixer returns them, under the `encoded_predictions` key). These scores are used in the conformal predictor confidence estimation step.