### PR TITLE
Improved gpu detection, fixes n#407

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.56.0'
+__version__ = '0.56.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/config/config.py
+++ b/lightwood/config/config.py
@@ -6,7 +6,7 @@ class CONFIG:
     USE_CUDA = False
     if torch.cuda.device_count() > 0:
         try:
-            torch.ones(1).cuda()
+            torch.ones(1).cuda().__repr__()
             # pytorch wheels support compute capability >= 3.7
             major, minor = torch.cuda.get_device_capability()
             if major + minor/10 >= 3.7:


### PR DESCRIPTION
See related issue [here](https://github.com/mindsdb/mindsdb_native/issues/407).

Basically, there were some edge cases where GPU detection was failing. For example, using a torch wheel without GPU support in a system with a GPU, and then training a model in Native with `use_gpu=False`.

The cause is somewhat weird. Apparently, `torch.ones(1).cuda()` can be lazy in some scenarios, thus not triggering a RuntimeError and incorrectly setting `USE_CUDA=True` in `lightwood.config.config`. A fix is to force the error by calling `.__repr__()` in that instruction, which is what this PR does.