### PR TITLE
Enhanced date-time + tag histograms

### DIFF
--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -60,7 +60,7 @@ def _standardize_array(element):
         element = element.rstrip(']').lstrip('[')
         element = element.rstrip(' ').lstrip(' ')
         element = element.replace(', ', ' ').replace(',', ' ')
-        # Weird edge case in which arrays are actually numbers -_-
+        # Handles cases where arrays are numbers
         if ' ' not in element:
             element = _clean_float_or_none(element)
     except Exception:

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -62,9 +62,11 @@ def _standardize_array(element):
         element = element.replace(', ', ' ').replace(',', ' ')
         # Weird edge case in which arrays are actually numbers -_-
         if ' ' not in element:
-            return _clean_float_or_none(element)
+            element = _clean_float_or_none(element)
     except Exception:
-        return element
+        pass
+    
+    return element
 
 
 def _clean_value(element: object, data_dtype: str):
@@ -149,7 +151,6 @@ def cleaner(
             try:
                 new_data.append(_clean_value(element, data_dtype))
             except Exception as e:
-                print(e, element)
                 new_data.append(None)
                 log.warning(
                     f'Unable to parse elemnt: {element} or type {data_dtype} from column {name}. Excetpion: {e}')

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -65,7 +65,7 @@ def _standardize_array(element):
             element = _clean_float_or_none(element)
     except Exception:
         pass
-    
+
     return element
 
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -149,6 +149,7 @@ def cleaner(
             try:
                 new_data.append(_clean_value(element, data_dtype))
             except Exception as e:
+                print(e, element)
                 new_data.append(None)
                 log.warning(
                     f'Unable to parse elemnt: {element} or type {data_dtype} from column {name}. Excetpion: {e}')

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 import datetime
 from dateutil.parser import parse as parse_dt
 from lightwood.api import StatisticalAnalysis, ProblemDefinition
-from lightwood.helpers.numeric import filter_nan
+from lightwood.helpers.numeric import filter_nan_and_none
 from lightwood.helpers.seed import seed
 from lightwood.data.cleaner import cleaner
 from lightwood.helpers.log import log
@@ -38,7 +38,7 @@ def get_numeric_histogram(data: pd.Series, data_dtype: dtype, bins: int) -> Dict
     """Generate the histogram for integer and float typed data
     """
     data = [_clean_float_or_none(x) for x in data]
-
+    
     Y, X = np.histogram(data, bins=min(bins, len(set(data))),
                         range=(min(data), max(data)), density=False)
     if data_dtype == dtype.integer:
@@ -116,12 +116,12 @@ def statistical_analysis(data: pd.DataFrame,
             }
             buckets[col] = histograms[col]['x']
         elif dtypes[col] in (dtype.integer, dtype.float, dtype.array):
-            histograms[col] = get_numeric_histogram(filter_nan(df[col]), dtypes[col], 50)
+            histograms[col] = get_numeric_histogram(filter_nan_and_none(df[col]), dtypes[col], 50)
             buckets[col] = histograms[col]['x']
         elif dtypes[col] in (dtype.date, dtype.datetime):
-            histograms[col] = get_datetime_histogram(filter_nan(df[col]), 50)
+            histograms[col] = get_datetime_histogram(filter_nan_and_none(df[col]), 50)
         else:
-            histograms[col] = {'x': ['Unknown'], 'y': [len(filter_nan(df[col]))]}
+            histograms[col] = {'x': ['Unknown'], 'y': [len(df[col])]}
             buckets[col] = []
 
     # get observed classes, used in analysis

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -13,7 +13,9 @@ from scipy.stats import entropy
 from lightwood.data.cleaner import _clean_float_or_none
 
 
-def get_datetime_histogram(data, data_dtype):
+def get_datetime_histogram(data: pd.Series) -> Dict[str, list]:
+    """Generates the histogram for date and datetime types
+    """
     if isinstance(data[0], float) or isinstance(data[0], int):
         data = [_clean_float_or_none(x) for x in data]
     else:
@@ -21,8 +23,6 @@ def get_datetime_histogram(data, data_dtype):
 
     Y, X = np.histogram(data, bins=min(50, len(set(data))),
                         range=(min(data), max(data)), density=False)
-    if data_dtype == dtype.integer:
-        Y, X = np.histogram(data, bins=[int(round(x)) for x in X], density=False)
 
     X = X[:-1].tolist()
     Y = Y.tolist()
@@ -34,7 +34,9 @@ def get_datetime_histogram(data, data_dtype):
     }
 
 
-def get_numeric_histogram(data, data_dtype):
+def get_numeric_histogram(data: pd.Series, data_dtype: dtype) -> Dict[str, list]:
+    """Generate the histogram for integer and float typed data
+    """
     data = [_clean_float_or_none(x) for x in data]
 
     Y, X = np.histogram(data, bins=min(50, len(set(data))),

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -119,7 +119,7 @@ def statistical_analysis(data: pd.DataFrame,
         elif dtypes[col] in (dtype.date, dtype.datetime):
             histograms[col] = get_datetime_histogram(filter_nan(df[col]), dtypes[col])
         else:
-            histograms[col] = {'x': ['Unknown'], 'y': [1]}
+            histograms[col] = {'x': ['Unknown'], 'y': [len(filter_nan(df[col]))]}
             buckets[col] = []
 
     # get observed classes, used in analysis

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -37,8 +37,15 @@ def get_datetime_histogram(data: pd.Series, bins: int) -> Dict[str, list]:
 def get_numeric_histogram(data: pd.Series, data_dtype: dtype, bins: int) -> Dict[str, list]:
     """Generate the histogram for integer and float typed data
     """
+    # Handle arrays that are actual arrays and not things that become arrays later
+    if ' ' in data[0]:
+        new_data = []
+        for list_str in data:
+            new_data.extend([float(x) for x in list_str.split(' ')])
+        data = new_data
+        
     data = [_clean_float_or_none(x) for x in data]
-    
+
     Y, X = np.histogram(data, bins=min(bins, len(set(data))),
                         range=(min(data), max(data)), density=False)
     if data_dtype == dtype.integer:

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -14,7 +14,10 @@ from lightwood.data.cleaner import _clean_float_or_none
 
 
 def get_datetime_histogram(data, data_dtype):
-    data = [_clean_float_or_none(parse_dt(str(x)).timestamp()) for x in data]
+    if isinstance(data[0], float) or isinstance(data[0], int):
+        data = [_clean_float_or_none(x) for x in data]
+    else:
+        data = [_clean_float_or_none(parse_dt(str(x)).timestamp()) for x in data]
 
     Y, X = np.histogram(data, bins=min(50, len(set(data))),
                         range=(min(data), max(data)), density=False)

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -27,7 +27,7 @@ def get_datetime_histogram(data: pd.Series, bins: int) -> Dict[str, list]:
     X = X[:-1].tolist()
     Y = Y.tolist()
 
-    X = [datetime.datetime.fromtimestamp(x) for x in X]
+    X = [str(datetime.datetime.fromtimestamp(x)) for x in X]
     return {
         'x': X,
         'y': Y

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -38,12 +38,12 @@ def get_numeric_histogram(data: pd.Series, data_dtype: dtype, bins: int) -> Dict
     """Generate the histogram for integer and float typed data
     """
     # Handle arrays that are actual arrays and not things that become arrays later
-    if ' ' in data[0]:
+    if ' ' in str(data[0]):
         new_data = []
         for list_str in data:
             new_data.extend([float(x) for x in list_str.split(' ')])
         data = new_data
-        
+
     data = [_clean_float_or_none(x) for x in data]
 
     Y, X = np.histogram(data, bins=min(bins, len(set(data))),
@@ -116,7 +116,7 @@ def statistical_analysis(data: pd.DataFrame,
         histograms[col] = None
         buckets[col] = None
         if dtypes[col] in (dtype.categorical, dtype.binary, dtype.tags):
-            hist = dict(df[col].value_counts().apply(lambda x: x / len(df[col])))
+            hist = dict(df[col].value_counts())
             histograms[col] = {
                 'x': list([str(x) for x in hist.keys()]),
                 'y': list(hist.values())

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -13,7 +13,7 @@ from scipy.stats import entropy
 from lightwood.data.cleaner import _clean_float_or_none
 
 
-def get_datetime_histogram(data: pd.Series) -> Dict[str, list]:
+def get_datetime_histogram(data: pd.Series, bins: int) -> Dict[str, list]:
     """Generates the histogram for date and datetime types
     """
     if isinstance(data[0], float) or isinstance(data[0], int):
@@ -21,7 +21,7 @@ def get_datetime_histogram(data: pd.Series) -> Dict[str, list]:
     else:
         data = [_clean_float_or_none(parse_dt(str(x)).timestamp()) for x in data]
 
-    Y, X = np.histogram(data, bins=min(50, len(set(data))),
+    Y, X = np.histogram(data, bins=min(bins, len(set(data))),
                         range=(min(data), max(data)), density=False)
 
     X = X[:-1].tolist()
@@ -34,12 +34,12 @@ def get_datetime_histogram(data: pd.Series) -> Dict[str, list]:
     }
 
 
-def get_numeric_histogram(data: pd.Series, data_dtype: dtype) -> Dict[str, list]:
+def get_numeric_histogram(data: pd.Series, data_dtype: dtype, bins: int) -> Dict[str, list]:
     """Generate the histogram for integer and float typed data
     """
     data = [_clean_float_or_none(x) for x in data]
 
-    Y, X = np.histogram(data, bins=min(50, len(set(data))),
+    Y, X = np.histogram(data, bins=min(bins, len(set(data))),
                         range=(min(data), max(data)), density=False)
     if data_dtype == dtype.integer:
         Y, X = np.histogram(data, bins=[int(round(x)) for x in X], density=False)
@@ -116,10 +116,10 @@ def statistical_analysis(data: pd.DataFrame,
             }
             buckets[col] = histograms[col]['x']
         elif dtypes[col] in (dtype.integer, dtype.float, dtype.array):
-            histograms[col] = get_numeric_histogram(filter_nan(df[col]), dtypes[col])
+            histograms[col] = get_numeric_histogram(filter_nan(df[col]), dtypes[col], 50)
             buckets[col] = histograms[col]['x']
         elif dtypes[col] in (dtype.date, dtype.datetime):
-            histograms[col] = get_datetime_histogram(filter_nan(df[col]), dtypes[col])
+            histograms[col] = get_datetime_histogram(filter_nan(df[col]), 50)
         else:
             histograms[col] = {'x': ['Unknown'], 'y': [len(filter_nan(df[col]))]}
             buckets[col] = []

--- a/lightwood/helpers/numeric.py
+++ b/lightwood/helpers/numeric.py
@@ -1,16 +1,14 @@
-'''
-To: future intern reading this bit of code thinking "this is dumb, we could just check for isnan and isinf
-
-No, no you can't, this will break subtly in a bunch of edge cases.
-
-See the example (+ comments) in this article: https://cerebralab.com/Exceptions_as_control_flow
-
-Sorry, python is dumb, but the spirit of your investigation wasn't, try again
-'''
 from typing import Iterable
 
 
 def can_be_nan_numeric(value: object) -> bool:
+    """
+    Tells us if **value** might be nan or inf or some other numeric value\
+        (i.e. which can be cast as `float`) that is not actually a number.\
+        Name is vague because I'm not 100% sure of all the edge cases of numeric\
+        values that have number-like type behavior.
+    """
+
     try:
         value = str(value)
         value = float(value)

--- a/lightwood/helpers/numeric.py
+++ b/lightwood/helpers/numeric.py
@@ -7,9 +7,10 @@ See the example (+ comments) in this article: https://cerebralab.com/Exceptions_
 
 Sorry, python is dumb, but the spirit of your investigation wasn't, try again
 '''
+from typing import Iterable
 
 
-def can_be_nan_numeric(value):
+def can_be_nan_numeric(value: object) -> bool:
     try:
         value = str(value)
         value = float(value)
@@ -25,5 +26,5 @@ def can_be_nan_numeric(value):
     return isnan
 
 
-def filter_nan(series):
-    return [x for x in series if not can_be_nan_numeric(x)]
+def filter_nan_and_none(series: Iterable) -> list:
+    return [x for x in series if not can_be_nan_numeric(x) and x is not None]

--- a/tests/integration/basic/test_analyze_dataset.py
+++ b/tests/integration/basic/test_analyze_dataset.py
@@ -48,7 +48,8 @@ class TestInferTypes(unittest.TestCase):
             self.assertTrue(type_information.identifiers[k] is None)
 
     def test_with_generated(self):
-        n_points = 100
+        # Must be an even number
+        n_points = 134
 
         # Apparently for n_category_values = 10 it doesn't work
         n_category_values = 4
@@ -100,8 +101,16 @@ class TestInferTypes(unittest.TestCase):
             assert type_information.dtypes[col_name] == expected_type
         
         stats = analysis.statistical_analysis
-        print(stats.histograms)
+        for k in stats.histograms:
+            if k != 'sequential_array':
+                assert np.sum(stats.histograms[k]['y']) == n_points
 
+        assert set(stats.histograms['short_text']['x']) == set(['Unknown'])
+        assert set(stats.histograms['rich_text']['x']) == set(['Unknown'])
+        assert set(stats.histograms['rich_text']['x']) == set(['Unknown'])
+        # 50 is a magic number, when we change this, tests must change
+        assert len(set(stats.histograms['date_timestamp']['x'])) == 50
+        assert len(set(stats.histograms['date_date']['x'])) == 50
 
 '''
     def test_deduce_foreign_key(self):

--- a/tests/integration/basic/test_analyze_dataset.py
+++ b/tests/integration/basic/test_analyze_dataset.py
@@ -99,7 +99,7 @@ class TestInferTypes(unittest.TestCase):
                 f"Got {type_information.dtypes[col_name]} | Expected: {expected_type}"
             )
             assert type_information.dtypes[col_name] == expected_type
-        
+
         stats = analysis.statistical_analysis
         for k in stats.histograms:
             if k != 'sequential_array':
@@ -111,6 +111,7 @@ class TestInferTypes(unittest.TestCase):
         # 50 is a magic number, when we change this, tests must change
         assert len(set(stats.histograms['date_timestamp']['x'])) == 50
         assert len(set(stats.histograms['date_date']['x'])) == 50
+
 
 '''
     def test_deduce_foreign_key(self):

--- a/tests/integration/basic/test_analyze_dataset.py
+++ b/tests/integration/basic/test_analyze_dataset.py
@@ -1,5 +1,5 @@
 from mindsdb_datasources import FileDS
-from lightwood import infer_types
+from lightwood import analyze_dataset
 from lightwood.api import dtype
 import unittest
 from itertools import cycle
@@ -16,11 +16,11 @@ from tests.utils.data_generation import (
 
 
 class TestInferTypes(unittest.TestCase):
-    def test_infer_types_on_home_rentlas(self):
+    def test_analyze_home_rentlas(self):
         datasource = FileDS(
             "https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/classics/home_rentals/dataset/train.csv"
         )
-        type_information = infer_types(datasource.df, pct_invalid=0)
+        type_information = analyze_dataset(datasource.df).type_information
 
         self.assertTrue(
             type_information.dtypes["number_of_rooms"] == dtype.categorical)
@@ -47,7 +47,7 @@ class TestInferTypes(unittest.TestCase):
         for k in type_information.identifiers:
             self.assertTrue(type_information.identifiers[k] is None)
 
-    def test_type_deduction(self):
+    def test_with_generated(self):
         n_points = 100
 
         # Apparently for n_category_values = 10 it doesn't work
@@ -90,13 +90,17 @@ class TestInferTypes(unittest.TestCase):
             }
         )
 
-        type_information = infer_types(df, pct_invalid=0)
+        analysis = analyze_dataset(df)
+        type_information = analysis.type_information
         for col_name in df.columns:
             expected_type = test_column_types[col_name]
             print(
                 f"Got {type_information.dtypes[col_name]} | Expected: {expected_type}"
             )
             assert type_information.dtypes[col_name] == expected_type
+        
+        stats = analysis.statistical_analysis
+        print(stats.histograms)
 
 
 '''


### PR DESCRIPTION
## Why

We weren't generating histograms for DateTime and tag types, our histograms for dates were arguably bad (using categorical histogram).

## How

Added  a numeric-like histogram for dates, using categorical histogram for tags

Resolves #479  | Obviously histograms can still be improved but this is the  bare minimum to get some decent graphics in the GUI in the vast majority of cases.