### PR TITLE
Update calls to avoid warnings

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -324,7 +324,7 @@ class DataSource(Dataset):
             is_target=is_target
         )
 
-        if training_data and 'training_data' in inspect.getargspec(encoder_instance.prepare).args:
+        if training_data and 'training_data' in inspect.getfullargspec(encoder_instance.prepare).args:
             encoder_instance.prepare(
                 column_data,
                 training_data=training_data

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -194,7 +194,7 @@ class NnMixer(BaseMixer):
                 # Note: MSELoss works great for numeric, for the other types it's more of a placeholder
                 else:
                     self.criterion_arr.append(torch.nn.MSELoss())
-                    self.unreduced_criterion_arr.append(torch.nn.MSELoss(reduce=False))
+                    self.unreduced_criterion_arr.append(torch.nn.MSELoss(reduction='none'))
 
         self.optimizer_class = Ranger
         if self.optimizer_args is None:
@@ -336,8 +336,8 @@ class NnMixer(BaseMixer):
 
                         last_test_error = test_error
 
-                        delta_mean = np.mean(test_error_delta_buff[-5:])
-                        subset_delta_mean = np.mean(subset_test_error_delta_buff[-5:])
+                        delta_mean = np.mean(test_error_delta_buff[-5:]) if test_error_delta_buff else 0
+                        subset_delta_mean = np.mean(subset_test_error_delta_buff[-5:]) if subset_test_error_delta_buff else 0
 
                         if self._nonpersistent['callback'] is not None:
                             self._nonpersistent['callback'](epoch, training_error, test_error, delta_mean, self.calculate_accuracy(test_ds))

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -187,10 +187,10 @@ class NnMixer(BaseMixer):
 
                     if output_type == COLUMN_DATA_TYPES.CATEGORICAL:
                         self.criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice))
-                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice, reduce=False))
+                        self.unreduced_criterion_arr.append(TransformCrossEntropyLoss(weight=weights_slice, reduction='none'))
                     elif output_type == COLUMN_DATA_TYPES.MULTIPLE_CATEGORICAL:
                         self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice))
-                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduce=False))
+                        self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduction='none'))
                 # Note: MSELoss works great for numeric, for the other types it's more of a placeholder
                 else:
                     self.criterion_arr.append(torch.nn.MSELoss())


### PR DESCRIPTION
## Why
During training, Lightwood raises some warnings that are mostly due to outdated function call signatures in the ranger optimizer and NnMixer.

## How
This PR updates those calls, which results in fewer raised warnings.