### PR TITLE
Dropout for DefaultNet

### DIFF
--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -14,8 +14,6 @@ class CONFIG:
     FORCE_HELPER_MIXERS = False
     HELPER_MIXERS = True
 
-    DEFNET_DROPOUT = 0.3
-
     MONITORING = {
         'epoch_loss': False
         ,'batch_loss': False

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -14,6 +14,8 @@ class CONFIG:
     FORCE_HELPER_MIXERS = False
     HELPER_MIXERS = True
 
+    DEFNET_DROPOUT = 0.0
+
     MONITORING = {
         'epoch_loss': False
         ,'batch_loss': False

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -14,7 +14,7 @@ class CONFIG:
     FORCE_HELPER_MIXERS = False
     HELPER_MIXERS = True
 
-    DEFNET_DROPOUT = 0.0
+    DEFNET_DROPOUT = 0.3
 
     MONITORING = {
         'epoch_loss': False

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -59,7 +59,7 @@ class DefaultNet(torch.nn.Module):
             layers = []
             for ind in range(len(shape) - 1):
                 if 0 < ind < len(shape):
-                    layers.append(torch.nn.Dropout(p=0.5))
+                    layers.append(torch.nn.Dropout(p=CONFIG.DEFNET_DROPOUT))
                 linear_function = PLinear if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
                 layers.append(linear_function(shape[ind],shape[ind+1]))
                 if ind < len(shape) - 2:

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -58,6 +58,8 @@ class DefaultNet(torch.nn.Module):
 
             layers = []
             for ind in range(len(shape) - 1):
+                if 0 < ind < len(shape):
+                    layers.append(torch.nn.Dropout(p=0.5))
                 linear_function = PLinear if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
                 layers.append(linear_function(shape[ind],shape[ind+1]))
                 if ind < len(shape) - 2:

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -15,33 +15,18 @@ class DefaultNet(torch.nn.Module):
                      nr_outputs=None,
                      shape=None,
                      dropout=None,
-                     size_parameters={},
-                     pretrained_net=None,
-                     deterministic=False):
+                     pretrained_net=None):
         self.input_size = input_size
         self.output_size = output_size
         self.nr_outputs = nr_outputs
-        # How many devices we can train this network on
-        self.available_devices = 1
         self.max_variance = None
+        # How many devices we can train this network on
+        if 'cuda' in str(self.device):
+            self.available_devices = torch.cuda.device_count()
+        else:
+            self.available_devices = 1
 
         self.device, _ = get_devices()
-
-        if deterministic:
-            '''
-                Seed that always has the same value on the same dataset plus setting the bellow CUDA options
-                In order to make sure pytorch randomly generate number will be the same every time
-                when training on the same dataset
-            '''
-            torch.manual_seed(66)
-
-            if 'cuda' in str(self.device):
-                torch.backends.cudnn.deterministic = True
-                torch.backends.cudnn.benchmark = False
-                self.available_devices = torch.cuda.device_count()
-            else:
-                self.available_devices = 1
-
         self.dynamic_parameters = dynamic_parameters
 
         """
@@ -59,10 +44,10 @@ class DefaultNet(torch.nn.Module):
 
             layers = []
             for ind in range(len(shape) - 1):
-                if (dropout is not None) and (not deterministic) and (0 < ind < len(shape)):
+                if (dropout is not None) and (0 < ind < len(shape)):
                     layers.append(torch.nn.Dropout(p=dropout))
                 linear_function = PLinear if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
-                layers.append(linear_function(shape[ind],shape[ind+1]))
+                layers.append(linear_function(shape[ind], shape[ind+1]))
                 if ind < len(shape) - 2:
                     layers.append(rectifier())
 
@@ -74,20 +59,6 @@ class DefaultNet(torch.nn.Module):
                     if self.input_size is None:
                         self.input_size = layer.in_features
                     self.output_size = layer.out_features
-
-        if deterministic and pretrained_net is None: # set initial weights based on a specific distribution if we have deterministic enabled
-            # lambda function so that we can do this for the internal layers of net
-            def reset_layer_params(layer):
-                if isinstance(layer, torch.nn.Linear):
-                    torch.nn.init.normal_(layer.weight, mean=0., std=1 / math.sqrt(layer.out_features))
-                    torch.nn.init.normal_(layer.bias, mean=0., std=0.1)
-
-                elif isinstance(layer, PLinear):
-                    torch.nn.init.normal_(layer.mean, mean=0., std=1 / math.sqrt(layer.out_features))
-                    torch.nn.init.normal_(layer.bias, mean=0., std=0.1)
-
-            for layer in self.net:
-                reset_layer_params(layer)
 
         self.net = self.net.to(self.device)
         if self.available_devices > 1:
@@ -114,7 +85,6 @@ class DefaultNet(torch.nn.Module):
         self.available_devices = available_devices
 
         return self
-
 
     def calculate_overall_certainty(self):
         """

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -21,10 +21,7 @@ class DefaultNet(torch.nn.Module):
         self.nr_outputs = nr_outputs
         self.max_variance = None
         # How many devices we can train this network on
-        if 'cuda' in str(self.device):
-            self.available_devices = torch.cuda.device_count()
-        else:
-            self.available_devices = 1
+        self.available_devices = 1
 
         self.device, _ = get_devices()
         self.dynamic_parameters = dynamic_parameters
@@ -61,6 +58,12 @@ class DefaultNet(torch.nn.Module):
                     self.output_size = layer.out_features
 
         self.net = self.net.to(self.device)
+
+        if 'cuda' in str(self.device):
+            self.available_devices = torch.cuda.device_count()
+        else:
+            self.available_devices = 1
+
         if self.available_devices > 1:
             self._foward_net = torch.nn.DataParallel(self.net)
         else:

--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -14,6 +14,7 @@ class DefaultNet(torch.nn.Module):
                      output_size=None,
                      nr_outputs=None,
                      shape=None,
+                     dropout=None,
                      size_parameters={},
                      pretrained_net=None,
                      deterministic=False):
