### PR TITLE
Add GradScaler for AMP usage

### DIFF
--- a/lightwood/helpers/torch.py
+++ b/lightwood/helpers/torch.py
@@ -29,6 +29,7 @@ class LightwoodAutocast:
     Equivalent to torch.cuda.amp.autocast, but checks device compute capability
     to activate the feature only when the GPU has tensor cores to leverage AMP.
     """
+    active = False
     def __init__(self, enabled=True):
         self.major = 0  # GPU major version
         torch_version = [int(i) for i in torch.__version__.split('.')[:-1]]
@@ -46,6 +47,7 @@ class LightwoodAutocast:
                 self._enabled = False  # gpu is available but cpu is forced
 
         self.prev = self._enabled  # necessary reference to exit
+        active = self._enabled
 
     def __enter__(self):
         if self._enabled:

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -634,7 +634,7 @@ class NnMixer(BaseMixer):
                     self.optimizer.step()
                     if self.is_selfaware and self.start_selfaware_training and awareness_loss is not None:
                         awareness_loss.backward(retain_graph=True)
-                        self.selfaware_optimizer.st ep()
+                        self.selfaware_optimizer.step()
 
                 error = running_loss / (i + 1)
 

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -1,21 +1,22 @@
+import time
 import copy
 import random
-import time
-
-import torch
-from torch.utils.data import DataLoader
-import numpy as np
 import operator
 
+import torch
+import numpy as np
+from torch.utils.data import DataLoader
+from torch.cuda.amp import GradScaler
+
+from lightwood.logger import log
+from lightwood.mixers import BaseMixer
+from lightwood.config.config import CONFIG
 from lightwood.helpers.torch import LightwoodAutocast
+from lightwood.constants.lightwood import COLUMN_DATA_TYPES
 from lightwood.mixers.helpers.default_net import DefaultNet
 from lightwood.mixers.helpers.selfaware import SelfAware
 from lightwood.mixers.helpers.ranger import Ranger
 from lightwood.mixers.helpers.transform_corss_entropy_loss import TransformCrossEntropyLoss
-from lightwood.config.config import CONFIG
-from lightwood.constants.lightwood import COLUMN_DATA_TYPES
-from lightwood.mixers import BaseMixer
-from lightwood.logger import log
 
 
 class NnMixer(BaseMixer):
@@ -547,6 +548,8 @@ class NnMixer(BaseMixer):
                 sampler=self._nonpersistent['sampler']
             )
 
+        scaler = GradScaler()
+
         for epoch in range(max_epochs):  # loop over the dataset multiple times
             running_loss = 0.0
             error = 0
@@ -600,10 +603,10 @@ class NnMixer(BaseMixer):
                         target_loss = target_loss.tolist()
                         if type(target_loss[0]) == type([]):
                             target_loss = [np.mean(x) for x in target_loss]
-                        for i, value in enumerate(target_loss):
-                            if len(unreduced_losses) <= i:
+                        for j, value in enumerate(target_loss):
+                            if len(unreduced_losses) <= j:
                                 unreduced_losses.append([])
-                            unreduced_losses[i].append(value)
+                            unreduced_losses[j].append(value)
 
                     unreduced_losses = torch.Tensor(unreduced_losses).to(self.net.device)
 
@@ -619,7 +622,14 @@ class NnMixer(BaseMixer):
                     awareness_loss.backward(retain_graph=True)
 
                 running_loss += loss.item()
-                loss.backward()
+                scaler.scale(loss).backward()
+                scaler.step(self.optimizer)
+                scaler.update()
+                error = running_loss / (i + 1)
+
+                # we'll need a GradScaler for the selfaware if any NaNs pop up in it
+                if self.is_selfaware and self.start_selfaware_training:
+                    self.selfaware_optimizer.step()
 
                 # @NOTE: Decrease 900 if you want to plot gradients more often, I find it's too expensive to do so
                 if CONFIG.MONITORING['network_heatmap'] and random.randint(0, 1000) > 900:
@@ -645,15 +655,6 @@ class NnMixer(BaseMixer):
                                 layer_name.append(f'Layer {index}-{index+1}')
                         self.monitor.weight_map(layer_name, weights, 'Awareness network weights')
                         self.monitor.weight_map(layer_name, weights, 'Awareness network gradients')
-
-                # now that we have run backward in both losses, optimize()
-                # (review: we may need to optimize for each step)
-                self.optimizer.step()
-
-                if self.is_selfaware and self.start_selfaware_training:
-                    self.selfaware_optimizer.step()
-
-                error = running_loss / (i + 1)
 
                 if CONFIG.MONITORING['batch_loss']:
                     #self.monitor.plot_loss(total_loss.item(), self.total_iterations, 'Total Batch Loss')

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -622,9 +622,15 @@ class NnMixer(BaseMixer):
                     awareness_loss.backward(retain_graph=True)
 
                 running_loss += loss.item()
-                scaler.scale(loss).backward()
-                scaler.step(self.optimizer)
-                scaler.update()
+
+                if LightwoodAutocast.active:
+                    scaler.scale(loss).backward()
+                    scaler.step(self.optimizer)
+                    scaler.update()
+                else:
+                    loss.backward()
+                    self.optimizer.step()
+
                 error = running_loss / (i + 1)
 
                 # we'll need a GradScaler for the selfaware if any NaNs pop up in it


### PR DESCRIPTION
## Why
With Automated Mixed Precision, sometimes gradients would underflow, resulting in NaNs being propagated.

## How
Implementing `torch.amp.GradScaler` recommended usage.