### PR TITLE
Fix sklearn GaussianNB

### DIFF
--- a/lightwood/mixers/sklearn_mixer.py
+++ b/lightwood/mixers/sklearn_mixer.py
@@ -185,8 +185,11 @@ class SklearnMixer(BaseMixer):
 
                     # add distribution belief if the flag was set in the target encoder
                     if getattr(self.encoders[target_col_name], 'predict_proba', False):
-                        predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].decision_function(X)
-                        predictions[target_col_name]['class_labels'] = {i:cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
+                        if hasattr(self.targets[target_col_name]['model'], 'decision_function'):
+                            predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].decision_function(X)
+                        else:
+                            predictions[target_col_name]['class_distribution'] = self.targets[target_col_name]['model'].predict_proba(X)
+                        predictions[target_col_name]['class_labels'] = {i: cls for i, cls in enumerate(self.targets[target_col_name]['model'].classes_)}
 
                 try:
                     predictions[target_col_name]['selfaware_confidences'] = [max(x) for x in self.targets[target_col_name]['model'].predict_proba(X)]


### PR DESCRIPTION
## Why
Confidence estimation was failing in Native if the SkLearn mixer chose to use `GaussianNB`, because this class does not have a `decision_function` method.

## How
Simple PR that checks the type of chosen model. If we use GaussianNB, then call `predict_proba()` instead of `decision_function()`.