### PR TITLE
Improved BaseEncoder .to()

### DIFF
--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -7,7 +7,6 @@ from lightwood.mixers.helpers.default_net import DefaultNet
 from lightwood.mixers.helpers.ranger import Ranger
 from lightwood.encoders.categorical.onehot import OneHotEncoder
 from lightwood.api.gym import Gym
-from lightwood.config.config import CONFIG
 from lightwood.encoders.encoder_base import BaseEncoder
 from lightwood.logger import log
 
@@ -42,10 +41,14 @@ class CategoricalAutoEncoder(BaseEncoder):
         labels = targets_c.to(self.net.device)
         return labels
 
-    def to(self, device, available_devices):
-        if self.use_autoencoder:
-            self.net = self.net.to(device, available_devices)
-        return self
+    #def to(self, device, available_devices):
+        #if self.use_autoencoder:
+        #    self.net = self.net.to(device, available_devices)
+        #for v in vars(self):
+        #    attr = getattr(self, v)
+        #    if isinstance(attr, torch.nn.Module):
+        #        attr.to(device)
+        #return self
 
     def prepare(self, priming_data):
         random.seed(len(priming_data))

--- a/lightwood/encoders/categorical/autoencoder.py
+++ b/lightwood/encoders/categorical/autoencoder.py
@@ -41,15 +41,6 @@ class CategoricalAutoEncoder(BaseEncoder):
         labels = targets_c.to(self.net.device)
         return labels
 
-    #def to(self, device, available_devices):
-        #if self.use_autoencoder:
-        #    self.net = self.net.to(device, available_devices)
-        #for v in vars(self):
-        #    attr = getattr(self, v)
-        #    if isinstance(attr, torch.nn.Module):
-        #        attr.to(device)
-        #return self
-
     def prepare(self, priming_data):
         random.seed(len(priming_data))
 

--- a/lightwood/encoders/encoder_base.py
+++ b/lightwood/encoders/encoder_base.py
@@ -1,5 +1,6 @@
 import torch
 
+
 class BaseEncoder:
     """Base class for all encoders"""
 
@@ -19,4 +20,8 @@ class BaseEncoder:
         raise NotImplementedError
 
     def to(self, device, available_devices):
+        for v in vars(self):
+            attr = getattr(self, v)
+            if isinstance(attr, torch.nn.Module):
+                attr.to(device)
         return self

--- a/lightwood/encoders/image/helpers/img_to_vec.py
+++ b/lightwood/encoders/image/helpers/img_to_vec.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torchvision.models as models
 from lightwood.helpers.device import get_devices
+from lightwood.helpers.torch import LightwoodAutocast
 from lightwood.config.config import CONFIG
 
 
@@ -15,8 +16,8 @@ class ChannelPoolAdaptiveAvg1d(torch.nn.AdaptiveAvgPool1d):
             pooled = pooled.permute(0,2,1)
             return pooled.view(n,c)
 
-class Img2Vec(nn.Module):
 
+class Img2Vec(nn.Module):
     def __init__(self, model):
         """ Img2Vec
         :param model: name of the model to use
@@ -28,7 +29,6 @@ class Img2Vec(nn.Module):
 
         self.model = self._get_model()
         self.model = self.model.to(self.device)
-
 
     def to(self, device, available_devices):
         self.device = device
@@ -47,7 +47,6 @@ class Img2Vec(nn.Module):
                 if batch:
                     return embedding[:, :, 0, 0]
                 return embedding[0, :, 0, 0]
-
 
     def _get_model(self):
         if self.model_name == 'resnet-18':

--- a/lightwood/encoders/image/helpers/nn.py
+++ b/lightwood/encoders/image/helpers/nn.py
@@ -45,11 +45,6 @@ class autoencoder(nn.Module):
             nn.Linear(64, 128),
             nn.ReLU(True), nn.Linear(128, 128 * 128), nn.Tanh())
 
-    def to(self, device, available_devices):
-        self.encoder = self.encoder.to(device)
-        self.decoder = self.decoder.to(device)
-        return self
-
     def forward(self, x):
         with LightwoodAutocast():
             x = self.encoder(x)
@@ -58,6 +53,7 @@ class autoencoder(nn.Module):
 
 
 class NnEncoderHelper:
+
     def __init__(self, images):
         """
 

