### PR TITLE
LightwoodEnsemble

### DIFF
--- a/lightwood/api/ensemble.py
+++ b/lightwood/api/ensemble.py
@@ -1,14 +1,13 @@
-from .predictor import Predictor
+from lightwood import Predictor
 from lightwood.constants.lightwood import ColumnDataTypes
 from collections import Counter
 import numpy as np
 import pickle
-import torch
 import os
 
 
 class LightwoodEnsemble:
-    def __init__(self, predictor=None, predictors=None, load_from_path=None):
+    def __init__(self, predictors=None, load_from_path=None):
         self.path_list = None
         if load_from_path is not None:
             with open(os.path.join(load_from_path, 'lightwood_data'), 'rb') as pickle_in:
@@ -16,7 +15,7 @@ class LightwoodEnsemble:
                 self.path = load_from_path
                 self.path_list = obj.path_list
                 self.ensemble = [Predictor(load_from_path=path) for path in self.path_list]
-        elif predictor is not None:
+        elif isinstance(predictors, Predictor):
             self.ensemble = [predictor]
         elif isinstance(predictors, list):
             self.ensemble = predictors
@@ -43,6 +42,8 @@ class LightwoodEnsemble:
                 final_preds = []
                 for idx in range(pred_arr.shape[1]):
                     final_preds.append(max(Counter(pred_arr[:, idx])))
+            else:
+                raise Exception('Only numeric and categorical datatypes are supported for ensembles')
 
             formatted_predictions[target_name]['predictions'] = final_preds
 
@@ -58,7 +59,7 @@ class LightwoodEnsemble:
 
         self.path_list = path_list
 
-        # TODO: in future, just save them inside this data struct
+        # TODO: in the future, save preds inside this data struct
         self.ensemble = None  # we deref predictors for now
         with open(os.path.join(path_to, 'lightwood_data'), 'wb') as file:
             pickle.dump(self, file, pickle.HIGHEST_PROTOCOL)

--- a/lightwood/api/ensemble.py
+++ b/lightwood/api/ensemble.py
@@ -16,7 +16,7 @@ class LightwoodEnsemble:
                 self.path_list = obj.path_list
                 self.ensemble = [Predictor(load_from_path=path) for path in self.path_list]
         elif isinstance(predictors, Predictor):
-            self.ensemble = [predictor]
+            self.ensemble = [predictors]
         elif isinstance(predictors, list):
             self.ensemble = predictors
 

--- a/lightwood/api/ensemble.py
+++ b/lightwood/api/ensemble.py
@@ -39,9 +39,7 @@ class LightwoodEnsemble:
             if target['type'] == ColumnDataTypes.NUMERIC:
                 final_preds = np.mean(pred_arr, axis=0).tolist()
             elif target['type'] == ColumnDataTypes.CATEGORICAL:
-                final_preds = []
-                for idx in range(pred_arr.shape[1]):
-                    final_preds.append(max(Counter(pred_arr[:, idx])))
+                final_preds = [max(Counter(pred_arr[:, idx])) for idx in range(pred_arr.shape[1])]
             else:
                 raise Exception('Only numeric and categorical datatypes are supported for ensembles')
 

--- a/lightwood/api/ensemble.py
+++ b/lightwood/api/ensemble.py
@@ -1,5 +1,6 @@
 from .predictor import Predictor
 from lightwood.constants.lightwood import ColumnDataTypes
+from collections import Counter
 import numpy as np
 import pickle
 import torch
@@ -39,8 +40,9 @@ class LightwoodEnsemble:
             if target['type'] == ColumnDataTypes.NUMERIC:
                 final_preds = np.mean(pred_arr, axis=0).tolist()
             elif target['type'] == ColumnDataTypes.CATEGORICAL:
-                # TODO: pending
-                final_preds = np.zeros(1, pred_arr.shape[1])
+                final_preds = []
+                for idx in range(pred_arr.shape[1]):
+                    final_preds.append(max(Counter(pred_arr[:, idx])))
 
             formatted_predictions[target_name]['predictions'] = final_preds
 

--- a/lightwood/api/ensemble.py
+++ b/lightwood/api/ensemble.py
@@ -1,0 +1,62 @@
+from .predictor import Predictor
+from lightwood.constants.lightwood import ColumnDataTypes
+import numpy as np
+import pickle
+import torch
+import os
+
+
+class LightwoodEnsemble:
+    def __init__(self, predictor=None, predictors=None, load_from_path=None):
+        self.path_list = None
+        if load_from_path is not None:
+            with open(os.path.join(load_from_path, 'lightwood_data'), 'rb') as pickle_in:
+                obj = pickle.load(pickle_in)
+                self.path = load_from_path
+                self.path_list = obj.path_list
+                self.ensemble = [Predictor(load_from_path=path) for path in self.path_list]
+        elif predictor is not None:
+            self.ensemble = [predictor]
+        elif isinstance(predictors, list):
+            self.ensemble = predictors
+
+    def append(self, predictor):
+        if isinstance(self.ensemble, list):
+            self.ensemble.append(predictor)
+        else:
+            self.ensemble = [predictor]
+
+    def __iter__(self):
+        yield self.ensemble
+
+    def predict(self, when_data):
+        predictions = [p.predict(when_data=when_data) for p in self.ensemble]
+        formatted_predictions = {}
+        for target in self.ensemble[0].config['output_features']:
+            target_name = target['name']
+            formatted_predictions[target_name] = {}
+            pred_arr = np.array([p[target_name]['predictions'] for p in predictions])
+            if target['type'] == ColumnDataTypes.NUMERIC:
+                final_preds = np.mean(pred_arr, axis=0).tolist()
+            elif target['type'] == ColumnDataTypes.CATEGORICAL:
+                # TODO: pending
+                final_preds = np.zeros(1, pred_arr.shape[1])
+
+            formatted_predictions[target_name]['predictions'] = final_preds
+
+        return formatted_predictions
+
+    def save(self, path_to):
+        # TODO: potentially save predictors inside ensemble pickle, though there's the issue of nonpersistent stuff with torch.save()
+        path_list = []
+        for i, model in enumerate(self.ensemble):
+            path = os.path.join(path_to, f'lightwood_predictor_{i}')
+            path_list.append(path)
+            model.save(path_to=path)
+
+        self.path_list = path_list
+
+        # TODO: in future, just save them inside this data struct
+        self.ensemble = None  # we deref predictors for now
+        with open(os.path.join(path_to, 'lightwood_data'), 'wb') as file:
+            pickle.dump(self, file, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
## Why
To continuously train predictors from streams of data.

## How
Added a `LightwoodEnsemble` class that holds and uses an array of `Predictor`s to operate.

As this is a proof of concept, predictions for now are extremely simple: mode is taken for classification targets, and mean for regression targets.