### PR TITLE
Improved time budgeting for LightGBM mixer grid search

### DIFF
--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -101,13 +101,12 @@ class LightGBMMixer(BaseMixer):
                       'force_row_wise': True,
                       'device_type': self.device_str
                       }
-            if self.stop_training_after_seconds is not None:
-                params['time_budget'] = self.stop_training_after_seconds
             if objective == 'multiclass':
                 self.all_classes = self.ord_encs[col_name].categories_[0]
                 params['num_class'] = self.all_classes.size
 
-            num_iterations = 100
+            num_iterations = 50
+            kwargs = {}
 
             if self.stop_training_after_seconds is not None:
                 train_data = lightgbm.Dataset(data['train']['data'], label=data['train']['label_data'][col_name])
@@ -116,20 +115,21 @@ class LightGBMMixer(BaseMixer):
                 params['num_iterations'] = 1
                 bst = lightgbm.train(params, train_data, valid_sets=validate_data, verbose_eval=False)
                 end = time.time()
-                seconds_for_one_iteration = min(0.1, end - start)
+                seconds_for_one_iteration = max(0.1, end - start)
                 logging.info(f'A single GBM itteration takes {seconds_for_one_iteration} seconds')
                 max_itt = int(self.stop_training_after_seconds / seconds_for_one_iteration)
                 num_iterations = max(1, min(num_iterations, max_itt))
                 # Turn on grid search if training doesn't take too long using it
-                if max_itt > 10 * num_iterations and seconds_for_one_iteration < 10:
+                if max_itt >= num_iterations and seconds_for_one_iteration < 10:
                     self.grid_search = True
+                    kwargs['time_budget'] = self.stop_training_after_seconds
 
             train_data = lightgbm.Dataset(data['train']['data'], label=data['train']['label_data'][col_name])
             validate_data = lightgbm.Dataset(data['test']['data'], label=data['test']['label_data'][col_name])
             model = lgb if self.grid_search else lightgbm
-            logging.info(f'Training GBM ({model}) with {num_iterations} iterations')
+            logging.info(f'Training GBM ({model}) with {num_iterations} iterations given {self.stop_training_after_seconds} seconds constraint')
             params['num_iterations'] = num_iterations
-            bst = model.train(params, train_data, valid_sets=validate_data, verbose_eval=False)
+            bst = model.train(params, train_data, valid_sets=validate_data, verbose_eval=False, **kwargs)
 
             self.models[col_name] = bst
 

--- a/lightwood/mixers/lightgbm.py
+++ b/lightwood/mixers/lightgbm.py
@@ -33,7 +33,6 @@ class LightGBMMixer(BaseMixer):
         self.ord_encs = {}
         self.label_sets = {}
         self.stop_training_after_seconds = stop_training_after_seconds
-        self.grid_search = grid_search  # using Optuna
 
         # GPU Only available via --install-option=--gpu with opencl-dev and libboost dev (a bunch of them) installed, so let's turn this off for now and we can put it behind some flag later
         self.device, _ = get_devices()
@@ -101,33 +100,18 @@ class LightGBMMixer(BaseMixer):
                       'force_row_wise': True,
                       'device_type': self.device_str
                       }
+            if self.stop_training_after_seconds is not None:
+                params['time_budget'] = self.stop_training_after_seconds
             if objective == 'multiclass':
                 self.all_classes = self.ord_encs[col_name].categories_[0]
                 params['num_class'] = self.all_classes.size
 
             num_iterations = 100
-
-            if self.stop_training_after_seconds is not None:
-                train_data = lightgbm.Dataset(data['train']['data'], label=data['train']['label_data'][col_name])
-                validate_data = lightgbm.Dataset(data['test']['data'], label=data['test']['label_data'][col_name])
-                start = time.time()
-                params['num_iterations'] = 1
-                bst = lightgbm.train(params, train_data, valid_sets=validate_data, verbose_eval=False)
-                end = time.time()
-                seconds_for_one_iteration = min(0.1, end - start)
-                logging.info(f'A single GBM itteration takes {seconds_for_one_iteration} seconds')
-                max_itt = int(self.stop_training_after_seconds/seconds_for_one_iteration)
-                num_iterations = max(1, min(num_iterations, max_itt))
-                # Turn on grid search if training doesn't take too long using it
-                if max_itt > 10*num_iterations and seconds_for_one_iteration < 10:
-                    self.grid_search = True
-
             train_data = lightgbm.Dataset(data['train']['data'], label=data['train']['label_data'][col_name])
             validate_data = lightgbm.Dataset(data['test']['data'], label=data['test']['label_data'][col_name])
-            model = lgb if self.grid_search else lightgbm
-            logging.info(f'Training GBM ({model}) with {num_iterations} iterations')
+            logging.info(f'Training GBM ({lgb}) with {num_iterations} iterations')
             params['num_iterations'] = num_iterations
-            bst = model.train(params, train_data, valid_sets=validate_data, verbose_eval=False)
+            bst = lgb.train(params, train_data, valid_sets=validate_data, verbose_eval=False)
 
             self.models[col_name] = bst
 


### PR DESCRIPTION
## Why

Solves #404 

## How
- fix bug in `seconds_for_one_iteration` definition
- add `time_budget` keyword argument for Optuna LightGBMTuner, forcing at most `stop_training_after_seconds` seconds of grid search