### PR TITLE
Better cuda check

### DIFF
--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -5,7 +5,11 @@ class CONFIG:
     """General"""
     USE_CUDA = False
     if torch.cuda.device_count() > 0:
-        USE_CUDA = True
+        try:
+            torch.ones(1).cuda()
+            USE_CUDA = True
+        except Exception as e:
+            USE_CUDA = False
     USE_DEVICE = None
 
     # Development flags (maybe move to somewhere else later)


### PR DESCRIPTION
## Why

* `torch.cuda.device_count()` is bigger than 0 even if the devices are torch incompatible in some cases (@StpMax had this issue)

## How

* Before setting GPU usage to True or False, try to create a GPU tensor consisting of one zero and set usage to False if this throws an exception.