### PR TITLE
Overflow fix for numeric decoding

### DIFF
--- a/lightwood/encoders/numeric/numeric.py
+++ b/lightwood/encoders/numeric/numeric.py
@@ -99,7 +99,10 @@ class NumericEncoder(BaseEncoder):
                 else:
                     if decode_log:
                         sign = -1 if vector[0] > 0.5 else 1
-                        real_value = math.exp(vector[1]) * sign
+                        try:
+                            real_value = math.exp(vector[1]) * sign
+                        except OverflowError as e:
+                            real_value = pow(10,63) * sign
                     else:
                         real_value = vector[2] * self._abs_mean
 

--- a/tests/unit_tests/encoders/numeric/test_numeric.py
+++ b/tests/unit_tests/encoders/numeric/test_numeric.py
@@ -39,3 +39,17 @@ class TestNumericEncoder(unittest.TestCase):
 
         for val in decoded_vals:
             self.assertTrue(val >= 0)
+
+    def test_log_overflow_and_none(self):
+        data = list(range(-2000,2000,66))
+        data.extend([None] * 200)
+        encoder = NumericEncoder()
+
+        encoder.is_target = True
+        encoder.positive_domain = True
+        encoder.decode_log = True
+        encoder.prepare(data)
+        decoded_vals = encoder.decode(encoder.encode(data))
+
+        for i in range(0,70,10):
+            encoder.decode([[0, pow(2,i), 0]])


### PR DESCRIPTION
## Why
* When the log-representation of a number was too big for math.exp to work (e.g. 2000), it overflowed, this caused issues when the encoder was set to `decode_log=True` and the network generate values that were way too large for the log representation.

## How
* When and overflow error is thrown by `math.exp` we instead assume that it returned a very large number and replace that number with `2^63`, same as we do for the "real" value when it's `inf`, then we go through the usual logic using this `2^63` value instead of the return value from `math.exp`
* Tests were added to check the numeric encoder in `decode_log=True` mode, this includes testing `.decode` with vectors like `[0,2^70,0]` which would cause an overflow for the `math.exp` function

## Extra

Also added tests for encoding, decoding and priming with `None` values.