### PR TITLE
Unittest text

### DIFF
--- a/tests/unit_tests/test_predictor.py
+++ b/tests/unit_tests/test_predictor.py
@@ -97,7 +97,7 @@ class TestPredictor(unittest.TestCase):
             "output_features": [
                 {"name": "output", "type": "numeric"},
             ],
-            "mixer": {"class": BoostMixer},
+            "mixer": {"class": LightGBMMixer},
         }
 
         inpx = ["this is a test case of text", "lightwood is awesome!"] *100

--- a/tests/unit_tests/test_predictor.py
+++ b/tests/unit_tests/test_predictor.py
@@ -82,3 +82,27 @@ class TestPredictor(unittest.TestCase):
 
         df = df.drop([x['name'] for x in config['output_features']], axis=1)
         predictor.predict(when_data=df)
+
+    def test_text_encoder(self):
+        """
+        2021.02.15
+        Check if the text encoder is properly deployed; NOT performance.
+
+        Config ensures "input" is treated as text.
+        """
+        config = {
+            "input_features": [
+                {"name": "input", "type": "text"},
+            ],
+            "output_features": [
+                {"name": "output", "type": "numeric"},
+            ],
+            "mixer": {"class": BoostMixer},
+        }
+
+        inpx = ["this is a test case of text", "lightwood is awesome!"] *100
+        outx = [0,1] * 100
+        df = pd.DataFrame({"input": inpx, "output": outx})
+
+        predictor = Predictor(config)
+        predictor.learn(from_data=df)


### PR DESCRIPTION
With regards to: [Issue 393](https://github.com/mindsdb/lightwood/issues/393)

The recent change to data_source.py influences the text encoder. This simple additional test checks to see if the text encoder is properly called by ensuring the config file tells lightwood that the input column is a text-type.

You can check this behavior between stable (0.60.0) and fix_l393
git checkout stable
python -m unittest test_predictor.TestPredictor.test_text_encoder

Versus
git checkout fix_l393
python -m unittest test_predictor.TestPredictor.test_text_encoder

The fix_l393 should be merged into stable in addition.