### PR TITLE
Offset for non-categorical features in DataSource.output_weights

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -265,7 +265,7 @@ class DataSource(Dataset):
             self.output_weights_offset = {}
             for idx, (otype, oidxs) in enumerate(zip(self.out_types, self.out_indexes)):
                 self.output_weights_offset[idx] = self.output_weights_offset.get(idx-1, 0)
-                if otype != ColumnDataTypes.CATEGORICAL:
+                if otype not in (ColumnDataTypes.CATEGORICAL, ColumnDataTypes.MULTIPLE_CATEGORICAL):
                      self.output_weights_offset[idx] += (oidxs[1] - oidxs[0])
 
         return sample

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -72,6 +72,7 @@ class DataSource(Dataset):
         self.config = config
         self.training = False  # Flip this flag if you are using the datasource while training
         self.output_weights = None
+        self.output_weights_offset = None
         self.dropout_dict = {}
         self.enable_dropout = False
         self.enable_cache = self.config['data_source']['cache_transformed_data']
@@ -260,11 +261,12 @@ class DataSource(Dataset):
         if self.enable_cache:
             self.transformed_cache[idx] = sample
 
-        # Add offset in output_weights (output_features might be categorical _and_ numerical)
-        self.output_weights_offset = 0
-        for otype, oidxs in zip(self.out_types, self.out_indexes):
-            if otype != ColumnDataTypes.CATEGORICAL:
-                self.output_weights_offset += (oidxs[1] - oidxs[0])
+        if self.output_weights_offset is None:
+            self.output_weights_offset = {}
+            for idx, (otype, oidxs) in enumerate(zip(self.out_types, self.out_indexes)):
+                self.output_weights_offset[idx] = self.output_weights_offset.get(idx-1, 0)
+                if otype != ColumnDataTypes.CATEGORICAL:
+                     self.output_weights_offset[idx] += (oidxs[1] - oidxs[0])
 
         return sample
 

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -260,6 +260,12 @@ class DataSource(Dataset):
         if self.enable_cache:
             self.transformed_cache[idx] = sample
 
+        # Add offset in output_weights (output_features might be categorical _and_ numerical)
+        self.output_weights_offset = 0
+        for otype, oidxs in zip(self.out_types, self.out_indexes):
+            if otype != ColumnDataTypes.CATEGORICAL:
+                self.output_weights_offset += (oidxs[1] - oidxs[0])
+
         return sample
 
     def get_column_original_data(self, column_name):

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -185,8 +185,8 @@ class NnMixer(BaseMixer):
                         weights_slice = None
                     else:
                         # account for numerical features, not included in the output_weights
-                        s_idx = train_ds.out_indexes[k][0] - train_ds.output_weights_offset
-                        e_idx = train_ds.out_indexes[k][1] - train_ds.output_weights_offset
+                        s_idx = train_ds.out_indexes[k][0] - train_ds.output_weights_offset[k]
+                        e_idx = train_ds.out_indexes[k][1] - train_ds.output_weights_offset[k]
                         weights_slice = output_weights[s_idx:e_idx]
 
                     self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -184,7 +184,10 @@ class NnMixer(BaseMixer):
                     if output_weights is None:
                         weights_slice = None
                     else:
-                        weights_slice = output_weights[train_ds.out_indexes[k][0]:train_ds.out_indexes[k][1]]
+                        # account for numerical features, not included in the output_weights
+                        s_idx = train_ds.out_indexes[k][0] - train_ds.output_weights_offset
+                        e_idx = train_ds.out_indexes[k][1] - train_ds.output_weights_offset
+                        weights_slice = output_weights[s_idx:e_idx]
 
                     self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))
                     self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice, reduce=False))

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -180,7 +180,7 @@ class NnMixer(BaseMixer):
                 output_weights = None
 
             for k, output_type in enumerate(train_ds.out_types):
-                if output_type == COLUMN_DATA_TYPES.CATEGORICAL:
+                if output_type in (COLUMN_DATA_TYPES.CATEGORICAL, COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL):
                     if output_weights is None:
                         weights_slice = None
                     else:
@@ -189,16 +189,12 @@ class NnMixer(BaseMixer):
                         e_idx = train_ds.out_indexes[k][1] - train_ds.output_weights_offset[k]
                         weights_slice = output_weights[s_idx:e_idx]
 
-                    self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))
-                    self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice, reduce=False))
-                elif output_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
-                    if output_weights is None:
-                        weights_slice = None
-                    else:
-                        weights_slice = output_weights[train_ds.out_indexes[k][0]:train_ds.out_indexes[k][1]]
-
-                    self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice))
-                    self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduce=False))
+                    if output_type == COLUMN_DATA_TYPES.CATEGORICAL:
+                        self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))
+                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice, reduce=False))
+                    elif output_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
+                        self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice))
+                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduce=False))
                 elif output_type == COLUMN_DATA_TYPES.NUMERIC:
                     self.criterion_arr.append(QuantileLoss(quantiles=self.quantiles))
                     self.unreduced_criterion_arr.append(QuantileLoss(quantiles=self.quantiles, reduce=False))


### PR DESCRIPTION
The call to `DataSource.output_weights` in the `NnMixer` did not account for offsets in this array when some of the output features were non categorical, which meant an empty tensor was passed to the CrossEntropyLoss, resulting in this [issue](https://github.com/mindsdb/mindsdb_native/issues/291). This PR fixes the bug.