### PR TITLE
Improved normalization in plain TS encoder

### DIFF
--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -355,7 +355,7 @@ class DataSource(Dataset):
             )
         else:
             # joint column data augmentation for time series
-            if config['type'] == ColumnDataTypes.TIME_SERIES and not is_target and '__mdb_ts_previous' not in config['name']:
+            if config['type'] == ColumnDataTypes.TIME_SERIES and not is_target:
                 encoder_instance.prepare(column_data, previous_target_data=training_data['previous'])
             else:
                 encoder_instance.prepare(column_data)
@@ -413,14 +413,14 @@ class DataSource(Dataset):
                                                             training_data=input_encoder_training_data)
             encoders[column_name] = encoder_instance
 
-            if column_name not in previous_cols:
-                if config['type'] == ColumnDataTypes.TIME_SERIES and len(input_encoder_training_data['previous']) > 0:
-                    for d in input_encoder_training_data['previous']:
-                        try:
-                            if not d['name'] in config['depends_on_column']:
-                                config['depends_on_column'].append(d['name'])
-                        except KeyError:
-                            config['depends_on_column'] = [d['name']]
+            # if column_name not in previous_cols:
+            if config['type'] == ColumnDataTypes.TIME_SERIES and len(input_encoder_training_data['previous']) > 0:
+                for d in input_encoder_training_data['previous']:
+                    try:
+                        if not d['name'] in config['depends_on_column']:
+                            config['depends_on_column'].append(d['name'])
+                    except KeyError:
+                        config['depends_on_column'] = [d['name']]
 
         # train time series output encoder
         for config in self.config['output_features']:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -413,7 +413,6 @@ class DataSource(Dataset):
                                                             training_data=input_encoder_training_data)
             encoders[column_name] = encoder_instance
 
-            # if column_name not in previous_cols:
             if config['type'] == ColumnDataTypes.TIME_SERIES and len(input_encoder_training_data['previous']) > 0:
                 for d in input_encoder_training_data['previous']:
                     try:

--- a/lightwood/api/data_source.py
+++ b/lightwood/api/data_source.py
@@ -371,12 +371,10 @@ class DataSource(Dataset):
         input_encoder_training_data = {'targets': [], 'previous': []}
 
         # handle time series previous target columns
-        previous_cols = []
         for config in self.config['input_features']:
             column_name = config['name']
             if column_name.startswith('__mdb_ts_previous_'):
                 column_data = self.get_column_original_data(column_name)
-                previous_cols.append(column_name)
                 col_info = {'data': column_data,
                             'name': column_name,
                             'original_type': config['original_type'],

--- a/lightwood/encoders/time_series/plain.py
+++ b/lightwood/encoders/time_series/plain.py
@@ -1,8 +1,10 @@
 import torch
+import numpy as np
+from itertools import product
 
 from lightwood.encoders.encoder_base import BaseEncoder
 from lightwood.constants.lightwood import COLUMN_DATA_TYPES
-from lightwood.encoders.time_series.helpers.common import MinMaxNormalizer, CatNormalizer
+from lightwood.encoders.time_series.helpers.common import MinMaxNormalizer, CatNormalizer, get_group_matches
 
 
 class TimeSeriesPlainEncoder(BaseEncoder):
@@ -13,24 +15,30 @@ class TimeSeriesPlainEncoder(BaseEncoder):
         """
         super().__init__(is_target)
         self.original_type = None
-        self._normalizer = None
+        self._normalizers = {}
 
-    def prepare(self, priming_data):
+    def prepare(self, priming_data, previous_target_data):
         if self._prepared:
             raise Exception('You can only call "prepare" once for a given encoder.')
 
-        if self.original_type == COLUMN_DATA_TYPES.CATEGORICAL:
-            self._normalizer = CatNormalizer(encoder_class='ordinal')
-        else:
-            self._normalizer = MinMaxNormalizer()
+        for group_name, norm in previous_target_data[0]['normalizers'].items():
+            self._normalizers[group_name] = norm
 
-        self._normalizer.prepare(priming_data)
         self._prepared = True
 
-    def encode(self, column_data):
+    def encode(self, column_data, group_info):
         if not self._prepared:
             raise Exception('You need to call "prepare" before calling "encode" or "decode".')
-        data = torch.cat([self._normalizer.encode(column_data)], dim=-1)
+
+        raw_data = np.array(column_data)
+        data = torch.cat([self._normalizers['__default'].encode(raw_data)], dim=-1)  # refined with group info
+
+        for combination in list(product(*[set(x) for x in group_info[0]['group_info'].values()])):
+            combination = frozenset(combination)
+            idxs, subset = get_group_matches(group_info[0], combination, group_info[0]['group_info'].keys())
+            if subset.size > 0:
+                data[idxs] =  self._normalizers[combination].encode(subset)
+
         data[torch.isnan(data)] = 0.0
         data[torch.isinf(data)] = 0.0
         return data

--- a/lightwood/encoders/time_series/plain.py
+++ b/lightwood/encoders/time_series/plain.py
@@ -36,7 +36,7 @@ class TimeSeriesPlainEncoder(BaseEncoder):
         for combination in list(product(*[set(x) for x in group_info[0]['group_info'].values()])):
             combination = frozenset(combination)
             idxs, subset = get_group_matches(group_info[0], combination, group_info[0]['group_info'].keys())
-            if subset.size > 0:
+            if subset.size > 0 and self._normalizers.get(combination, False):
                 data[idxs] =  self._normalizers[combination].encode(subset)
 
         data[torch.isnan(data)] = 0.0


### PR DESCRIPTION
## Why
To improve MindsDB time series capabilities

## How
Instead of having its own normalizer, now the "plain" time series encoder (used to estimate the autoregressive weights in ArNet) further refines its output if the group combination has a matching normalizer that was trained in the standard time series encoder.