### PR TITLE
Hotfix: prepare_encoder order call

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.60.0'
+__version__ = '0.60.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'


### PR DESCRIPTION
## Why
Text encoder was triggering an IndexError, this PR solves that.

## How
Reordering the `prepare()` call to lightwood encoders, so that now we:
1. Add information to "autoregressive" time series columns
2. Train all output column encoders except for time series ones (as they require input columns' encoded data)
3. Train all input column encoders
4. Train all time series output column encoders

This restores the information flow that was lost in the #382 rearrangement, and fixes #393.