### PR TITLE
Positive domain handling for LightBGM mixer

### DIFF
--- a/lightwood/encoders/numeric/__init__.py
+++ b/lightwood/encoders/numeric/__init__.py
@@ -1,1 +1,2 @@
 from lightwood.encoders.numeric.numeric import NumericEncoder
+from lightwood.encoders.numeric.ts_numeric import TsNumericEncoder

--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -148,8 +148,9 @@ class LightGBMMixer(BaseMixer):
                 ypred[col_name]['class_distribution'] = list(col_preds)
                 ypred[col_name]['class_labels'] = {i: cls for i, cls in enumerate(self.all_classes)}
                 col_preds = self.ord_encs[col_name].inverse_transform(np.argmax(col_preds, axis=1).reshape(-1, 1)).flatten()
-            if col_config['encoder_attrs'].get('positive_domain', False):
-                col_preds = col_preds.clip(0)
+            if col_config.get('encoder_attrs', False):
+                if col_config['encoder_atts'].get('positive_domain', False):
+                    col_preds = col_preds.clip(0)
             ypred[col_name]['predictions'] = list(col_preds)
 
         return ypred

--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -149,7 +149,7 @@ class LightGBMMixer(BaseMixer):
                 ypred[col_name]['class_labels'] = {i: cls for i, cls in enumerate(self.all_classes)}
                 col_preds = self.ord_encs[col_name].inverse_transform(np.argmax(col_preds, axis=1).reshape(-1, 1)).flatten()
             if col_config.get('encoder_attrs', False):
-                if col_config['encoder_atts'].get('positive_domain', False):
+                if col_config['encoder_attrs'].get('positive_domain', False):
                     col_preds = col_preds.clip(0)
             ypred[col_name]['predictions'] = list(col_preds)
 

--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -141,12 +141,15 @@ class LightGBMMixer(BaseMixer):
 
         ypred = {}
         for col_name in when_data_source.output_feature_names:
+            col_config = [conf for conf in when_data_source.config['output_features'] if conf['name'] == col_name][0]
             col_preds = self.models[col_name].predict(data)
             ypred[col_name] = {}
             if col_name in self.ord_encs:
                 ypred[col_name]['class_distribution'] = list(col_preds)
                 ypred[col_name]['class_labels'] = {i: cls for i, cls in enumerate(self.all_classes)}
                 col_preds = self.ord_encs[col_name].inverse_transform(np.argmax(col_preds, axis=1).reshape(-1, 1)).flatten()
+            if col_config['encoder_attrs'].get('positive_domain', False):
+                col_preds = col_preds.clip(0)
             ypred[col_name]['predictions'] = list(col_preds)
 
         return ypred

--- a/tests/unit_tests/encoders/numeric/test_numeric.py
+++ b/tests/unit_tests/encoders/numeric/test_numeric.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from lightwood.encoders.numeric import NumericEncoder
+from lightwood.encoders.numeric import TsNumericEncoder
 
 
 class TestNumericEncoder(unittest.TestCase):
@@ -30,15 +31,14 @@ class TestNumericEncoder(unittest.TestCase):
 
     def test_positive_domain(self):
         data = [-1, -2, -100, 5, 10, 15]
-        encoder = NumericEncoder()
+        for encoder in [NumericEncoder(), TsNumericEncoder()]:
+            encoder.is_target = True        # only affects target values
+            encoder.positive_domain = True
+            encoder.prepare(data)
+            decoded_vals = encoder.decode(encoder.encode(data))
 
-        encoder.is_target = True        # only affects target values
-        encoder.positive_domain = True
-        encoder.prepare(data)
-        decoded_vals = encoder.decode(encoder.encode(data))
-
-        for val in decoded_vals:
-            self.assertTrue(val >= 0)
+            for val in decoded_vals:
+                self.assertTrue(val >= 0)
 
     def test_log_overflow_and_none(self):
         data = list(range(-2000,2000,66))

--- a/tests/unit_tests/mixers/test_ligthgbm.py
+++ b/tests/unit_tests/mixers/test_ligthgbm.py
@@ -48,3 +48,38 @@ class TestLightGBMMixer(unittest.TestCase):
         mixer = LightGBMMixer()
         mixer.fit(train_ds, test_ds )
         _ = mixer.predict(train_ds.make_child(data_frame[['x', 'y']]))
+
+    def test_fit_and_predict_posdom(self):
+        config = {
+            'input_features': [
+                {
+                    'name': 'x',
+                    'type': 'numeric'
+                }
+            ],
+            'output_features': [
+                {
+                    'name': 'y',
+                    'type': 'numeric',
+                    'encoder_attrs': {
+                        'positive_domain': True
+                    }
+                }
+            ]
+        }
+
+        config = predictor_config_schema.validate(config)
+        N = 100
+
+        data = {'x': [i for i in range(N)], 'y': [-i for i in range(N)]}
+        data_frame = pandas.DataFrame(data)
+        train_ds = DataSource(data_frame, config)
+        test_ds = train_ds.subset(0.25)
+
+        mixer = LightGBMMixer()
+        mixer.fit(train_ds, test_ds)
+        preds = mixer.predict(train_ds.make_child(data_frame[['x', 'y']]))
+        print(preds)
+
+        for p in preds['y']['predictions']:
+            assert p >= 0


### PR DESCRIPTION
## Why
As the LightGBM mixer does not use any encoder `.decode()` methods, our `positive_domain` logic for the NnMixer was not being used, and so negative predictions would arise even if the user specified this flag.

## How
Added a check in the `._predict()` method.

Also, added `TsNumericEncoder` to `test_positive_domain`.