### PR TITLE
Fix for lightgbm device check

### DIFF
--- a/lightwood/mixer/lightgbm.py
+++ b/lightwood/mixer/lightgbm.py
@@ -11,6 +11,8 @@ import time
 from lightwood.helpers.log import log
 from sklearn.preprocessing import OrdinalEncoder
 from lightwood.mixer.base import BaseMixer
+from helpers.device import get_devices
+
 
 optuna.logging.set_verbosity(optuna.logging.CRITICAL)
 
@@ -22,7 +24,11 @@ def check_gpu_support():
         train_data = lightgbm.Dataset(data, label=label)
         params = {'num_iterations': 1, 'device': 'gpu'}
         lightgbm.train(params, train_set=train_data)
-        return True
+        device, nr_devices = get_devices()
+        if nr_devices > 0 and str(device) != 'cpu':
+            return True
+        else:
+            return False
     except Exception:
         return False
 

--- a/lightwood/mixer/lightgbm.py
+++ b/lightwood/mixer/lightgbm.py
@@ -11,7 +11,7 @@ import time
 from lightwood.helpers.log import log
 from sklearn.preprocessing import OrdinalEncoder
 from lightwood.mixer.base import BaseMixer
-from helpers.device import get_devices
+from lightwood.helpers.device import get_devices
 
 
 optuna.logging.set_verbosity(optuna.logging.CRITICAL)


### PR DESCRIPTION
LightGBM's function to check GPU support (`check_gpu_support`) only checked if lgbm was installed with GPU enabled.

*But* the way we use LGBM means we also need torch installed with GPU support, so lightwood was failing in the odd case where the user had and lgbm install with GPU support but no torch with cuda support.