### PR TITLE
Fix for #347 - set invalid keys to 0 in class weight_map

### DIFF
--- a/lightwood/mixers/base_mixer.py
+++ b/lightwood/mixers/base_mixer.py
@@ -1,3 +1,5 @@
+import time
+import numpy as np
 from sklearn.metrics import accuracy_score, r2_score, f1_score
 from lightwood.constants.lightwood import COLUMN_DATA_TYPES
 
@@ -152,10 +154,17 @@ class BaseMixer:
             else:
                 sample_weight = [weight_map[val] for val in reals]
 
-            accuracy = {
-                'function': 'accuracy_score',
-                'value': accuracy_score(reals, preds, sample_weight=sample_weight)
-            }
+            try:
+                accuracy = {
+                    'function': 'accuracy_score',
+                    'value': accuracy_score(reals, preds, sample_weight=sample_weight)
+                }
+            # happens for timeseries predictors if test_ds doesn't have enough rows to evaluate for some timesteps
+            except ZeroDivisionError:
+                accuracy = {
+                    'function': 'accuracy_score',
+                    'value': np.nan
+                }
         elif col_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
             if weight_map is None:
                 sample_weight = [1] * len(reals)

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -684,6 +684,12 @@ class NnMixer(BaseMixer):
 
             if 'weights' in ds.get_column_config(output_column):
                 weight_map = ds.get_column_config(output_column)['weights']
+                # omit points for which there's no target info in timeseries forecasting
+                if '_timestep_' in ds.get_column_config(output_column)['name']:
+                    classes = set(weight_map.keys())
+                    observed_classes = set(reals)
+                    for unrecognized_class in observed_classes.difference(classes):
+                        weight_map[unrecognized_class] = 0
             else:
                 weight_map = None
 


### PR DESCRIPTION
## Why
See #347 for more error details. The situation is that whenever a time series predictor is trained for a binary/boolean categorical target with `nr_predictions > 1`, the temporally displaced target columns insert '0' values, which are foreign to the previously built `weight_map`, thus raising the KeyError when trying to access `weight_map['0']`.

## How
The fix is to set any unrecognized class with a null weight, avoiding the error without affecting the accuracy estimation. 

Also, a handler is added for the case when Native passes a test dataframe with less rows per `group_by` than the specified `nr_predictions` (see [N#374](https://github.com/mindsdb/mindsdb_native/issues/374)), returning `NaN` in this case. 
