### PR TITLE
Reintroduce positive domain target

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -41,12 +41,14 @@ def lookup_encoder(
     }
 
     if is_target:
-        encoder_dict['args'] = {'is_target': 'True', 'positive_domain': '$statistical_analysis.positive_domain'}
+        encoder_dict['args'] = {'is_target': 'True'}
         if col_dtype in target_encoder_lookup_override:
             encoder_dict['module'] = target_encoder_lookup_override[col_dtype]
         if col_dtype in (dtype.categorical, dtype.binary):
             if problem_defintion.unbias_target:
                 encoder_dict['args'] = {'target_class_distribution': '$statistical_analysis.target_class_distribution'}
+        if col_dtype in (dtype.integer, dtype.float, dtype.array):
+            encoder_dict['args']['positive_domain'] = '$statistical_analysis.positive_domain'
 
     if tss.is_timeseries:
         gby = tss.group_by if tss.group_by is not None else []

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -41,7 +41,7 @@ def lookup_encoder(
     }
 
     if is_target:
-        encoder_dict['args'] = {'is_target': 'True'}
+        encoder_dict['args'] = {'is_target': 'True', 'positive_domain': '$statistical_analysis.positive_domain'}
         if col_dtype in target_encoder_lookup_override:
             encoder_dict['module'] = target_encoder_lookup_override[col_dtype]
         if col_dtype in (dtype.categorical, dtype.binary):
@@ -369,7 +369,7 @@ def add_implicit_values(json_ai: JsonAI) -> JsonAI:
                 'dtype_dict': '$dtype_dict',
                 'fixed_significance': None,
                 'confidence_normalizer': False,
-                'positive_domain': False,
+                'positive_domain': '$statistical_analysis.positive_domain',
             }
         }
 
@@ -378,7 +378,7 @@ def add_implicit_values(json_ai: JsonAI) -> JsonAI:
             'module': 'explain',
             'args': {
                 'timeseries_settings': '$problem_definition.timeseries_settings',
-                'positive_domain': '$problem_definition.positive_domain',
+                'positive_domain': '$statistical_analysis.positive_domain',
                 'fixed_confidence': '$problem_definition.fixed_confidence',
                 'anomaly_detection': '$problem_definition.anomaly_detection',
                 'anomaly_error_rate': '$problem_definition.anomaly_error_rate',

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -77,6 +77,7 @@ class StatisticalAnalysis:
     distinct: object
     bias: object
     avg_words_per_sentence: object
+    positive_domain: bool
 
 
 @dataclass_json

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -56,14 +56,19 @@ def statistical_analysis(data: pd.DataFrame,
 
     nr_rows = len(df)
     target = problem_definition.target
+    positive_domain = False
     # get train std, used in analysis
     if dtypes[target] in [dtype.float, dtype.integer, dtype.array]:
         df_std = df[target].astype(float).std()
+        if min(data[target]) >= 0:
+            positive_domain = True
     elif dtypes[target] in [dtype.array]:
         try:
             all_vals = []
             for x in df[target]:
                 all_vals += x
+            if min(all_vals) >= 0:
+                positive_domain = True
             df_std = pd.Series(all_vals).astype(float).std()
         except Exception as e:
             log.warning(e)
@@ -123,6 +128,7 @@ def statistical_analysis(data: pd.DataFrame,
         df_std_dev=df_std,
         train_observed_classes=train_observed_classes,
         target_class_distribution=target_class_distribution,
+        positive_domain=positive_domain,
         histograms=histograms,
         buckets=buckets,
         missing=missing,

--- a/lightwood/encoder/numeric/numeric.py
+++ b/lightwood/encoder/numeric/numeric.py
@@ -7,11 +7,11 @@ from lightwood.helpers.log import log
 
 class NumericEncoder(BaseEncoder):
 
-    def __init__(self, data_type=None, is_target=False):
+    def __init__(self, data_type=None, is_target: bool = False, positive_domain: bool = False):
         super().__init__(is_target)
         self._type = data_type
         self._abs_mean = None
-        self.positive_domain = False
+        self.positive_domain = positive_domain
         self.decode_log = False
         self.output_size = 4 if not self.is_target else 3
 

--- a/lightwood/encoder/numeric/ts_array_numeric.py
+++ b/lightwood/encoder/numeric/ts_array_numeric.py
@@ -9,14 +9,15 @@ class TsArrayNumericEncoder(BaseEncoder):
     Variant of vanilla numerical encoder, supports dynamic mean re-scaling
     """
 
-    def __init__(self, timesteps, is_target=False, grouped_by=None):
+    def __init__(self, timesteps: int, is_target: bool = False, positive_domain: bool = False, grouped_by=None):
         super(TsArrayNumericEncoder, self).__init__(is_target=is_target)
         # time series normalization params
         self.normalizers = None
-        self.sub_encoder = TsNumericEncoder(is_target=is_target, grouped_by=grouped_by)
         self.group_combinations = None
         self.dependencies = grouped_by
         self.data_window = timesteps
+        self.positive_domain = positive_domain
+        self.sub_encoder = TsNumericEncoder(is_target=is_target, positive_domain=positive_domain, grouped_by=grouped_by)
         self.output_size = self.data_window * self.sub_encoder.output_size
 
     def prepare(self, priming_data):

--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -10,8 +10,8 @@ class TsNumericEncoder(NumericEncoder):
     Variant of vanilla numerical encoder, supports dynamic mean re-scaling
     """
 
-    def __init__(self, is_target=False, grouped_by=None):
-        super(TsNumericEncoder, self).__init__(is_target=is_target)
+    def __init__(self, is_target: bool = False, positive_domain: bool = False, grouped_by=None):
+        super(TsNumericEncoder, self).__init__(is_target=is_target, positive_domain=positive_domain)
         # time series normalization params
         self.normalizers = None
         self.group_combinations = None


### PR DESCRIPTION
## Why
To reintroduce flagging a target as having positive domain (see #460).

## How
Logic was in place for the most part, but the actual check was missing from the statistical analysis + JSON AI dispatch.