### PR TITLE
requirements.txt: numpy != 1.19.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 NLTK >= 3
 python-dateutil <2.8.1,>=2.1
-numpy >= 1.16.2
+numpy >= 1.16.2,!=1.19.4 
 pandas >= 0.25.1
 schema >= 0.6.8
 scikit-learn >= 0.22.1


### PR DESCRIPTION
because numpy 1.19.4 has a bug on windows: https://github.com/twintproject/twint/issues/1030#issuecomment-726914912
