### PR TITLE
Handle ' and " in column names

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -459,7 +459,9 @@ def code_from_json_ai(json_ai: JsonAI) -> str:
         )
 
     ignored_cols = json_ai.problem_definition.ignore_features
-    input_cols = ','.join([f"""'{name}'""" for name in json_ai.features if name not in ignored_cols])
+    input_cols = [x.replace("'", "\\'").replace('"', '\\"')
+                  for x in json_ai.features]
+    input_cols = ','.join([f"""'{name}'""" for name in input_cols if name not in ignored_cols])
 
     ts_transform_code = ''
     ts_analyze_code = ''

--- a/lightwood/helpers/templating.py
+++ b/lightwood/helpers/templating.py
@@ -84,6 +84,7 @@ def call(entity: dict, json_ai: JsonAI) -> str:
 def inline_dict(obj: dict) -> str:
     arr = []
     for k, v in obj.items():
+        k = k.replace("'", "\\'").replace('"', '\\"')
         arr.append(f"""'{k}': {v}""")
 
     dict_code = '{\n' + ',\n'.join(arr) + '\n}'

--- a/tests/integration/basic/test_boston_housing.py
+++ b/tests/integration/basic/test_boston_housing.py
@@ -10,6 +10,7 @@ class TestBasic(unittest.TestCase):
         from lightwood.api.high_level import predictor_from_problem
 
         df = pd.read_csv('tests/data/boston.csv')[:500]
+        df = df.rename(columns={df.columns[1]: f'\'{df.columns[1]}\''})
         target = 'MEDV'
 
         predictor = predictor_from_problem(df, ProblemDefinition.from_dict({'target': target, 'time_aim': 200}))

--- a/tests/integration/basic/test_boston_housing.py
+++ b/tests/integration/basic/test_boston_housing.py
@@ -10,7 +10,10 @@ class TestBasic(unittest.TestCase):
         from lightwood.api.high_level import predictor_from_problem
 
         df = pd.read_csv('tests/data/boston.csv')[:500]
+        # Mess with the names to also test if lightwood can deal /w weird names
         df = df.rename(columns={df.columns[1]: f'\'{df.columns[1]}\''})
+        df = df.rename(columns={df.columns[2]: f'\'{df.columns[2]}}}'})
+        df = df.rename(columns={df.columns[3]: f'{{{df.columns[3]}\"'})
         target = 'MEDV'
 
         predictor = predictor_from_problem(df, ProblemDefinition.from_dict({'target': target, 'time_aim': 200}))


### PR DESCRIPTION
The title is self-explanatory, also added tests to check if lightwood handles names with `'`, `"`, `{` and `}` properly.

Closes #464 