### PR TITLE
Fix: LightGBM mixer minimum iterations

### DIFF
--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -100,7 +100,7 @@ class LightGBMMixer(BaseMixer):
                 seconds_for_one_iteration = end - start
                 logging.info(f'A single GBM itteration takes {seconds_for_one_iteration} seconds')
                 max_itt = int(self.stop_training_after_seconds/seconds_for_one_iteration)
-                num_iterations = min(num_iterations, max_itt)
+                num_iterations = max(1, min(num_iterations, max_itt))
                 # Turn on grid search if training doesn't take too long using it
                 if max_itt > 10*num_iterations and seconds_for_one_iteration < 10:
                     self.grid_search = True


### PR DESCRIPTION
## Why
Edge cases with very little training time would trigger a call to LightGBM with no iterations, raising an exception.

## How
Adding a safeguard to execute at least one iteration.