### PR TITLE
Fixes -- #459 #462

### DIFF
--- a/lightwood/analysis/model_analyzer.py
+++ b/lightwood/analysis/model_analyzer.py
@@ -62,6 +62,7 @@ def model_analyzer(
     disable_column_importance = disable_column_importance or ts_cfg.is_timeseries or has_pretrained_text_enc
 
     data = encoded_data.data_frame
+    tr_data = encoded_train_data.data_frame
     runtime_analyzer = {}
     predictions = {}
     input_cols = list([col for col in data.columns if col != target])
@@ -130,11 +131,12 @@ def model_analyzer(
         elif is_multi_ts:
             # we fit ICPs for time series confidence bounds only at t+1 forecast
             icp.nc_function.model.prediction_cache = np.array([p[0] for p in normal_predictions['prediction']])
-
         else:
             icp.nc_function.model.prediction_cache = np.array(normal_predictions['prediction'])
 
         if not is_classification:
+            data[target] = data[target].astype(float)
+            tr_data[target] = tr_data[target].astype(float)
             runtime_analyzer['df_std_dev'] = {'__default': stats_info.df_std_dev}
 
         # fit additional ICPs in time series tasks with grouped columns

--- a/lightwood/analysis/model_analyzer.py
+++ b/lightwood/analysis/model_analyzer.py
@@ -62,7 +62,6 @@ def model_analyzer(
     disable_column_importance = disable_column_importance or ts_cfg.is_timeseries or has_pretrained_text_enc
 
     data = encoded_data.data_frame
-    tr_data = encoded_train_data.data_frame
     runtime_analyzer = {}
     predictions = {}
     input_cols = list([col for col in data.columns if col != target])
@@ -135,8 +134,6 @@ def model_analyzer(
             icp.nc_function.model.prediction_cache = np.array(normal_predictions['prediction'])
 
         if not is_classification:
-            data[target] = data[target].astype(float)
-            tr_data[target] = tr_data[target].astype(float)
             runtime_analyzer['df_std_dev'] = {'__default': stats_info.df_std_dev}
 
         # fit additional ICPs in time series tasks with grouped columns

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -145,15 +145,18 @@ def generate_json_ai(type_information: TypeInformation, statistical_analysis: St
                     'stop_after': '$problem_definition.seconds_per_model',
                     'n_ts_predictions': '$problem_definition.timeseries_settings.nr_predictions'
                 }
-            },
-                {
-                'module': 'SkTime',
-                'args': {
-                    'stop_after': '$problem_definition.seconds_per_model',
-                    'n_ts_predictions': '$problem_definition.timeseries_settings.nr_predictions',
-                },
-            }
-            ])
+            }])
+
+            if problem_definition.timeseries_settings.use_previous_target:
+                models.extend([
+                    {
+                    'module': 'SkTime',
+                    'args': {
+                        'stop_after': '$problem_definition.seconds_per_model',
+                        'n_ts_predictions': '$problem_definition.timeseries_settings.nr_predictions',
+                    },
+                }
+                ])
 
     outputs = {target: Output(
         data_dtype=type_information.dtypes[target],
@@ -298,7 +301,9 @@ def add_implicit_values(json_ai: JsonAI) -> JsonAI:
             models[i]['args']['timeseries_settings'] = models[i]['args'].get(
                 'timeseries_settings', '$problem_definition.timeseries_settings')
             models[i]['args']['net'] = models[i]['args'].get(
-                'net', '"DefaultNet"' if not problem_definition.timeseries_settings.is_timeseries else '"ArNet"')
+                'net', '"DefaultNet"' if not problem_definition.timeseries_settings.is_timeseries
+                                         or not problem_definition.timeseries_settings.use_previous_target
+                else '"ArNet"')
 
         elif models[i]['module'] == 'LightGBM':
             models[i]['args']['target'] = models[i]['args'].get('target', '$target')

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -150,12 +150,12 @@ def generate_json_ai(type_information: TypeInformation, statistical_analysis: St
             if problem_definition.timeseries_settings.use_previous_target:
                 models.extend([
                     {
-                    'module': 'SkTime',
-                    'args': {
-                        'stop_after': '$problem_definition.seconds_per_model',
-                        'n_ts_predictions': '$problem_definition.timeseries_settings.nr_predictions',
-                    },
-                }
+                        'module': 'SkTime',
+                        'args': {
+                            'stop_after': '$problem_definition.seconds_per_model',
+                            'n_ts_predictions': '$problem_definition.timeseries_settings.nr_predictions',
+                        },
+                    }
                 ])
 
     outputs = {target: Output(
@@ -302,7 +302,7 @@ def add_implicit_values(json_ai: JsonAI) -> JsonAI:
                 'timeseries_settings', '$problem_definition.timeseries_settings')
             models[i]['args']['net'] = models[i]['args'].get(
                 'net', '"DefaultNet"' if not problem_definition.timeseries_settings.is_timeseries
-                                         or not problem_definition.timeseries_settings.use_previous_target
+                or not problem_definition.timeseries_settings.use_previous_target
                 else '"ArNet"')
 
         elif models[i]['module'] == 'LightGBM':

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -346,7 +346,8 @@ def add_implicit_values(json_ai: JsonAI) -> JsonAI:
                 'dtype_dict': '$dtype_dict',
                 'target': '$target',
                 'mode': '$mode',
-                'timeseries_settings': '$problem_definition.timeseries_settings'
+                'timeseries_settings': '$problem_definition.timeseries_settings',
+                'anomaly_detection': '$problem_definition.anomaly_detection'
             }
         }
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -103,7 +103,8 @@ def cleaner(
         data: pd.DataFrame, dtype_dict: Dict[str, str],
         pct_invalid: float, ignore_features: List[str],
         identifiers: Dict[str, str],
-        target: str, mode: str, timeseries_settings: TimeseriesSettings) -> pd.DataFrame:
+        target: str, mode: str, timeseries_settings: TimeseriesSettings,
+        anomaly_detection: bool) -> pd.DataFrame:
     # Drop columns we don't want to use
     data = deepcopy(data)
     to_drop = [*ignore_features, *list(identifiers.keys())]