@@ -58,8 +59,8 @@ class DefaultNet(torch.nn.Module):
 
             layers = []
             for ind in range(len(shape) - 1):
-                if 0 < ind < len(shape):
-                    layers.append(torch.nn.Dropout(p=CONFIG.DEFNET_DROPOUT))
+                if (dropout is not None) and (not deterministic) and (0 < ind < len(shape)):
+                    layers.append(torch.nn.Dropout(p=dropout))
                 linear_function = PLinear if CONFIG.USE_PROBABILISTIC_LINEAR else torch.nn.Linear
                 layers.append(linear_function(shape[ind],shape[ind+1]))
                 if ind < len(shape) - 2:

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -350,6 +350,7 @@ class NnMixer(BaseMixer):
                             self._nonpersistent['callback'](epoch, training_error, test_error, delta_mean, self.calculate_accuracy(test_ds))
                         else:
                             self._default_on_iter(epoch, training_error, test_error, delta_mean, self.calculate_accuracy(test_ds))
+                        self.net.train()
 
                         # Stop if we're past the time limit allocated for training
                         if (time.time() - started) > stop_training_after_seconds:

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -155,7 +155,8 @@ class NnMixer(BaseMixer):
             input_size=len(input_sample),
             output_size=len(output_sample),
             nr_outputs=len(train_ds.out_types),
-            deterministic=self.deterministic
+            deterministic=self.deterministic,
+            dropout=CONFIG.DEFNET_DROPOUT if not self.deterministic else None
         )
         self.net = self.net.train()
 

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -22,15 +22,14 @@ class NnMixer(BaseMixer):
     
     def __init__(self,
                  selfaware=False,
-                 deterministic=False,
                  callback_on_iter=None,
                  eval_every_x_epochs=20,
+                 dropout_p=0.3,
                  stop_training_after_seconds=None,
                  stop_model_building_after_seconds=None,
                  param_optimizer=None):
         """
         :param selfaware: bool
-        :param deterministic: bool
         :param callback_on_iter: Callable[epoch, training_error, test_error, delta_mean, accuracy]
         :param eval_every_x_epochs: int
         :param stop_training_after_seconds: int
@@ -40,7 +39,6 @@ class NnMixer(BaseMixer):
         super().__init__()
 
         self.selfaware = selfaware
-        self.deterministic = deterministic
         self.eval_every_x_epochs = eval_every_x_epochs
         self.stop_training_after_seconds = stop_training_after_seconds
         self.stop_model_building_after_seconds = stop_model_building_after_seconds
@@ -59,6 +57,7 @@ class NnMixer(BaseMixer):
         self.batch_size = 200
 
         self.nn_class = DefaultNet
+        self.dropout_p = max(0.0, min(1.0, dropout_p))
         self.dynamic_parameters = {}
         self.awareness_criterion = None
         self.awareness_scale_factor = 1/10  # scales self-aware total loss contribution
@@ -78,9 +77,7 @@ class NnMixer(BaseMixer):
                 break
 
         self.total_iterations = 0
-
         self._nonpersistent = {'sampler': None, 'callback': callback_on_iter}
-
 
     def _default_on_iter(self, epoch, train_error, test_error, delta_mean, accuracy):
         test_error_rounded = round(test_error, 4)
@@ -155,8 +152,7 @@ class NnMixer(BaseMixer):
             input_size=len(input_sample),
             output_size=len(output_sample),
             nr_outputs=len(train_ds.out_types),
-            deterministic=self.deterministic,
-            dropout=CONFIG.DEFNET_DROPOUT if not self.deterministic else None
+            dropout=self.dropout_p
         )
         self.net = self.net.train()
 


### PR DESCRIPTION
- Adds dropout (`p = 0.3`) to the DefaultNet when used in the NnMixer, based on the results of our parameter search.
- Also simplifies logic in DefaultNet, deleting `deterministic` flag as most of that logic is already implemented in `__init__.py`