### PR TITLE
Small time series fixes

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -316,6 +316,7 @@ class DataSource(Dataset):
             self._lookup_encoder_class(config['type'], is_target)
         )
         encoder_attrs = config.get('encoder_attrs', {})
+        encoder_attrs['original_type'] = config.get('original_type', None)
         encoder_attrs['secondary_type'] = config.get('secondary_type', None)
 
         encoder_instance = self._make_column_encoder(
@@ -332,7 +333,9 @@ class DataSource(Dataset):
         else:
             # joint column data augmentation for time series
             if config['type'] == ColumnDataTypes.TIME_SERIES and not is_target:
-                encoder_instance.prepare(column_data, previous_target_data=training_data['previous'])
+                encoder_instance.prepare(column_data,
+                                         feedback_hoop_function=lambda x: print(x),
+                                         previous_target_data=training_data['previous'])
 
             else:
                 encoder_instance.prepare(column_data)

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -333,10 +333,7 @@ class DataSource(Dataset):
         else:
             # joint column data augmentation for time series
             if config['type'] == ColumnDataTypes.TIME_SERIES and not is_target:
-                encoder_instance.prepare(column_data,
-                                         feedback_hoop_function=lambda x: print(x),
-                                         previous_target_data=training_data['previous'])
-
+                encoder_instance.prepare(column_data, previous_target_data=training_data['previous'])
             else:
                 encoder_instance.prepare(column_data)
 

--- a/lightwood/encoders/encoder_base.py
+++ b/lightwood/encoders/encoder_base.py
@@ -5,6 +5,7 @@ class BaseEncoder:
 
     def __init__(self, is_target=False):
         self.is_target = is_target
+        self.original_type = None
         self.secondary_type = None
         self._prepared = False
 

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -34,11 +34,11 @@ class TimeSeriesEncoder(BaseEncoder):
         self._target_ar_normalizers = []
 
     def setup_nn(self, additional_targets=None):
-        """This method must be executed after initializing, else self.secondary_type is unassigned"""
-        if self.secondary_type == 'datetime':
+        """This method must be executed after initializing, else types are unassigned"""
+        if 'datetime' in (self.original_type, self.secondary_type):
             self._normalizer = DatetimeEncoder(sinusoidal=True)
             self._n_dims *= len(self._normalizer.fields)*2  # sinusoidal datetime components
-        elif self.secondary_type == 'numeric':
+        elif 'numeric' in (self.original_type, self.secondary_type):
             self._normalizer = MinMaxNormalizer()
 
         total_dims = self._n_dims
@@ -86,21 +86,16 @@ class TimeSeriesEncoder(BaseEncoder):
         return self
 
     def _prepare_raw_data(self, data):
-        # Convert to array and determine max length:
-        # priming_data is a list of len B with lists of length in [0, T]
-        # If the length of the series varies a lot, it would be worth it to order them and apply a few optimisations
-        # we do not do so now
+        """Convert to array and determine max length"""
         out_data = []
         for e in data:
             if not isinstance(e, torch.Tensor):
-                t = torch.tensor(e, dtype=torch.float, device=self.device)
+                t = torch.tensor(e, dtype=torch.float)
             else:
                 t = e.float()
             t[torch.isnan(t)] = 0.0
             out_data.append(t)
-        lengths = torch.tensor(
-            [len(e) for e in data], dtype=torch.float, device=self.device
-        )
+        lengths = torch.tensor([len(e) for e in data], dtype=torch.float)
         return out_data, lengths
 
     def _get_batch(self, source, start, step):


### PR DESCRIPTION
## Why
The `historical_columns` feature was failing, see [N#398](https://github.com/mindsdb/mindsdb_native/issues/398) for more details.

## How 
Add `original_type` handling inside time series encoders common loop to normalize the input based on its value.

Also, removed an unnecessary `.to(device)` cast inside `_prepare_raw_data()`.