### PR TITLE
Fix 461, 488, 495

### DIFF
--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -45,9 +45,10 @@ class TsNumericEncoder(NumericEncoder):
                         mean = self.normalizers['__default'].abs_mean
                 else:
                     mean = self._abs_mean
-                if real is not None and mean > 0:
+
+                if real is not None:
                     vector[0] = 1 if real < 0 and not self.positive_domain else 0
-                    vector[1] = real / mean
+                    vector[1] = real / mean if mean != 0 else real
                 else:
                     raise Exception(f'Can\'t encode target value: {real}')
 
@@ -100,7 +101,7 @@ class TsNumericEncoder(NumericEncoder):
                         else:
                             mean = self._abs_mean
 
-                        real_value = vector[1] * mean
+                        real_value = vector[1] * mean if mean != 0 else vector[1]
 
                     if self.positive_domain:
                         real_value = abs(real_value)

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -18,6 +18,8 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss: Times
         else:
             series_delta = deltas['__default'][col]
         timestamps = [last + t * series_delta for t in range(nr_predictions)]
+        if len(timestamps) == 1:
+            timestamps = timestamps[0]  # preserves original input format in nr_predictions==1 case
         df[f'order_{col}'].iloc[idx] = timestamps
     return df[f'order_{col}']
 

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -18,8 +18,10 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss: Times
         else:
             series_delta = deltas['__default'][col]
         timestamps = [last + t * series_delta for t in range(nr_predictions)]
-        if len(timestamps) == 1:
-            timestamps = timestamps[0]  # preserves original input format in nr_predictions==1 case
+
+        if tss.nr_predictions == 1:
+            timestamps = timestamps[0]  # preserves original input format if nr_predictions == 1
+
         df[f'order_{col}'].iloc[idx] = timestamps
     return df[f'order_{col}']
 

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -263,25 +263,18 @@ class Neural(BaseModel):
         criterion = self._select_criterion()
         scaler = GradScaler()
 
-        if not self.timeseries_settings.is_timeseries:
-            for subset_itt in (0, 1):
-                for subset_idx in range(len(dev_ds_arr)):
-                    train_dl = DataLoader(
-                        ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
-                        batch_size=200, shuffle=True)
-
-                    stop_after = self.stop_after / 4
-                    self.model, epoch_to_best_model, err = self._max_fit(
-                        train_dl, dev_dl, criterion, optimizer, scaler, stop_after / 2, 20000 if subset_itt > 0 else 1)
-
-                    self.epochs_to_best += epoch_to_best_model
-        else:
+        for subset_itt in (0, 1):
             for subset_idx in range(len(dev_ds_arr)):
                 train_dl = DataLoader(
                     ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
                     batch_size=200, shuffle=True)
+
+                stop_after = self.stop_after / 4
+                return_model_after = (20000 if subset_itt > 0 else 1) if not self.timeseries_settings.is_timeseries \
+                    else 20000
+
                 self.model, epoch_to_best_model, err = self._max_fit(
-                    train_dl, dev_dl, criterion, optimizer, scaler, self.stop_after, 20000)
+                    train_dl, dev_dl, criterion, optimizer, scaler, stop_after / 2, return_model_after)
 
                 self.epochs_to_best += epoch_to_best_model
 

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -199,8 +199,8 @@ class Neural(BaseModel):
                 epochs_to_best = epoch
 
             if len(running_errors) >= 5:
-                delta_mean = np.mean([running_errors[-i - 1] - running_errors[-i]
-                                     for i in range(1, len(running_errors[-5:]))])
+                delta_mean = np.average([running_errors[-i - 1] - running_errors[-i] for i in range(1, 5)],
+                                        weights=[(1/2)**i for i in range(1, 5)])
                 if delta_mean <= 0:
                     break
             elif (time.time() - started) > stop_after:

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -200,7 +200,7 @@ class Neural(BaseModel):
 
             if len(running_errors) >= 5:
                 delta_mean = np.average([running_errors[-i - 1] - running_errors[-i] for i in range(1, 5)],
-                                        weights=[(1/2)**i for i in range(1, 5)])
+                                        weights=[(1 / 2)**i for i in range(1, 5)])
                 if delta_mean <= 0:
                     break
             elif (time.time() - started) > stop_after:

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -184,7 +184,9 @@ class Neural(BaseModel):
 
             train_error = np.mean(running_losses)
 
-            running_errors.append(self._error(dev_dl, criterion))
+            epoch_error = self._error(dev_dl, criterion)
+            running_errors.append(epoch_error)
+            log.info(f'Loss @ epoch {epoch}: {epoch_error}')
 
             if np.isnan(train_error) or np.isnan(
                     running_errors[-1]) or np.isinf(train_error) or np.isinf(
@@ -261,16 +263,25 @@ class Neural(BaseModel):
         criterion = self._select_criterion()
         scaler = GradScaler()
 
-        for subset_itt in (0, 1):
+        if not self.timeseries_settings.is_timeseries:
+            for subset_itt in (0, 1):
+                for subset_idx in range(len(dev_ds_arr)):
+                    train_dl = DataLoader(
+                        ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
+                        batch_size=200, shuffle=True)
+
+                    stop_after = self.stop_after / 4
+                    self.model, epoch_to_best_model, err = self._max_fit(
+                        train_dl, dev_dl, criterion, optimizer, scaler, stop_after / 2, 20000 if subset_itt > 0 else 1)
+
+                    self.epochs_to_best += epoch_to_best_model
+        else:
             for subset_idx in range(len(dev_ds_arr)):
                 train_dl = DataLoader(
                     ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
                     batch_size=200, shuffle=True)
-
-                stop_after = self.stop_after / 4
-
                 self.model, epoch_to_best_model, err = self._max_fit(
-                    train_dl, dev_dl, criterion, optimizer, scaler, stop_after / 2, 20000 if subset_itt > 0 else 1)
+                    train_dl, dev_dl, criterion, optimizer, scaler, self.stop_after, 20000)
 
                 self.epochs_to_best += epoch_to_best_model
 

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -263,23 +263,12 @@ class Neural(BaseModel):
         criterion = self._select_criterion()
         scaler = GradScaler()
 
