### PR TITLE
Improved DefaultNet shape policy

### DIFF
--- a/lightwood/mixers/helpers/default_net.py
+++ b/lightwood/mixers/helpers/default_net.py
@@ -1,3 +1,4 @@
+import math
 import torch
 from functools import reduce
 
@@ -16,7 +17,7 @@ class DefaultNet(torch.nn.Module):
                      output_size=None,
                      nr_outputs=None,
                      shape=None,
-                     target_params=3e5,
+                     max_params=3e5,
                      dropout=None,
                      pretrained_net=None):
         self.input_size = input_size
@@ -39,9 +40,9 @@ class DefaultNet(torch.nn.Module):
             # default shape, inflated, yields 240k params if input has 200 components
             shape = [self.input_size, max([self.input_size*2, self.output_size*2, 400]), self.output_size]
 
-            # if NN is too big, we do not inflate and aim for max target_params
-            if reduce(lambda x, y: x*y, shape) > target_params:
-                hidden_size = int(target_params//(self.input_size*self.output_size))
+            # if NN is too big, we do not inflate and aim for max_params instead
+            if reduce(lambda x, y: x*y, shape) > max_params:
+                hidden_size = math.floor(max_params/(self.input_size*self.output_size))
 
                 if hidden_size > self.output_size:
                     shape = [self.input_size, hidden_size, self.output_size]


### PR DESCRIPTION
## Why
As framed in #378, there were certain cases for which the concatenated input tensor to the DefaultNet was very big, and this led to prohibitively big NnMixers. 

As an example, let's consider the `micro_mass` [dataset](https://www.openml.org/d/1514), which has some 1.3k columns. After all respective encoders have been trained, the NnMixer has to deal with (or learn from) a `(B, 6072)` shaped input tensor. The current shape policy for the NnMixer's DefaultNet would then instantiate a sequential model with dimensions `[6072, 12144, 3]` with some 220 million trainable parameters. This, naturally, led to incredibly long training times with poor performance to boot. 

## How
The PR introduces a non-destructive additional size check, where we check if the candidate shape for the NnMixer has less than `target_params`. If not, we rescale accordingly. In extreme cases (whenever the input descriptor is enormous), we omit the hidden layer as well.

## Experiments
We experimented with the `micro_mass` and `stack_overflow_survey` datasets, forcing the predictor to use an NnMixer:

- `micro_mass`: `5590 [s]` runtime to `52 [s]` runtime, with a very small decrease in balanced accuracy from `0.159` to `0.1314`.
- `stack_overflow_survey`: `501 [s]` runtime to `470 [s]` runtime, increasing r2 score from `0.5995` to `0.6663`.

It is very likely that some OpenML datasets which timed out will now run normally. This will be tried out during the week.
