### PR TITLE
Smaller Self-Aware

### DIFF
--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies OSX
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          brew install libomp;
+          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb;
         fi
       shell: bash
       env:

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies OSX
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb;
+          brew install libomp@11.1.0;
         fi
       shell: bash
       env:

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies OSX
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          brew install libomp@11.1.0;
+          brew install libomp;
         fi
       shell: bash
       env:

--- a/lightwood/mixers/helpers/selfaware.py
+++ b/lightwood/mixers/helpers/selfaware.py
@@ -15,8 +15,10 @@ class SelfAware(torch.nn.Module):
         self.nr_outputs = nr_outputs
 
         awareness_layers = []
-        awareness_net_shape = [(self.input_size + self.output_size),
-                               max([int((self.input_size + self.output_size) * 1.5), 300]),
+        awareness_net_shape = [self.input_size,  # ( + self.output_size),
+                               # max([int((self.input_size + self.output_size) * 1.5), 300]),
+                               min(self.input_size * 2, 100),
+                               # max([int(self.input_size * 1.5), 300]),
                                self.nr_outputs]
 
         for ind in range(len(awareness_net_shape) - 1):
@@ -51,7 +53,7 @@ class SelfAware(torch.nn.Module):
         :return: predicted loss value over the tensor samples
         """
         with LightwoodAutocast():
-            aware_in = torch.cat((true_input, main_net_output), 1)
+            aware_in = true_input  # torch.cat((true_input, main_net_output), 1)
             output = self.net(aware_in)
             return output
     

--- a/lightwood/mixers/helpers/selfaware.py
+++ b/lightwood/mixers/helpers/selfaware.py
@@ -15,10 +15,8 @@ class SelfAware(torch.nn.Module):
         self.nr_outputs = nr_outputs
 
         awareness_layers = []
-        awareness_net_shape = [self.input_size,  # ( + self.output_size),
-                               # max([int((self.input_size + self.output_size) * 1.5), 300]),
+        awareness_net_shape = [self.input_size,
                                min(self.input_size * 2, 100),
-                               # max([int(self.input_size * 1.5), 300]),
                                self.nr_outputs]
 
         for ind in range(len(awareness_net_shape) - 1):
@@ -53,7 +51,6 @@ class SelfAware(torch.nn.Module):
         :return: predicted loss value over the tensor samples
         """
         with LightwoodAutocast():
-            aware_in = true_input  # torch.cat((true_input, main_net_output), 1)
+            aware_in = true_input
             output = self.net(aware_in)
             return output
-    

--- a/lightwood/mixers/helpers/selfaware.py
+++ b/lightwood/mixers/helpers/selfaware.py
@@ -13,6 +13,7 @@ class SelfAware(torch.nn.Module):
         self.input_size = input_size
         self.output_size = output_size
         self.nr_outputs = nr_outputs
+        self.base_loss = 1.0
 
         awareness_layers = []
         awareness_net_shape = [self.input_size,
@@ -44,7 +45,7 @@ class SelfAware(torch.nn.Module):
 
         return self
 
-    def forward(self, true_input, main_net_output):
+    def forward(self, true_input):
         """
         :param true_input: tensor with data point features
         :param main_net_output: tensor with main NN prediction for true_input

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -23,7 +23,7 @@ from lightwood.mixers.helpers.transform_corss_entropy_loss import TransformCross
 class NnMixer(BaseMixer):
 
     def __init__(self,
-                 selfaware=True,
+                 selfaware=False,
                  callback_on_iter=None,
                  eval_every_x_epochs=20,
                  dropout_p=0.0,
@@ -64,9 +64,9 @@ class NnMixer(BaseMixer):
         self.awareness_criterion = None
         self.awareness_scale_factor = 1/6  # scales self-aware total loss contribution
         self.selfaware_lr_factor = 2/3      # scales self-aware learning rate compared to mixer
-        self.start_selfaware_training = True
+        self.start_selfaware_training = False
         self.stop_selfaware_training = False
-        self.is_selfaware = True
+        self.is_selfaware = False
 
         self.max_confidence_per_output = []
         self.monitor = None
@@ -213,7 +213,7 @@ class NnMixer(BaseMixer):
 
         self.selfaware_optimizer_args = copy.deepcopy(self.optimizer_args)
         self.selfaware_optimizer_args['lr'] = self.selfaware_optimizer_args['lr'] * self.selfaware_lr_factor
-        self.selfaware_optimizer_args['weight_decay'] = 0.5
+        self.selfaware_optimizer_args['weight_decay'] = 2e-5
         self.selfaware_optimizer = self.optimizer_class(self.selfaware_net.parameters(), **self.optimizer_args)
 
         if stop_training_after_seconds is None:
@@ -444,7 +444,6 @@ class NnMixer(BaseMixer):
                 scores = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
                 scores = (0.0+torch.sigmoid(torch.log(torch.Tensor(scores)))).tolist()
                 predictions[output_column]['selfaware_confidences'] = scores
-                # print(predictions[output_column]['selfaware_confidences'])
 
             if loss_confidence_arr[k] is not None:
                 predictions[output_column]['loss_confidences'] = loss_confidence_arr[k]

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -23,7 +23,7 @@ from lightwood.mixers.helpers.transform_corss_entropy_loss import TransformCross
 class NnMixer(BaseMixer):
 
     def __init__(self,
-                 selfaware=False,
+                 selfaware=True,
                  callback_on_iter=None,
                  eval_every_x_epochs=20,
                  dropout_p=0.0,
@@ -62,11 +62,11 @@ class NnMixer(BaseMixer):
         self.dropout_p = max(0.0, min(1.0, dropout_p))
         self.dynamic_parameters = {}
         self.awareness_criterion = None
-        self.awareness_scale_factor = 1/10  # scales self-aware total loss contribution
-        self.selfaware_lr_factor = 1/2      # scales self-aware learning rate compared to mixer
-        self.start_selfaware_training = False
+        self.awareness_scale_factor = 1/6  # scales self-aware total loss contribution
+        self.selfaware_lr_factor = 2/3      # scales self-aware learning rate compared to mixer
+        self.start_selfaware_training = True
         self.stop_selfaware_training = False
-        self.is_selfaware = False
+        self.is_selfaware = True
 
         self.max_confidence_per_output = []
         self.monitor = None

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -442,7 +442,7 @@ class NnMixer(BaseMixer):
 
             if awareness_arr is not None:
                 scores = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
-                scores = torch.sigmoid(torch.Tensor(scores)).tolist()
+                scores = (0.0+torch.sigmoid(torch.log(torch.Tensor(scores)))).tolist()
                 predictions[output_column]['selfaware_confidences'] = scores
                 # print(predictions[output_column]['selfaware_confidences'])
 

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -466,13 +466,9 @@ class NnMixer(BaseMixer):
 
             if awareness_arr is not None:
                 # scores: relative magnitude to last seen self-aware loss during training
-                # sum 1 to keep in R+, then log2 to rescale the scores accordingly
-                # ICP bounds linearly scale with scores (if < 1, tighter, else wider)
-                # We clamp > 1 (cases where normalizer is unsure, default to vanilla ICP bound width)
                 scaler = self.selfaware_net.base_loss
-                scores = [abs(x[k])/scaler if x[k] != 0 else 1e-5 for x in awareness_arr]
-                scores = torch.clamp(torch.log2(1+torch.Tensor(scores)), min=0.1, max=1).tolist()
-                predictions[output_column]['selfaware_confidences'] = scores
+                scores = torch.Tensor([1+(abs(x[k])/scaler) if x[k] != 0 else 1 for x in awareness_arr])
+                predictions[output_column]['selfaware_confidences'] = scores.tolist()
 
             if loss_confidence_arr[k] is not None:
                 predictions[output_column]['loss_confidences'] = loss_confidence_arr[k]

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -24,7 +24,7 @@ from lightwood.mixers.helpers.transform_corss_entropy_loss import TransformCross
 class NnMixer(BaseMixer):
 
     def __init__(self,
-                 selfaware=True,
+                 selfaware=False,
                  callback_on_iter=None,
                  eval_every_x_epochs=20,
                  dropout_p=0.0,
@@ -65,9 +65,9 @@ class NnMixer(BaseMixer):
         self.awareness_criterion = None
         self.awareness_scale_factor = 1/6  # scales self-aware total loss contribution
         self.selfaware_lr_factor = 2/3      # scales self-aware learning rate compared to mixer
-        self.start_selfaware_training = True
+        self.start_selfaware_training = False
         self.stop_selfaware_training = False
-        self.is_selfaware = True
+        self.is_selfaware = False
 
         self.max_confidence_per_output = []
         self.monitor = None

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -213,6 +213,7 @@ class NnMixer(BaseMixer):
 
         self.selfaware_optimizer_args = copy.deepcopy(self.optimizer_args)
         self.selfaware_optimizer_args['lr'] = self.selfaware_optimizer_args['lr'] * self.selfaware_lr_factor
+        self.selfaware_optimizer_args['weight_decay'] = 0.5
         self.selfaware_optimizer = self.optimizer_class(self.selfaware_net.parameters(), **self.optimizer_args)
 
         if stop_training_after_seconds is None:
@@ -440,7 +441,10 @@ class NnMixer(BaseMixer):
             predictions[output_column] = {'predictions': decoded_predictions['predictions']}
 
             if awareness_arr is not None:
-                predictions[output_column]['selfaware_confidences'] = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
+                scores = [1/abs(x[k]) if x[k] != 0 else 1/0.000001 for x in awareness_arr]
+                scores = torch.sigmoid(torch.Tensor(scores)).tolist()
+                predictions[output_column]['selfaware_confidences'] = scores
+                # print(predictions[output_column]['selfaware_confidences'])
 
             if loss_confidence_arr[k] is not None:
                 predictions[output_column]['loss_confidences'] = loss_confidence_arr[k]


### PR DESCRIPTION
## Why
The SelfAware NN job has changed slightly since it was implemented: the scores it sends to Native now should represent a "sample difficulty" estimation rather than a confidence, because that part is now handled by the ICPs in Native.

## How
This PR:
- Makes the SelfAware NN smaller
- Modifies its forward pass to only use the NnMixer input vector
- Stores mean reference "base loss" observed after training
- Changes the scores themselves to the formula: `1+(abs(selfaware(x))/reference_loss)`