### PR TITLE
Fix analysis memory usage

### DIFF
--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -8,6 +8,7 @@ import abc
 import numpy as np
 import sklearn.base
 from scipy.interpolate import interp1d
+from copy import deepcopy
 
 
 # -----------------------------------------------------------------------------
@@ -336,6 +337,17 @@ class BaseModelNc(BaseScorer):
                 pass
 
         return self.err_func.apply(prediction, y) / norm
+
+    def __deepcopy__(self, memo={}):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k != 'model':  # model should not be copied
+                setattr(result, k, deepcopy(v, memo))
+            else:
+                setattr(result, k, v)
+        return result
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Why
Analysis is currently saving a copy of the model inside each group confidence model. This means for tasks with multiple time series, memory usage is much larger than needed.

## How
Custom `__deepcopy__()` method for `BaseModelNc` does not copy the model when doing `deepcopy(icp)` during analysis.

### Affected modules

 * `lightwood.analysis.nc`