### PR TITLE
DateTime encoder improvements

### DIFF
--- a/tests/unit_tests/encoders/date/test_datetime.py
+++ b/tests/unit_tests/encoders/date/test_datetime.py
@@ -1,4 +1,6 @@
 import unittest
+import numpy as np
+from dateutil.parser import parse as parse_datetime
 from lightwood.encoders.datetime.datetime import DatetimeEncoder
 
 
@@ -11,9 +13,6 @@ class TestDatetimeEncoder(unittest.TestCase):
         enc.decode(enc.encode(data))
 
     def test_sinusoidal_encoding(self):
-        import numpy as np
-        from dateutil.parser import parse as parse_datetime
-
         dates = ['1971-12-1 00:01', '2000-5-29 23:59:30', '2262-3-11 3:0:5']
         dates = [parse_datetime(d) for d in dates]
         data = [d.timestamp() for d in dates]
@@ -28,3 +27,21 @@ class TestDatetimeEncoder(unittest.TestCase):
         recons = normalizer.decode(results)
         for a, b in zip(recons, data):
             self.assertEqual(a, b)  # check correct reconstruction
+
+    def test_cap_invalid_dates(self):
+        dates = ['9999-12-31 23:59']
+        dates = [parse_datetime(d) for d in dates]
+        data = [d.timestamp() for d in dates]
+
+        normalizer = DatetimeEncoder()
+        normalizer.prepare([])
+        results = normalizer.encode(data)
+
+        # artificially inflate encoded descriptor to invalid values in each dimension
+        for i in range(7):
+            results[:, i] = 1.5
+            try:
+                recons = normalizer.decode(results)
+                print(recons)
+            except Exception as e:
+                print(e)

--- a/tests/unit_tests/encoders/date/test_datetime.py
+++ b/tests/unit_tests/encoders/date/test_datetime.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 import numpy as np
 from dateutil.parser import parse as parse_datetime
 from lightwood.encoders.datetime.datetime import DatetimeEncoder
@@ -29,19 +30,29 @@ class TestDatetimeEncoder(unittest.TestCase):
             self.assertEqual(a, b)  # check correct reconstruction
 
     def test_cap_invalid_dates(self):
-        dates = ['9999-12-31 23:59']
-        dates = [parse_datetime(d) for d in dates]
+        """
+        Test decoding robustness against invalid magnitudes in datetime encodings.
+        """
+        dates = [parse_datetime('2020-10-10 10:10:10')]
         data = [d.timestamp() for d in dates]
+        limits = {
+            'lower': {'month': 1,  'day':  1, 'hour':  0, 'minute':  0, 'second':  0, 'corruption': -0.5},
+            'upper': {'month': 12, 'day': 31, 'hour': 23, 'minute': 59, 'second': 59, 'corruption':  1.5}
+        }
 
         normalizer = DatetimeEncoder()
         normalizer.prepare([])
-        results = normalizer.encode(data)
 
-        # artificially inflate encoded descriptor to invalid values in each dimension
-        for i in range(7):
-            results[:, i] = 1.5
-            try:
-                recons = normalizer.decode(results)
-                print(recons)
-            except Exception as e:
-                print(e)
+        # change descriptor to invalid values in each dimension (out of 0-1 range)
+        for limit in limits.values():
+            print(limit)
+            for i, attr in zip(range(7),  normalizer.fields):
+                if attr in ('year', 'weekday'):
+                    continue
+                else:
+                    vector = normalizer.encode(data)
+                    vector[:, i] = limit['corruption']
+                    recons = datetime.fromtimestamp(normalizer.decode(vector)[0])
+
+                    # decoding correctly caps the invalid vector component
+                    self.assertEqual(getattr(recons, attr), limit[attr])


### PR DESCRIPTION
Addresses #235 and [N#92](https://github.com/mindsdb/mindsdb_native/issues/92).

- Determine monthly number of days given the year and month, instead of using a fixed value as before.
- Normalizes intermediate representation components in .decode() to avoid errors when NnMixer encodes values that are negative and/or too large.
- Introduces test for this. 