--- a/lightwood/encoders/image/helpers/nn.py
+++ b/lightwood/encoders/image/helpers/nn.py
@@ -45,6 +45,11 @@ class autoencoder(nn.Module):
             nn.Linear(64, 128),
             nn.ReLU(True), nn.Linear(128, 128 * 128), nn.Tanh())
 
+    def to(self, device, available_devices):
+        self.encoder = self.encoder.to(device)
+        self.decoder = self.decoder.to(device)
+        return self
+
     def forward(self, x):
         with LightwoodAutocast():
             x = self.encoder(x)
@@ -53,7 +58,6 @@ class autoencoder(nn.Module):
 
 
 class NnEncoderHelper:
-
     def __init__(self, images):
         """
 

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -29,9 +29,9 @@ class Img2VecEncoder(BaseEncoder):
         pil_logger = logging.getLogger('PIL')
         pil_logger.setLevel(logging.ERROR)
 
-    def to(self, device, available_devices):
-        self.model.to(device, available_devices)
-        return self
+    #def to(self, device, available_devices):
+    #    self.model.to(device, available_devices)
+    #    return self
 
     def prepare(self, priming_data):
         if self._prepared:

--- a/lightwood/encoders/image/img_2_vec.py
+++ b/lightwood/encoders/image/img_2_vec.py
@@ -29,10 +29,6 @@ class Img2VecEncoder(BaseEncoder):
         pil_logger = logging.getLogger('PIL')
         pil_logger.setLevel(logging.ERROR)
 
-    #def to(self, device, available_devices):
-    #    self.model.to(device, available_devices)
-    #    return self
-
     def prepare(self, priming_data):
         if self._prepared:
             raise Exception('You can only call "prepare" once for a given encoder.')

--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -104,14 +104,6 @@ class DistilBertEncoder(BaseEncoder):
 
         return loss
 
-    # def to(self, device, available_devices):
-    #     self._model = self._model.to(self.device)
-    #
-    #     if self._head is not None:
-    #         self._head = self._head.to(self.device)
-    #
-    #     return self
-
     def prepare(self, priming_data, training_data=None):
         if self._prepared:
             raise Exception('You can only call "prepare" once for a given encoder.')

--- a/lightwood/encoders/text/distilbert.py
+++ b/lightwood/encoders/text/distilbert.py
@@ -104,13 +104,13 @@ class DistilBertEncoder(BaseEncoder):
 
         return loss
 
-    def to(self, device, available_devices):
-        self._model = self._model.to(self.device)
-
-        if self._head is not None:
-            self._head = self._head.to(self.device)
-
-        return self
+    # def to(self, device, available_devices):
+    #     self._model = self._model.to(self.device)
+    #
+    #     if self._head is not None:
+    #         self._head = self._head.to(self.device)
+    #
+    #     return self
 
     def prepare(self, priming_data, training_data=None):
         if self._prepared:

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -90,8 +90,7 @@ class TimeSeriesEncoder(BaseEncoder):
     def to(self, device, available_devices):
         if self._is_setup:
             self.device = device
-            self._encoder = self._encoder.to(self.device)
-            self._decoder = self._decoder.to(self.device)
+            return super().to(device, available_devices)
         return self
 
     def _prepare_raw_data(self, data):


### PR DESCRIPTION
## Why
To minimize risk of model transfer issues. For more context, see #282.

## How
Modified `BaseEncoder.to()` so that it sends all `torch.nn.Module()` atributes to the respective device. This simplifies `.to()` logic in a bunch of encoders.