### PR TITLE
Fix #510 - Sktime dependency

### DIFF
--- a/lightwood/model/sktime.py
+++ b/lightwood/model/sktime.py
@@ -42,6 +42,7 @@ class SkTime(BaseModel):
                                for gcol in self.grouped_by} if self.ts_analysis['tss'].group_by else {}}
 
         for group in self.ts_analysis['group_combinations']:
+            # many warnings might be thrown inside of statsmodels during stepwise procedure
             self.models[group] = self.model_class(suppress_warnings=True)
 
             if self.grouped_by == ['__default']:

--- a/lightwood/model/sktime.py
+++ b/lightwood/model/sktime.py
@@ -42,7 +42,7 @@ class SkTime(BaseModel):
                                for gcol in self.grouped_by} if self.ts_analysis['tss'].group_by else {}}
 
         for group in self.ts_analysis['group_combinations']:
-            self.models[group] = self.model_class()
+            self.models[group] = self.model_class(suppress_warnings=True)
 
             if self.grouped_by == ['__default']:
                 series_idxs = data['data'].index

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ langdetect >= 1.0.0
 dataclasses_json >= 0.5.4
 autopep8 >= 1.5.7
 dill == 0.3.4
-sktime[arima] >= 0.5.0
+sktime >= 0.5.0
 torch_optimizer == 0.1.0
 pmdarima >= 1.8.0


### PR DESCRIPTION
## Why
To fix #510 -- a warning that pops up while installing lightwood dependencies

## How
Remove `[arima]` from `sktime` dependency, as `pmdarima` is enough.

Unrelated, but this PR also supresses warnings from `statsmethods` in the `AutoARIMA` model, as the user cannot act upon them and they are not very informative.

### Affected modules
- `requirements.txt`
