### PR TITLE
Nonconformist optimizations (for speed)

### DIFF
--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -195,7 +195,7 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
         # TODO: if x == self.last_x ...
         n_test_objects = x.shape[0]
         p = np.zeros((n_test_objects, self.classes.size))
-        
+
         for i, c in enumerate(self.classes):
             test_class = np.zeros(x.shape[0], dtype=self.classes.dtype)
             test_class.fill(c)

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -195,7 +195,10 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
         # TODO: if x == self.last_x ...
         n_test_objects = x.shape[0]
         p = np.zeros((n_test_objects, self.classes.size))
-        random_uniform_dist = np.random.uniform(0, 1, 1)
+        
+        if self.smoothing:
+            random_uniform_dist = np.random.uniform(0, 1, 1)
+        
         for i, c in enumerate(self.classes):
             test_class = np.zeros(x.shape[0], dtype=self.classes.dtype)
             test_class.fill(c)

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -194,6 +194,7 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
         # TODO: if x == self.last_x ...
         n_test_objects = x.shape[0]
         p = np.zeros((n_test_objects, self.classes.size))
+        random_uniform_dist = np.random.uniform(0, 1, 1)
         for i, c in enumerate(self.classes):
             test_class = np.zeros(x.shape[0], dtype=self.classes.dtype)
             test_class.fill(c)
@@ -215,7 +216,7 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
                 p[j, i] = n_gt / (n_cal + 1)
 
                 if self.smoothing:
-                    p[j, i] += (n_eq * np.random.uniform(0, 1, 1)) / (n_cal + 1)
+                    p[j, i] += (n_eq * random_uniform_dist) / (n_cal + 1)
                 else:
                     p[j, i] += n_eq / (n_cal + 1)
 

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -196,9 +196,6 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
         n_test_objects = x.shape[0]
         p = np.zeros((n_test_objects, self.classes.size))
         
-        if self.smoothing:
-            random_uniform_dist = np.random.uniform(0, 1, 1)
-        
         for i, c in enumerate(self.classes):
             test_class = np.zeros(x.shape[0], dtype=self.classes.dtype)
             test_class.fill(c)
@@ -221,7 +218,7 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
                         n_gt += 1
 
                 if self.smoothing:
-                    p[j, i] = (n_gt + n_eq * random_uniform_dist) / (n_cal + 1)
+                    p[j, i] = (n_gt + n_eq * np.random.uniform(0, 1, 1)) / (n_cal + 1)
                 else:
                     p[j, i] = (n_gt + n_eq) / (n_cal + 1)
 

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -208,16 +208,18 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
                 cal_scores = self.cal_scores[self.condition((x[j, :], c))][::-1]
                 n_cal = cal_scores.size
 
-                idx_left = np.searchsorted(cal_scores, nc, 'left')
-                idx_right = np.searchsorted(cal_scores, nc, 'right')
-                n_gt = n_cal - idx_right
-                n_eq = idx_right - idx_left + 1
+                n_eq = 0
+                n_gt = 0
+                for cal_score in cal_scores:
+                    if cal_score == nc:
+                        n_eq += 1
+                    elif nc < cal_score:
+                        n_gt += 1
 
-                p[j, i] = n_gt / (n_cal + 1)
-
-                p[j, i] += n_eq / (n_cal + 1)
                 if self.smoothing:
-                    p[j, i] *= random_uniform_dist
+                    p[j, i] = (n_gt + n_eq) / (n_cal + 1)
+                else:
+                    p[j, i] = (n_gt + n_eq * random_uniform_dist) / (n_cal + 1)
                     
 
         if significance is not None:

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -6,6 +6,7 @@ Inductive conformal predictors.
 
 from collections import defaultdict
 from functools import partial
+from typing import Optional
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -170,7 +171,7 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
         else:
             self.classes = np.unique(np.hstack([self.classes, y]))
 