-        for subset_itt in (0, 1):
-            for subset_idx in range(len(dev_ds_arr)):
-                train_dl = DataLoader(
-                    ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
-                    batch_size=200, shuffle=True)
+        train_dl = DataLoader(ConcatedEncodedDs(train_ds_arr), batch_size=200, shuffle=True)
 
-                stop_after = self.stop_after / 8
-                return_model_after = 20000 if subset_itt > 0 else 1
+        self.model, epoch_to_best_model, err = self._max_fit(
+            train_dl, dev_dl, criterion, optimizer, scaler, self.stop_after, return_model_after=20000)
 
-                if self.timeseries_settings.is_timeseries:
-                    return_model_after = 20000
-                    stop_after = self.stop_after
-
-                self.model, epoch_to_best_model, err = self._max_fit(
-                    train_dl, dev_dl, criterion, optimizer, scaler, stop_after, return_model_after)
-
-                self.epochs_to_best += epoch_to_best_model
+        self.epochs_to_best += epoch_to_best_model
 
         if len(con_test_ds) > 0:
             if self.fit_on_dev:

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -186,7 +186,7 @@ class Neural(BaseModel):
 
             epoch_error = self._error(dev_dl, criterion)
             running_errors.append(epoch_error)
-            log.info(f'Loss @ epoch {epoch}: {epoch_error}')
+            log.debug(f'Loss @ epoch {epoch}: {epoch_error}')
 
             if np.isnan(train_error) or np.isnan(
                     running_errors[-1]) or np.isinf(train_error) or np.isinf(

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -269,9 +269,12 @@ class Neural(BaseModel):
                     ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
                     batch_size=200, shuffle=True)
 
-                stop_after = self.stop_after / 8 if not self.timeseries_settings.is_timeseries else self.stop_after
-                return_model_after = (20000 if subset_itt > 0 else 1) if not self.timeseries_settings.is_timeseries \
-                    else 20000
+                stop_after = self.stop_after / 8
+                return_model_after = 20000 if subset_itt > 0 else 1
+
+                if self.timeseries_settings.is_timeseries:
+                    return_model_after = 20000
+                    stop_after = self.stop_after
 
                 self.model, epoch_to_best_model, err = self._max_fit(
                     train_dl, dev_dl, criterion, optimizer, scaler, stop_after, return_model_after)

--- a/lightwood/model/neural.py
+++ b/lightwood/model/neural.py
@@ -269,12 +269,12 @@ class Neural(BaseModel):
                     ConcatedEncodedDs(train_ds_arr[subset_idx * 9: (subset_idx + 1) * 9]),
                     batch_size=200, shuffle=True)
 
-                stop_after = self.stop_after / 4
+                stop_after = self.stop_after / 8 if not self.timeseries_settings.is_timeseries else self.stop_after
                 return_model_after = (20000 if subset_itt > 0 else 1) if not self.timeseries_settings.is_timeseries \
                     else 20000
 
                 self.model, epoch_to_best_model, err = self._max_fit(
-                    train_dl, dev_dl, criterion, optimizer, scaler, stop_after / 2, return_model_after)
+                    train_dl, dev_dl, criterion, optimizer, scaler, stop_after, return_model_after)
 
                 self.epochs_to_best += epoch_to_best_model
 


### PR DESCRIPTION
## Why
Fixes #461, #488 and #495

## How

- #461: remove warmup step in `fit()` training loop _and_ modify policy for deciding to early stop by giving more importance to most recently seen errors, to avoid premature early stopping.
- #488: cast unitary forecasts from list to first (and only) value to keep original column format
- #495: add special handling for groups where `mean = 0.0`

### Affected modules
- `lightwood/model/neural`
- `lightwood/helpers/ts`
- `lightwood/encoder/numeric/ts_numeric`

### Accuracy changes

Reverting back to no warmup in neural model means that it is once again able to produce sane forecasts. Here is an example (monthly sunspots test split):

Before:
![image](https://user-images.githubusercontent.com/12536303/132395805-de27bc7a-b2a7-4b4c-afec-d74f7b111b87.png)

After:
![image](https://user-images.githubusercontent.com/12536303/132395830-6fc0174c-84b2-4a3e-a54e-1cff6733aa92.png)

As reference, new R2 score in one-step-ahead forecasts for the test set is `0.803`. Before, it was `-1.105`. Comparisons against `lightwood <= 0.69.0` + `mindsdb_native` were not performed.
