### PR TITLE
Class distribution for classification tasks 

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -459,8 +459,8 @@ class DataSource(Dataset):
             decoder_instance = self.encoders[column_name]
 
         decoded_data = {}
-        if hasattr(decoder_instance, 'predict_proba'):
-            # used for encoders with onehot decoding
+        if hasattr(decoder_instance, 'predict_proba') and decoder_instance.predict_proba:
+            # return complete belief distribution
             preds, pred_probs, labels = decoder_instance.decode(encoded_data)
             decoded_data['predictions'] = preds
             decoded_data['predict_proba'] = pred_probs

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -459,11 +459,11 @@ class DataSource(Dataset):
             decoder_instance = self.encoders[column_name]
 
         decoded_data = {}
-        if hasattr(decoder_instance, 'predict_proba') and decoder_instance.predict_proba:
+        if getattr(decoder_instance, 'predict_proba', False):
             # return complete belief distribution
             preds, pred_probs, labels = decoder_instance.decode(encoded_data)
             decoded_data['predictions'] = preds
-            decoded_data['predict_proba'] = pred_probs
+            decoded_data['class_distribution'] = pred_probs
             decoded_data['class_labels'] = labels
         else:
             decoded_data['predictions'] = decoder_instance.decode(encoded_data)

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -457,7 +457,16 @@ class DataSource(Dataset):
                     You should not decode before having encoding at least once
                     """)
             decoder_instance = self.encoders[column_name]
-        decoded_data = decoder_instance.decode(encoded_data)
+
+        decoded_data = {}
+        if hasattr(decoder_instance, 'predict_proba'):
+            # used for encoders with onehot decoding
+            preds, pred_probs, labels = decoder_instance.decode(encoded_data)
+            decoded_data['predictions'] = preds
+            decoded_data['predict_proba'] = pred_probs
+            decoded_data['class_labels'] = labels
+        else:
+            decoded_data['predictions'] = decoder_instance.decode(encoded_data)
 
         return decoded_data
 

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -21,6 +21,7 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.net = None
         self.encoder = None
         self.decoder = None
+        self.predict_proba = None # whether to return the belief distribution as well
         self.onehot_encoder = OneHotEncoder(is_target=self.is_target)
         self.desired_error = 0.01
         self.use_autoencoder = None
@@ -110,11 +111,11 @@ class CategoricalAutoEncoder(BaseEncoder):
                 return embeddings
 
     def decode(self, encoded_data):
+        self.onehot_encoder.predict_proba = self.predict_proba
         if not self.use_autoencoder:
             return self.onehot_encoder.decode(encoded_data)
         else:
             with torch.no_grad():
                 oh_encoded_tensor = self.decoder(encoded_data)
                 oh_encoded_tensor = oh_encoded_tensor.to('cpu')
-                decoded_categories = self.onehot_encoder.decode(oh_encoded_tensor)
-                return decoded_categories
+                return self.onehot_encoder.decode(oh_encoded_tensor)

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -71,4 +71,7 @@ class OneHotEncoder(BaseEncoder):
             if self.predict_proba:
                 probs.append(softmax(vector).tolist())
 
-        return ret, probs, self._lang.index2word
+        if self.predict_proba:
+            return ret, probs, self._lang.index2word
+        else:
+            return ret

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -1,5 +1,6 @@
 import torch
 import numpy as np
+from copy import deepcopy
 from scipy.special import softmax
 from lightwood.encoders.text.helpers.rnn_helpers import Lang
 from lightwood.encoders.encoder_base import BaseEncoder
@@ -60,6 +61,7 @@ class OneHotEncoder(BaseEncoder):
         return torch.Tensor(ret)
 
     def decode(self, encoded_data):
+        unk_idx = self._lang.word2index['<UNCOMMON>']
         encoded_data_list = encoded_data.tolist()
         ret = []
         probs = []
@@ -69,9 +71,12 @@ class OneHotEncoder(BaseEncoder):
             ret.append(self._lang.index2word[ohe_index])
 
             if self.predict_proba:
+                del(vector[unk_idx])
                 probs.append(softmax(vector).tolist())
 
         if self.predict_proba:
+            class_map = deepcopy(self._lang.index2word)
+            del(class_map[unk_idx])
             return ret, probs, self._lang.index2word
         else:
             return ret

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -1,6 +1,5 @@
 import torch
 import numpy as np
-from copy import deepcopy
 from scipy.special import softmax
 from lightwood.encoders.text.helpers.rnn_helpers import Lang
 from lightwood.encoders.encoder_base import BaseEncoder
@@ -77,8 +76,6 @@ class OneHotEncoder(BaseEncoder):
             # UNK not included in class_map nor belief distribution
             if UNCOMMON_TOKEN != 0:
                 raise Exception("Uncommon token should be the first assigned token in the vocabulary, aborting.")
-            class_map = deepcopy(self._lang.index2word)
-            del(class_map[UNCOMMON_TOKEN])
-            return ret, probs, {k-1: v for k, v in class_map.items()}
+            return ret, probs, {k-1: v for k, v in self._lang.index2word.items() if k != UNCOMMON_TOKEN}
         else:
             return ret

--- a/lightwood/encoders/categorical/onehot.py
+++ b/lightwood/encoders/categorical/onehot.py
@@ -61,7 +61,6 @@ class OneHotEncoder(BaseEncoder):
         return torch.Tensor(ret)
 
     def decode(self, encoded_data):
-        unk_idx = self._lang.word2index['<UNCOMMON>']
         encoded_data_list = encoded_data.tolist()
         ret = []
         probs = []
@@ -71,12 +70,15 @@ class OneHotEncoder(BaseEncoder):
             ret.append(self._lang.index2word[ohe_index])
 
             if self.predict_proba:
-                del(vector[unk_idx])
+                del(vector[UNCOMMON_TOKEN])
                 probs.append(softmax(vector).tolist())
 
         if self.predict_proba:
+            # UNK not included in class_map nor belief distribution
+            if UNCOMMON_TOKEN != 0:
+                raise Exception("Uncommon token should be the first assigned token in the vocabulary, aborting.")
             class_map = deepcopy(self._lang.index2word)
-            del(class_map[unk_idx])
-            return ret, probs, self._lang.index2word
+            del(class_map[UNCOMMON_TOKEN])
+            return ret, probs, {k-1: v for k, v in class_map.items()}
         else:
             return ret

--- a/lightwood/mixers/boost.py
+++ b/lightwood/mixers/boost.py
@@ -91,6 +91,11 @@ class BoostMixer(BaseMixer):
                 else:
                     predictions[target_col_name]['predictions'] = list(self.targets[target_col_name]['model'].predict(X))
 
+                    # add distribution belief if the flag was set in the target encoder
+                    if hasattr(self.encoders[target_col_name], 'predict_proba') and self.encoders[target_col_name].predict_proba:
+                        predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].predict_proba(X)
+                        predictions[target_col_name]['class_labels'] = {i:cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
+
                 try:
                     predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
                 except Exception:

--- a/lightwood/mixers/boost.py
+++ b/lightwood/mixers/boost.py
@@ -92,7 +92,7 @@ class BoostMixer(BaseMixer):
                     predictions[target_col_name]['predictions'] = list(self.targets[target_col_name]['model'].predict(X))
 
                     # add distribution belief if the flag was set in the target encoder
-                    if hasattr(self.encoders[target_col_name], 'predict_proba') and self.encoders[target_col_name].predict_proba:
+                    if getattr(self.encoders[target_col_name], 'predict_proba', False):
                         predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].predict_proba(X)
                         predictions[target_col_name]['class_labels'] = {i:cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
 

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -447,8 +447,8 @@ class NnMixer(BaseMixer):
             if include_extra_data:
                 predictions[output_column]['encoded_predictions'] = output_trasnformed_vectors[output_column]
 
-            if 'predict_proba' in decoded_predictions:
-                predictions[output_column]['class_distribution'] = decoded_predictions['predict_proba']
+            if 'class_distribution' in decoded_predictions:
+                predictions[output_column]['class_distribution'] = decoded_predictions['class_distribution']
                 predictions[output_column]['class_labels'] = decoded_predictions['class_labels']
 
         log.info('Model predictions and decoding completed')

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -710,7 +710,7 @@ class NnMixer(BaseMixer):
                 preds = ds.get_decoded_column_data(
                     output_column,
                     predictions[output_column]['encoded_predictions']
-                )
+                )['predictions']
 
                 alternative_accuracy = BaseMixer._apply_accuracy_function(
                     ds.get_column_config(output_column)['type'],

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -24,7 +24,7 @@ class NnMixer(BaseMixer):
                  selfaware=False,
                  callback_on_iter=None,
                  eval_every_x_epochs=20,
-                 dropout_p=0.3,
+                 dropout_p=0.0,
                  stop_training_after_seconds=None,
                  stop_model_building_after_seconds=None,
                  param_optimizer=None):
@@ -436,7 +436,7 @@ class NnMixer(BaseMixer):
                 torch.Tensor(output_trasnformed_vectors[output_column])
             )
 
-            predictions[output_column] = {'predictions': decoded_predictions}
+            predictions[output_column] = {'predictions': decoded_predictions['predictions']}
 
             if awareness_arr is not None:
                 predictions[output_column]['selfaware_confidences'] = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
@@ -446,6 +446,10 @@ class NnMixer(BaseMixer):
 
             if include_extra_data:
                 predictions[output_column]['encoded_predictions'] = output_trasnformed_vectors[output_column]
+
+            if 'predict_proba' in decoded_predictions:
+                predictions[output_column]['class_distribution'] = decoded_predictions['predict_proba']
+                predictions[output_column]['class_labels'] = decoded_predictions['class_labels']
 
         log.info('Model predictions and decoding completed')
 

--- a/lightwood/mixers/sklearn_mixer.py
+++ b/lightwood/mixers/sklearn_mixer.py
@@ -183,6 +183,12 @@ class SklearnMixer(BaseMixer):
                         self.targets[target_col_name]['model'].predict(X)
                     )
 
+
+                    # add distribution belief if the flag was set in the target encoder
+                    if hasattr(self.encoders[target_col_name], 'predict_proba') and self.encoders[target_col_name].predict_proba:
+                        predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].decision_function(X)
+                        predictions[target_col_name]['class_labels'] = {i:cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
+
                 try:
                     predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]
                 except Exception:

--- a/lightwood/mixers/sklearn_mixer.py
+++ b/lightwood/mixers/sklearn_mixer.py
@@ -183,9 +183,8 @@ class SklearnMixer(BaseMixer):
                         self.targets[target_col_name]['model'].predict(X)
                     )
 
-
                     # add distribution belief if the flag was set in the target encoder
-                    if hasattr(self.encoders[target_col_name], 'predict_proba') and self.encoders[target_col_name].predict_proba:
+                    if getattr(self.encoders[target_col_name], 'predict_proba', False):
                         predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].decision_function(X)
                         predictions[target_col_name]['class_labels'] = {i:cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
 


### PR DESCRIPTION
## Why
For classification tasks, we need Lightwood to return the complete class distribution probabilities for certain scenarios downstream, like using XAI techniques like LIME, or running MindsDB in the OpenML AutoML benchmark suite.

## How
Added support for returning class probabilities in all mixers (SkLearn and Boost by calling `.predict_proba(X)`, NnMixer by adding non-calibrated softmax to the one-hot encoder). Predictions are now sent to native as a dictionary.