-    def predict(self, x, significance=None):
+    def predict(self, x: np.array, significance: Optional[float] = None) -> np.array:
         """Predict the output values for a set of input patterns.
 
         Parameters
@@ -220,7 +221,6 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
                     p[j, i] = (n_gt + n_eq) / (n_cal + 1)
                 else:
                     p[j, i] = (n_gt + n_eq * random_uniform_dist) / (n_cal + 1)
-                    
 
         if significance is not None:
             return p > significance

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -215,10 +215,10 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
 
                 p[j, i] = n_gt / (n_cal + 1)
 
+                p[j, i] += n_eq / (n_cal + 1)
                 if self.smoothing:
-                    p[j, i] += (n_eq * random_uniform_dist) / (n_cal + 1)
-                else:
-                    p[j, i] += n_eq / (n_cal + 1)
+                    p[j, i] *= random_uniform_dist
+                    
 
         if significance is not None:
             return p > significance

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -218,9 +218,9 @@ class IcpClassifier(BaseIcp, ClassifierMixin):
                         n_gt += 1
 
                 if self.smoothing:
-                    p[j, i] = (n_gt + n_eq) / (n_cal + 1)
-                else:
                     p[j, i] = (n_gt + n_eq * random_uniform_dist) / (n_cal + 1)
+                else:
+                    p[j, i] = (n_gt + n_eq) / (n_cal + 1)
 
         if significance is not None:
             return p > significance

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -329,12 +329,14 @@ class BaseModelNc(BaseScorer):
         prediction = self.model.predict(x)
         n_test = x.shape[0]
 
-        norm = np.ones(n_test)
+        
         if self.normalizer is not None:
             try:
                 norm = self.normalizer.score(x) + self.beta
             except Exception:
-                pass
+                norm = np.ones(n_test)
+        else:
+            norm = np.ones(n_test)
 
         return self.err_func.apply(prediction, y) / norm
 

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -472,7 +472,7 @@ class RegressorNc(BaseModelNc):
                 norm = self.normalizer.score(x) + self.beta
             except Exception:
                 pass
-        
+
         if significance:
             err_dist = self.err_func.apply_inverse(nc, significance)
             err_dist = np.hstack([err_dist] * n_test)

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -343,7 +343,7 @@ class BaseModelNc(BaseScorer):
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
-            if k != 'model':  # model should not be copied
+            if k not in ['model', 'normalizer']:  # model should not be copied
                 setattr(result, k, deepcopy(v, memo))
             else:
                 setattr(result, k, v)

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -329,7 +329,6 @@ class BaseModelNc(BaseScorer):
         prediction = self.model.predict(x)
         n_test = x.shape[0]
 
-        
         if self.normalizer is not None:
             try:
                 norm = self.normalizer.score(x) + self.beta

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -466,19 +466,19 @@ class RegressorNc(BaseModelNc):
         n_test = x.shape[0]
         prediction = self.model.predict(x)
 
-        norm = np.ones(n_test)
+        norm = 1
         if self.normalizer is not None:
             try:
                 norm = self.normalizer.score(x) + self.beta
             except Exception:
                 pass
-
+        
         if significance:
-            intervals = np.zeros((x.shape[0], 2))
             err_dist = self.err_func.apply_inverse(nc, significance)
             err_dist = np.hstack([err_dist] * n_test)
             err_dist *= norm
 
+            intervals = np.zeros((x.shape[0], 2))
             intervals[:, 0] = prediction - err_dist[0, :]
             intervals[:, 1] = prediction + err_dist[1, :]
 

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -327,17 +327,16 @@ class BaseModelNc(BaseScorer):
             Nonconformity scores of samples.
         """ # noqa
         prediction = self.model.predict(x)
-        n_test = x.shape[0]
 
+        err = self.err_func.apply(prediction, y)
         if self.normalizer is not None:
             try:
                 norm = self.normalizer.score(x) + self.beta
+                err = err / norm
             except Exception:
-                norm = np.ones(n_test)
-        else:
-            norm = np.ones(n_test)
+                pass
 
-        return self.err_func.apply(prediction, y) / norm
+        return err
 
     def __deepcopy__(self, memo={}):
         cls = self.__class__

--- a/lightwood/analysis/nc/wrappers.py
+++ b/lightwood/analysis/nc/wrappers.py
@@ -19,25 +19,6 @@ def clear_icp_state(icp):
         icp.normalizer.model = None
 
 
-def restore_icp_state(col, hmd, session):
-    icps = hmd['icp'][col]
-    try:
-        predictor = session.transaction.model_backend.predictor
-    except AttributeError:
-        model_path = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, hmd['name'], 'lightwood_data')
-        predictor = Predictor(load_from_path=model_path)
-
-    for group, icp in icps.items():
-        if group not in ['__mdb_groups', '__mdb_group_keys']:
-            icp.nc_function.model.model = predictor
-
-    # restore model in normalizer
-    for group, icp in icps.items():
-        if group not in ['__mdb_groups', '__mdb_group_keys']:
-            if icp.nc_function.normalizer is not None:
-                icp.nc_function.normalizer.model = icp.nc_function.model.model
-
-
 class ConformalRegressorAdapter(RegressorAdapter):
     def __init__(self, model, fit_params=None):
         super(ConformalRegressorAdapter, self).__init__(model, fit_params)

--- a/lightwood/analysis/nc/wrappers.py
+++ b/lightwood/analysis/nc/wrappers.py
@@ -1,4 +1,3 @@
-import os
 import torch
 from torch.nn.functional import softmax
 from lightwood.analysis.nc.base import RegressorAdapter, ClassifierAdapter


### PR DESCRIPTION
## Why ?

We need to make lightwood's inferences faster. Non conformist is very slow, `explain` takes 40-90% of inference time, see these tests for detail: https://github.com/mindsdb/magazine_of_magical_minutia/blob/master/performance_benchmarks/Results_Lightwood.md

## How

Optimizations to `explain increase performance across the board.

Example on bench 3

Before:
```
3.376 <module>  lightwood_benchmark_3.py:1
`- 3.367 predict  ../../../tmp/4f35588c6bb1fff0ac002432f937e88e2054d0e88762253d16309827790861123.py:162
   |- 2.931 explain  lightwood/analysis/explain.py:14
```

After:
```
1.747 <module>  lightwood_benchmark_3.py:1
`- 1.733 predict  ../../../tmp/5f283d544a1c1c511a03088822d4e48f62b680f06ec161f816311097846519938.py:162
   |- 1.398 explain  lightwood/analysis/explain.py:13
```

Example on bench 1

Before:
```
10.420 <module>  lightwood_benchmark_1.py:1
`- 10.409 predict  ../../../tmp/9446c53b9c6e2de2a7608e9ba8049b19392d1ce48a727f26163098244731725.py:163
   |- 5.391 explain  lightwood/analysis/explain.py:14
```

After:
```
8.570 <module>  lightwood_benchmark_1.py:1
`- 8.563 predict  ../../../tmp/af76354f4b30c2802dd9b04d3e91a00b43728b8a05f97c6616311102106541724.py:163
   |- 4.338 explain  lightwood/analysis/explain.py:13
```

These are run on my laptop, relative improvements are:

bench 1: `explain` took 51.7% of the runtime, now 50.6% -- NOISE
bench 3: `explain` took 87% of runtime, now 80% -- Signal?