@@ -116,6 +117,9 @@ def cleaner(
 
     if mode == 'train':
         data = clean_empty_targets(data, target)
+    if mode == 'predict':
+        if target in data.columns and not timeseries_settings.use_previous_target and not anomaly_detection:
+            data = data.drop(columns=[target])
 
     # Drop extra columns
     for name in list(data.columns):

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -103,8 +103,7 @@ def cleaner(
         data: pd.DataFrame, dtype_dict: Dict[str, str],
         pct_invalid: float, ignore_features: List[str],
         identifiers: Dict[str, str],
-        target: str, mode: str, timeseries_settings: TimeseriesSettings,
-        anomaly_detection: bool) -> pd.DataFrame:
+        target: str, mode: str, timeseries_settings: TimeseriesSettings, anomaly_detection: bool) -> pd.DataFrame:
     # Drop columns we don't want to use
     data = deepcopy(data)
     to_drop = [*ignore_features, *list(identifiers.keys())]

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -155,4 +155,9 @@ def cleaner(
 
         data[name] = new_data
 
+        if data_dtype == dtype.integer:
+            data[name] = data[name].astype(int)
+        elif data_dtype in (dtype.float, dtype.array):
+            data[name] = data[name].astype(float)
+
     return data

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -116,9 +116,6 @@ def cleaner(
 
     if mode == 'train':
         data = clean_empty_targets(data, target)
-    if mode == 'predict':
-        if target in data.columns and not timeseries_settings.use_previous_target:
-            data = data.drop(columns=[target])
 
     # Drop extra columns
     for name in list(data.columns):

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -49,7 +49,8 @@ def statistical_analysis(data: pd.DataFrame,
     seed()
     log.info('Starting statistical analysis')
     df = cleaner(data, dtypes, problem_definition.pct_invalid, problem_definition.ignore_features,
-                 identifiers, problem_definition.target, 'train', problem_definition.timeseries_settings)
+                 identifiers, problem_definition.target, 'train', problem_definition.timeseries_settings,
+                 problem_definition.anomaly_detection)
 
     missing = {col: len([x for x in df[col] if x is None]) / len(df[col]) for col in df.columns}
     distinct = {col: len(set(df[col])) / len(df[col]) for col in df.columns}

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -227,8 +227,6 @@ def _ts_add_previous_rows(df, historical_columns, window):
 def _ts_add_previous_target(df, target, window, data_dtype):
     if target not in df:
         return df
-    if data_dtype in (dtype.integer, dtype.float, dtype.array):
-        df[target] = df[target].astype(float)
     previous_target_values = list(df[target])
     del previous_target_values[-1]
     previous_target_values = [None] + previous_target_values

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -101,12 +101,11 @@ def transform_timeseries(
             partial(
                 _ts_add_previous_rows, historical_columns=ob_arr + tss.historical_columns, window=window),
             df_arr)
-        if tss.use_previous_target:
-            df_arr = pool.map(
-                partial(
-                    _ts_add_previous_target, target=target, nr_predictions=tss.nr_predictions,
-                    window=tss.window, data_dtype=tss.target_type, mode=mode),
-                df_arr)
+        df_arr = pool.map(
+            partial(
+                _ts_add_previous_target, target=target, nr_predictions=tss.nr_predictions,
+                window=tss.window, data_dtype=tss.target_type, mode=mode),
+            df_arr)
         pool.close()
         pool.join()
     else:
@@ -115,11 +114,10 @@ def transform_timeseries(
             df_arr[i] = _ts_order_col_to_cell_lists(df_arr[i], historical_columns=ob_arr + tss.historical_columns)
             df_arr[i] = _ts_add_previous_rows(df_arr[i],
                                               historical_columns=ob_arr + tss.historical_columns, window=window)
-            if tss.use_previous_target:
-                df_arr[i] = _ts_add_previous_target(
-                    df_arr[i],
-                    target=target, nr_predictions=tss.nr_predictions, window=tss.window, data_dtype=tss.target_type,
-                    mode=mode)
+            df_arr[i] = _ts_add_previous_target(
+                df_arr[i],
+                target=target, nr_predictions=tss.nr_predictions, window=tss.window, data_dtype=tss.target_type,
+                mode=mode)
 
     combined_df = pd.concat(df_arr)
 

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -101,11 +101,17 @@ def transform_timeseries(
             partial(
                 _ts_add_previous_rows, historical_columns=ob_arr + tss.historical_columns, window=window),
             df_arr)
-        df_arr = pool.map(
-            partial(
-                _ts_add_previous_target, target=target, nr_predictions=tss.nr_predictions,
-                window=tss.window, data_dtype=tss.target_type, mode=mode),
-            df_arr)
+
+        df_arr = pool.map(partial(_ts_add_future_target, target=target, nr_predictions=tss.nr_predictions,
+                                  data_dtype=tss.target_type, mode=mode),
+                          df_arr)
+
+        if tss.use_previous_target:
+            df_arr = pool.map(
+                partial(
+                    _ts_add_previous_target, target=target, nr_predictions=tss.nr_predictions,
+                    window=tss.window, data_dtype=tss.target_type, mode=mode),
+                df_arr)
         pool.close()
         pool.join()
     else:
@@ -114,10 +120,11 @@ def transform_timeseries(
             df_arr[i] = _ts_order_col_to_cell_lists(df_arr[i], historical_columns=ob_arr + tss.historical_columns)
             df_arr[i] = _ts_add_previous_rows(df_arr[i],
                                               historical_columns=ob_arr + tss.historical_columns, window=window)
-            df_arr[i] = _ts_add_previous_target(
-                df_arr[i],
-                target=target, nr_predictions=tss.nr_predictions, window=tss.window, data_dtype=tss.target_type,
-                mode=mode)
+            df_arr[i] = _ts_add_future_target(df_arr[i], target=target, nr_predictions=tss.nr_predictions,
+                                              data_dtype=tss.target_type, mode=mode)
+            if tss.use_previous_target:
+                df_arr[i] = _ts_add_previous_target(df_arr[i], target=target, window=tss.window,
+                                                    data_dtype=tss.target_type)
 
     combined_df = pd.concat(df_arr)
 
@@ -217,7 +224,7 @@ def _ts_add_previous_rows(df, historical_columns, window):
     return df
 
 
-def _ts_add_previous_target(df, target, nr_predictions, window, data_dtype, mode):
+def _ts_add_previous_target(df, target, window, data_dtype):
     if target not in df:
         return df
     if data_dtype in (dtype.integer, dtype.float, dtype.array):
@@ -234,6 +241,15 @@ def _ts_add_previous_target(df, target, nr_predictions, window, data_dtype, mode
         previous_target_values_arr.append(arr)
 
     df[f'__mdb_ts_previous_{target}'] = previous_target_values_arr
+    return df
+
+
+def _ts_add_future_target(df, target, nr_predictions, data_dtype, mode):
+    if target not in df:
+        return df
+    if data_dtype in (dtype.integer, dtype.float, dtype.array):
+        df[target] = df[target].astype(float)
+
     for timestep_index in range(1, nr_predictions):
         next_target_value_arr = list(df[target])
         for del_index in range(0, min(timestep_index, len(next_target_value_arr))):

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -109,8 +109,8 @@ def transform_timeseries(
         if tss.use_previous_target:
             df_arr = pool.map(
                 partial(
-                    _ts_add_previous_target, target=target, nr_predictions=tss.nr_predictions,
-                    window=tss.window, data_dtype=tss.target_type, mode=mode),
+                    _ts_add_previous_target, target=target,
+                    window=tss.window, data_dtype=tss.target_type),
                 df_arr)
         pool.close()
         pool.join()

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -1,4 +1,5 @@
 import random
+from typing import Union
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
@@ -11,7 +12,8 @@ from lightwood.model.helpers.default_net import DefaultNet
 
 
 class CategoricalAutoEncoder(BaseEncoder):
-    def __init__(self, stop_after: int = 3600, is_target=False, max_encoded_length=100, use_autoencoder=None):
+    def __init__(self, stop_after: int = 3600, is_target: bool = False, max_encoded_length: int = 100,
+                 use_autoencoder: Union[bool, None] = None):
         super().__init__(is_target)
         self._prepared = False
         self.name = 'Categorical Autoencoder'

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -11,7 +11,7 @@ from lightwood.model.helpers.default_net import DefaultNet
 
 
 class CategoricalAutoEncoder(BaseEncoder):
-    def __init__(self, stop_after: int = 3600, is_target=False, max_encoded_length=100):
+    def __init__(self, stop_after: int = 3600, is_target=False, max_encoded_length=100, use_autoencoder=None):
         super().__init__(is_target)
         self._prepared = False
         self.name = 'Categorical Autoencoder'
@@ -20,7 +20,7 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.decoder = None
         self.onehot_encoder = OneHotEncoder(is_target=self.is_target)
         self.desired_error = 0.01
-        self.use_autoencoder = None
+        self.use_autoencoder = use_autoencoder
         self.stop_after = stop_after
         # @TODO stop using instead of ONEHOT !!!@!
         self.is_nn_encoder = True
@@ -50,7 +50,8 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.onehot_encoder.prepare(priming_data)
 
         input_len = self.onehot_encoder._lang.n_words
-        self.use_autoencoder = self.max_encoded_length is not None and input_len > self.max_encoded_length
+        if self.use_autoencoder is None:
+            self.use_autoencoder = self.max_encoded_length is not None and input_len > self.max_encoded_length
 
         if self.use_autoencoder:
             log.info('Preparing a categorical autoencoder, this might take a while')

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -17,7 +17,7 @@ def evaluate_accuracy(data: pd.DataFrame,
         if accuracy_function_str == 'evaluate_array_accuracy':
             nr_predictions = len(predictions.iloc[0])
             cols = [target] + [f'{target}_timestep_{i}' for i in range(1, nr_predictions)]
-            true_values = data[cols].values.tolist()
+            true_values = data[cols].astype(float).values.tolist()
             accuracy_function = evaluate_array_accuracy
         else:
             true_values = data[target].tolist()
@@ -52,7 +52,6 @@ def evaluate_array_accuracy(
         predictions: List[List[Union[int, float]]],
         **kwargs
 ) -> float:
-
     aggregate = 0
 
     for i in range(len(predictions)):

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -17,7 +17,7 @@ def evaluate_accuracy(data: pd.DataFrame,
         if accuracy_function_str == 'evaluate_array_accuracy':
             nr_predictions = len(predictions.iloc[0])
             cols = [target] + [f'{target}_timestep_{i}' for i in range(1, nr_predictions)]
-            true_values = data[cols].astype(float).values.tolist()
+            true_values = data[cols].values.tolist()
             accuracy_function = evaluate_array_accuracy
         else:
             true_values = data[target].tolist()

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -45,50 +45,49 @@ class TestTimeseries(unittest.TestCase):
         target = 'Traffic'
         order_by = 'T'
 
-        # Test multiple predictors playing along together
-        pred_arr = {}
+        # Predictor #1: no anomalies + no autoregressiveness
         nr_preds = 1
-        pred_arr[1] = predictor_from_problem(data,
-                                             ProblemDefinition.from_dict({'target': target,
-                                                                          'nfolds': 10,
-                                                                          'anomaly_detection': False,
-                                                                          'timeseries_settings': {
-                                                                              'use_previous_target': False,
-                                                                              'nr_predictions': nr_preds,
-                                                                              'order_by': [order_by],
-                                                                              'window': 5}
-                                                                          }))
-        pred_arr[1].learn(data)
-        preds = pred_arr[1].predict(data[0:10])
+        pred = predictor_from_problem(data,
+                                      ProblemDefinition.from_dict({'target': target,
+                                                                   'nfolds': 10,
+                                                                   'anomaly_detection': False,
+                                                                   'timeseries_settings': {
+                                                                       'use_previous_target': False,
+                                                                       'nr_predictions': nr_preds,
+                                                                       'order_by': [order_by],
+                                                                       'window': 5}
+                                                                   }))
+        pred.learn(data)
+        preds = pred.predict(data[0:10])
         self.check_ts_prediction_df(preds, nr_preds, [order_by])
 
         # test inferring mode
         test['__mdb_make_predictions'] = False
-        preds = pred_arr[1].predict(test)
+        preds = pred.predict(test)
         self.check_ts_prediction_df(preds, nr_preds, [order_by])
 
+        # Predictor #2: anomalies + autoregressiveness + forecast horizon > 1
         nr_preds = 2
-        pred_arr[2] = predictor_from_problem(train,
-                                             ProblemDefinition.from_dict({'target': target,
-                                                                          'time_aim': 30,
-                                                                          'nfolds': 10,
-                                                                          'anomaly_detection': True,
-                                                                          'timeseries_settings': {
-                                                                              'use_previous_target': True,
-                                                                              'group_by': ['Country'],
-                                                                              'nr_predictions': nr_preds,
-                                                                              'order_by': [order_by],
-                                                                              'window': 5
-                                                                          }
-                                                                          }))
+        pred = predictor_from_problem(train,
+                                      ProblemDefinition.from_dict({'target': target,
+                                                                   'time_aim': 30,
+                                                                   'nfolds': 10,
+                                                                   'anomaly_detection': True,
+                                                                   'timeseries_settings': {
+                                                                       'use_previous_target': True,
+                                                                       'group_by': ['Country'],
+                                                                       'nr_predictions': nr_preds,
+                                                                       'order_by': [order_by],
+                                                                       'window': 5
+                                                                   }}))
 
-        pred_arr[2].learn(train)
-        preds = pred_arr[2].predict(test)
+        pred.learn(train)
+        preds = pred.predict(test)
         self.check_ts_prediction_df(preds, nr_preds, [order_by])
 
         # test inferring mode
         test['__mdb_make_predictions'] = False
-        preds = pred_arr[2].predict(test)
+        preds = pred.predict(test)
         self.check_ts_prediction_df(preds, nr_preds, [order_by])
 
         # Additionally, check timestamps are further into the future than test dates


### PR DESCRIPTION
## Why
Fixes:

- #459
- #462

## How

For #459:
- Add respective parameters to `TimeSeriesEncoder` and `CategoricalAutoEncoder` signatures

For #462:
- Use `ArNet` in the Neural model only if `use_previous_target = True`
- Add `SkTime` to predictor models only if `use_previous_target = True`
- Decouple addition of future target values from previous target values in `timeseries_transform`

### Additional changes:
- Revert to not dropping the target column in predict mode if anomaly detection mode is active
- Expanded integration test to cover `anomaly_detection` on and off _and_ `use_previous_target` on vs off
- When needed, target type casting to `float` in analysis and array accuracy helper