### PR TITLE
Fix ts errfunc nn mixer

### DIFF
--- a/lightwood/helpers/torch.py
+++ b/lightwood/helpers/torch.py
@@ -3,7 +3,6 @@ import itertools
 import warnings
 import torch
 from torch.nn.functional import pad
-from torch.utils.data import SequentialSampler
 from lightwood.helpers.device import get_devices
 
 
@@ -25,23 +24,6 @@ def average_vectors(vec_list):
     assert len(vec_list) > 0
     return torch.cat([emb[None] for emb in vec_list], dim=0).mean(0)
 
-
-class NotNullSampler(SequentialSampler):
-    def __init__(self, ds):
-        super().__init__(self)
-        self.incomplete_rows = self.get_incomplete_rows(ds)
-
-    def get_incomplete_rows(self, ds):
-        temporal_features = [feat for feat in ds.input_features if feat['type'] == 'time_series']
-        incomplete_rows = set()
-        for tf in temporal_features:
-            incomplete_rows.add([idx for idx, row in ds.data_frame.iterrows() if not all(row['T'])])
-        return incomplete_rows
-
-    def __iter__(self):
-        for idx in range(len(self.data_source)):
-            if idx not in self.incomplete_rows:
-                yield idx
 
 class LightwoodAutocast:
     """

--- a/lightwood/helpers/torch.py
+++ b/lightwood/helpers/torch.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 import warnings
 import torch
 from torch.nn.functional import pad

--- a/lightwood/helpers/torch.py
+++ b/lightwood/helpers/torch.py
@@ -1,7 +1,9 @@
 import functools
+import itertools
 import warnings
 import torch
 from torch.nn.functional import pad
+from torch.utils.data import SequentialSampler
 from lightwood.helpers.device import get_devices
 
 
@@ -23,6 +25,23 @@ def average_vectors(vec_list):
     assert len(vec_list) > 0
     return torch.cat([emb[None] for emb in vec_list], dim=0).mean(0)
 
+
+class NotNullSampler(SequentialSampler):
+    def __init__(self, ds):
+        super().__init__(self)
+        self.incomplete_rows = self.get_incomplete_rows(ds)
+
+    def get_incomplete_rows(self, ds):
+        temporal_features = [feat for feat in ds.input_features if feat['type'] == 'time_series']
+        incomplete_rows = set()
+        for tf in temporal_features:
+            incomplete_rows.add([idx for idx, row in ds.data_frame.iterrows() if not all(row['T'])])
+        return incomplete_rows
+
+    def __iter__(self):
+        for idx in range(len(self.data_source)):
+            if idx not in self.incomplete_rows:
+                yield idx
 
 class LightwoodAutocast:
     """

--- a/lightwood/mixers/base_mixer.py
+++ b/lightwood/mixers/base_mixer.py
@@ -55,7 +55,7 @@ class BaseMixer:
 
         # why is this done? I assume it's a first-iter initialization of
         # something and we can move it to DataSource.__iter__
-        _, _ = when_data_source[0]
+        _ = when_data_source[0]
 
         return self._predict(when_data_source, **kwargs)
 

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -772,10 +772,6 @@ class NnMixer(BaseMixer):
                     predictions[output_column]['encoded_predictions']
                 )['predictions']
 
-                if isinstance(self.net, ArNet):
-                    # for time series, only consider rows w/full historical context
-                    preds = np.delete(preds, ds.ts_incomplete_rows)
-
                 alternative_accuracy = BaseMixer._apply_accuracy_function(
                     ds.get_column_config(output_column)['type'],
                     reals,

--- a/lightwood/mixers/nn.py
+++ b/lightwood/mixers/nn.py
@@ -208,8 +208,8 @@ class NnMixer(BaseMixer):
                         self.criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice))
                         self.unreduced_criterion_arr.append(torch.nn.BCEWithLogitsLoss(weight=weights_slice, reduction='none'))
                 elif is_ts_target:
-                    self.criterion_arr.append(torch.nn.MSELoss())
-                    self.unreduced_criterion_arr.append(torch.nn.MSELoss(reduction='none'))
+                    self.criterion_arr.append(torch.nn.L1Loss())
+                    self.unreduced_criterion_arr.append(torch.nn.L1Loss(reduction='none'))
                 # Note: MSELoss works great for numeric, for the other types it's more of a placeholder
                 else:
                     self.criterion_arr.append(torch.nn.MSELoss())


### PR DESCRIPTION
## Why

For time series tasks, the rows without complete historical context were being considered for the error computation. As those are hard to get right, their contribution ended up dominating the error magnitude. This PR removes ignores those rows for improved accuracy.

## How
A simple filter done in `_error` and `calculate_accuracy` methods.