### PR TITLE
Seed keyword passed

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -627,7 +627,7 @@ class Predictor(PredictorInterface):
     mode: str
 
     def __init__(self):
-        seed()
+        seed({json_ai.problem_definition.seed_nr})
         self.target = '{json_ai.problem_definition.target}'
         self.mode = 'innactive'
 

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -193,7 +193,8 @@ class ProblemDefinition:
             anomaly_cooldown=anomaly_cooldown,
             ignore_features=ignore_features,
             fit_on_validation=fit_on_validation,
-            strict_mode=strict_mode
+            strict_mode=strict_mode,
+            seed_nr=seed_nr
         )
 
         return problem_definition

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -153,6 +153,7 @@ class ProblemDefinition:
     ignore_features: List[str]
     fit_on_validation: bool
     strict_mode: bool
+    seed_nr: int
 
     @staticmethod
     def from_dict(obj: Dict):
@@ -173,6 +174,7 @@ class ProblemDefinition:
         ignore_features = obj.get('ignore_features', [])
         fit_on_validation = obj.get('fit_on_validation', True)
         strict_mode = obj.get('strict_mode', True)
+        seed_nr = obj.get('seed_nr', 420)
 
         problem_definition = ProblemDefinition(
             target=target,

--- a/lightwood/data/infer_types.py
+++ b/lightwood/data/infer_types.py
@@ -349,8 +349,8 @@ def sample_data(df: pd.DataFrame):
     return df.iloc[input_data_sample_indexes]
 
 
-def infer_types(data: pd.DataFrame, pct_invalid: float) -> TypeInformation:
-    seed()
+def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420) -> TypeInformation:
+    seed(seed_nr)
     type_information = TypeInformation()
     sample_df = sample_data(data)
     sample_size = len(sample_df)

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -45,8 +45,9 @@ def compute_entropy_biased_buckets(histogram):
 def statistical_analysis(data: pd.DataFrame,
                          dtypes: Dict[str, str],
                          identifiers: Dict[str, object],
-                         problem_definition: ProblemDefinition) -> StatisticalAnalysis:
-    seed()
+                         problem_definition: ProblemDefinition,
+                         seed_nr: int = 420) -> StatisticalAnalysis:
+    seed(seed_nr)
     log.info('Starting statistical analysis')
     df = cleaner(data, dtypes, problem_definition.pct_invalid, problem_definition.ignore_features,
                  identifiers, problem_definition.target, 'train', problem_definition.timeseries_settings,

--- a/lightwood/helpers/seed.py
+++ b/lightwood/helpers/seed.py
@@ -3,7 +3,7 @@ import numpy as np
 import random
 
 
-def seed(seed_nr):
+def seed(seed_nr: int) -> None:
     torch.manual_seed(seed_nr)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False

--- a/lightwood/helpers/seed.py
+++ b/lightwood/helpers/seed.py
@@ -3,7 +3,7 @@ import numpy as np
 import random
 
 
-def seed(seed_nr=420):
+def seed(seed_nr):
     torch.manual_seed(seed_nr)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False


### PR DESCRIPTION
Batch improvements based on suggestions from @hakunanatasha after her extensive review of the codebase.

* Seed function no longer has a default value for the seed, the seed_nr being passed is configurable from all of the functions that `seed` is called in.