### PR TITLE
hotfix: torch >= 1.6

### DIFF
--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies Windows
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html;
+          pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html;
         fi
       shell: bash
       env:

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies Windows
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html;
+          pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html;
         fi
       shell: bash
       env:

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'mindsdb'
-__version__ = '0.62.0'
+__version__ = '0.62.1'
 __description__ = "Lightwood's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/encoders/time_series/rnn.py
+++ b/lightwood/encoders/time_series/rnn.py
@@ -98,6 +98,8 @@ class TimeSeriesEncoder(BaseEncoder):
         out_data = []
         for e in data:
             if not isinstance(e, torch.Tensor):
+                e = np.array(e, dtype=float)
+                e[np.isnan(e)] = 0.0
                 t = torch.tensor(e, dtype=torch.float)
             else:
                 t = e.float()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ numpy >= 1.16.2,!=1.19.4
 pandas >= 0.25.1
 schema >= 0.6.8
 scikit-learn >= 0.22.1, <= 0.23.2
-torchvision >= 0.8.2, <= 0.9.0
-torch >= 1.7.1, <= 1.8.0
+torchvision >= 0.7.0, <= 0.9.0
+torch >= 1.6.0, <= 1.8.0
 xlrd >= 1.0.0
 requests >= 2.0.0
 transformers >= 4.1.0, <= 4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ numpy >= 1.16.2,!=1.19.4
 pandas >= 0.25.1
 schema >= 0.6.8
 scikit-learn >= 0.22.1, <= 0.23.2
-torchvision >= 0.5.0, <= 0.8.1
-torch >= 1.4.0, <= 1.7.0
+torchvision >= 0.8.2, <= 0.9.0
+torch >= 1.7.1, <= 1.8.0
 xlrd >= 1.0.0
 requests >= 2.0.0
-transformers >= 2.10.0, <= 4.0.0
+transformers >= 4.1.0, <= 4.3.0
 lightgbm >= 3.1.1
 optuna >= 2.4.0


### PR DESCRIPTION
Hotfix:
- Bounds PyTorch to `>= 1.6.0` as needed by the `torch.cuda.amp` module.
- Implements empty order by column handling in time series encoder (solves #407)