### PR TITLE
add compute capability >= 3.7 check

### DIFF
--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -7,7 +7,12 @@ class CONFIG:
     if torch.cuda.device_count() > 0:
         try:
             torch.ones(1).cuda()
-            USE_CUDA = True
+            # pytorch wheels support compute capability >= 3.7
+            major, minor = torch.cuda.get_device_capability()
+            if major + minor/10 >= 3.7:
+                USE_CUDA = True
+            else:
+                USE_CUDA = False
         except Exception as e:
             USE_CUDA = False
     USE_DEVICE = None


### PR DESCRIPTION
## Why
PyTorch reports CUDA availability even when the pre-built wheel might contain instructions that are not supported by older GPUs (compute capability must be `>= 3.7`, otherwise PyTorch should be built from source). This should be considered in the logic that determines CUDA usage.

## How
By checking `torch.cuda.get_device_capability() >= 3.7` when setting the `USE_CUDA` flag.