### PR TITLE
Casting fix

### DIFF
--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse as parse_dt
 import datetime
 from lightwood.helpers.text import clean_float
 import pandas as pd
-from helpers.numeric import can_be_nan_numeric
+from lightwood.helpers.numeric import can_be_nan_numeric
 
 def _to_datetime(element):
     try:

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -43,16 +43,6 @@ def _tags_to_tuples(tags_str):
         return tuple()
 
 
-def _standardize_array(element):
-    try:
-        element = str(element)
-        element = element.rstrip(']').lstrip('[')
-        element = element.rstrip(' ').lstrip(' ')
-        return element.replace(', ', ' ').replace(',', ' ')
-    except Exception:
-        return element
-
-
 def _clean_float_or_none(element):
     try:
         calened_float = clean_float(element)
@@ -61,6 +51,19 @@ def _clean_float_or_none(element):
         return calened_float
     except Exception:
         return None
+
+
+def _standardize_array(element):
+    try:
+        element = str(element)
+        element = element.rstrip(']').lstrip('[')
+        element = element.rstrip(' ').lstrip(' ')
+        element = element.replace(', ', ' ').replace(',', ' ')
+        # Weird edge case in which arrays are actually numbers -_-
+        if ' ' not in element:
+            return _clean_float_or_none(element)
+    except Exception:
+        return element
 
 
 def _clean_value(element: object, data_dtype: str):
@@ -74,11 +77,7 @@ def _clean_value(element: object, data_dtype: str):
         element = float(_clean_float_or_none(element))
     if data_dtype in (dtype.integer):
         element = int(_clean_float_or_none(element))
-    if data_dtype in (dtype.array):
-        # Sometimes arrays are actually numbers (always?) this is wrong but handle this case anyway
-        if not str(element).startswith('(') and not str(element).startswith('['):
-            element = _clean_float_or_none(element)
-            
+
     if data_dtype in (dtype.array):
         element = _standardize_array(element)
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -10,6 +10,7 @@ from lightwood.helpers.text import clean_float
 import pandas as pd
 from lightwood.helpers.numeric import can_be_nan_numeric
 
+
 def _to_datetime(element):
     try:
         date = parse_dt(str(element))

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -156,8 +156,7 @@ def cleaner(
         data[name] = new_data
 
         if data_dtype == dtype.integer:
-            data[name] = data[name].astype(int)
+            data[name] = [int(x) if x is not None else None for x in data[name]]
         elif data_dtype in (dtype.float, dtype.array):
-            data[name] = data[name].astype(float)
-
+            data[name] = [float(x) if x is not None else None for x in data[name]]
     return data


### PR DESCRIPTION
Casting integers and floats to their respective types in the cleaner now takes into account `None` values and leaves them as is (since the respective encoders handle `None`).

In addition: Int/float cleaning in the cleaner now also converts nan-stlye values (nan, inf ,etc) into `None`.