### PR TITLE
Select OHE at json-ai build time and fix pandas None bugs

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -81,7 +81,7 @@ def lookup_encoder(
         dtype.float: 'Float.NumericEncoder',
         dtype.binary: 'Binary.BinaryEncoder',
         dtype.categorical: 'Categorical.CategoricalAutoEncoder'
-        if statistical_analysis is None or len(statistical_analysis.histograms[col_name]) > 100 
+        if statistical_analysis is None or len(statistical_analysis.histograms[col_name]) > 100
         else 'Categorical.OneHotEncoder',
         dtype.tags: 'Tags.MultiHotEncoder',
         dtype.date: 'Date.DatetimeEncoder',

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -59,6 +59,7 @@ def lookup_encoder(
     is_target: bool,
     problem_defintion: ProblemDefinition,
     is_target_predicting_encoder: bool,
+    statistical_analysis: StatisticalAnalysis
 ):
     """
     Assign a default encoder for a given column based on its data type, and whether it is a target. Encoders intake raw (but cleaned) data and return an feature representation. This function assigns, per data type, what the featurizer should be. This function runs on each column within the dataset available for model building to assign how it should be featurized.
@@ -79,7 +80,9 @@ def lookup_encoder(
         dtype.integer: 'Integer.NumericEncoder',
         dtype.float: 'Float.NumericEncoder',
         dtype.binary: 'Binary.BinaryEncoder',
-        dtype.categorical: 'Categorical.CategoricalAutoEncoder',
+        dtype.categorical: 'Categorical.CategoricalAutoEncoder'
+        if statistical_analysis is None or len(statistical_analysis.histograms[col_name]) > 100 
+        else 'Categorical.OneHotEncoder',
         dtype.tags: 'Tags.MultiHotEncoder',
         dtype.date: 'Date.DatetimeEncoder',
         dtype.datetime: 'Datetime.DatetimeEncoder',
@@ -266,7 +269,7 @@ def generate_json_ai(
         list(outputs.values())[0].data_dtype = dtype.tsarray
 
     list(outputs.values())[0].encoder = lookup_encoder(
-        type_information.dtypes[target], target, True, problem_definition, False
+        type_information.dtypes[target], target, True, problem_definition, False, statistical_analysis
     )
 
     features: Dict[str, Feature] = {}
@@ -274,7 +277,7 @@ def generate_json_ai(
         col_dtype = type_information.dtypes[col_name]
         dependency = []
         encoder = lookup_encoder(
-            col_dtype, col_name, False, problem_definition, is_target_predicting_encoder
+            col_dtype, col_name, False, problem_definition, is_target_predicting_encoder, statistical_analysis
         )
 
         if tss.is_timeseries and eval(encoder['module'].split(".")[1]).is_timeseries_encoder:
@@ -545,6 +548,7 @@ def code_from_json_ai(json_ai: JsonAI) -> str:
                                                      False,
                                                      json_ai.problem_definition,
                                                      False,
+                                                     None
                                                      ))
         dependency_dict[col_name] = []
         dtype_dict[col_name] = f"""'{list(json_ai.outputs.values())[0].data_dtype}'"""

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -54,7 +54,7 @@ def cleaner(
         # If you want to customize the cleaner, it's likely you can to modify ``get_cleaning_func``
         for nan_val in VALUES_FOR_NAN_AND_NONE_IN_PANDAS:
             data[col] = data[col].apply(get_cleaning_func(dtype_dict[col], custom_cleaning_functions)
-                                    ).replace({nan_val: None})
+                                        ).replace({nan_val: None})
         # If a column has too many None values, raise an Excpetion
         # Figure out how to reintroduce later, maybe a custom flag, `crash for too much invalid data`?
         # _check_if_invalid(data[col], pct_invalid, col)

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -15,6 +15,9 @@ import numpy as np
 from typing import Dict, List, Optional, Tuple, Callable, Union
 
 
+VALUES_FOR_NAN_AND_NONE_IN_PANDAS = [np.nan, 'nan', 'NaN', 'Nan', 'None']
+
+
 def cleaner(
     data: pd.DataFrame,
     dtype_dict: Dict[str, str],
@@ -49,12 +52,13 @@ def cleaner(
     for col in _get_columns_to_clean(data, dtype_dict, mode, target):
         # Get and apply a cleaning function for each data type
         # If you want to customize the cleaner, it's likely you can to modify ``get_cleaning_func``
-        data[col] = data[col].apply(get_cleaning_func(dtype_dict[col], custom_cleaning_functions)
-                                    ).replace({np.nan: None})
+        for nan_val in VALUES_FOR_NAN_AND_NONE_IN_PANDAS:
+            data[col] = data[col].apply(get_cleaning_func(dtype_dict[col], custom_cleaning_functions)
+                                    ).replace({nan_val: None})
         # If a column has too many None values, raise an Excpetion
         # Figure out how to reintroduce later, maybe a custom flag, `crash for too much invalid data`?
         # _check_if_invalid(data[col], pct_invalid, col)
-
+    pd.set_option("display.max_rows", None, "display.max_columns", None)
     return data
 
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -58,7 +58,6 @@ def cleaner(
         # If a column has too many None values, raise an Excpetion
         # Figure out how to reintroduce later, maybe a custom flag, `crash for too much invalid data`?
         # _check_if_invalid(data[col], pct_invalid, col)
-    pd.set_option("display.max_rows", None, "display.max_columns", None)
     return data
 
 

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -155,7 +155,8 @@ def statistical_analysis(data: pd.DataFrame,
         if dtypes[col] in (dtype.rich_text, dtype.short_text):
             words_per_sentence = []
             for item in df[col]:
-                words_per_sentence.append(len(item.split(' ')))
+                if item is not None:
+                    words_per_sentence.append(len(item.split(' ')))
             avg_words_per_sentence[col] = int(np.mean(words_per_sentence))
         else:
             avg_words_per_sentence[col] = None

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -1,5 +1,4 @@
 import random
-from typing import Union
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
@@ -63,8 +62,8 @@ class CategoricalAutoEncoder(BaseEncoder):
         optimizer = Ranger(self.net.parameters())
 
         gym = Gym(model=self.net, optimizer=optimizer, scheduler=None, loss_criterion=criterion,
-                    device=self.net.device, name=self.name, input_encoder=self.onehot_encoder.encode,
-                    output_encoder=self._encoder_targets)
+                  device=self.net.device, name=self.name, input_encoder=self.onehot_encoder.encode,
+                  output_encoder=self._encoder_targets)
 
         batch_size = min(200, int(len(priming_data) / 50))
 
@@ -75,13 +74,13 @@ class CategoricalAutoEncoder(BaseEncoder):
 
         test_data_loader = None
 
-        best_model, error, training_time = gym.fit(train_data_loader,
-                                                    test_data_loader,
-                                                    desired_error=self.desired_error,
-                                                    max_time=self.stop_after,
-                                                    callback=self._train_callback,
-                                                    eval_every_x_epochs=1,
-                                                    max_unimproving_models=5)
+        best_model, _, _ = gym.fit(train_data_loader,
+                                   test_data_loader,
+                                   desired_error=self.desired_error,
+                                   max_time=self.stop_after,
+                                   callback=self._train_callback,
+                                   eval_every_x_epochs=1,
+                                   max_unimproving_models=5)
 
         self.net = best_model.to(self.net.device)
 

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -14,8 +14,7 @@ from lightwood.mixer.helpers.default_net import DefaultNet
 class CategoricalAutoEncoder(BaseEncoder):
     is_trainable_encoder: bool = True
 
-    def __init__(self, stop_after: int = 3600, is_target: bool = False, max_encoded_length: int = 100,
-                 use_autoencoder: Union[bool, None] = None):
+    def __init__(self, stop_after: int = 3600, is_target: bool = False, max_encoded_length: int = 100):
         super().__init__(is_target)
         self._prepared = False
         self.name = 'Categorical Autoencoder'
@@ -24,15 +23,11 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.decoder = None
         self.onehot_encoder = OneHotEncoder(is_target=self.is_target)
         self.desired_error = 0.01
-        self.use_autoencoder = use_autoencoder
         self.stop_after = stop_after
         # @TODO stop using instead of ONEHOT !!!@!
         self.is_nn_encoder = True
         self.output_size = None
-        if self.is_target:
-            self.max_encoded_length = None
-        else:
-            self.max_encoded_length = max_encoded_length
+        self.max_encoded_length = max_encoded_length
 
     def _train_callback(self, error, real_buff, predicted_buff):
         log.info(f'{self.name} reached a loss of {error} while training !')
@@ -54,73 +49,63 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.onehot_encoder.prepare(priming_data)
 
         input_len = self.onehot_encoder._lang.n_words
-        if self.use_autoencoder is None:
-            self.use_autoencoder = self.max_encoded_length is not None and input_len > self.max_encoded_length
 
-        if self.use_autoencoder:
-            if self.is_target:
-                log.warning('You are trying to use an autoencoder for the target value! \
-                This is very likely a bad idea')
-            log.info('Preparing a categorical autoencoder, this might take a while')
+        if self.is_target:
+            log.warning('You are trying to use an autoencoder for the target value! \
+            This is very likely a bad idea')
+        log.info('Preparing a categorical autoencoder, this might take a while')
 
-            embeddings_layer_len = self.max_encoded_length
+        embeddings_layer_len = self.max_encoded_length
 
-            self.net = DefaultNet(shape=[
-                                  input_len, embeddings_layer_len, input_len])
+        self.net = DefaultNet(shape=[input_len, embeddings_layer_len, input_len])
 
-            criterion = torch.nn.CrossEntropyLoss()
-            optimizer = Ranger(self.net.parameters())
+        criterion = torch.nn.CrossEntropyLoss()
+        optimizer = Ranger(self.net.parameters())
 
-            gym = Gym(model=self.net, optimizer=optimizer, scheduler=None, loss_criterion=criterion,
-                      device=self.net.device, name=self.name, input_encoder=self.onehot_encoder.encode,
-                      output_encoder=self._encoder_targets)
+        gym = Gym(model=self.net, optimizer=optimizer, scheduler=None, loss_criterion=criterion,
+                    device=self.net.device, name=self.name, input_encoder=self.onehot_encoder.encode,
+                    output_encoder=self._encoder_targets)
 
-            batch_size = min(200, int(len(priming_data) / 50))
+        batch_size = min(200, int(len(priming_data) / 50))
 
-            priming_data_str = [str(x) for x in priming_data]
-            train_data_loader = DataLoader(
-                list(zip(priming_data_str, priming_data_str)),
-                batch_size=batch_size, shuffle=True)
+        priming_data_str = [str(x) for x in priming_data]
+        train_data_loader = DataLoader(
+            list(zip(priming_data_str, priming_data_str)),
+            batch_size=batch_size, shuffle=True)
 
-            test_data_loader = None
+        test_data_loader = None
 
-            best_model, error, training_time = gym.fit(train_data_loader,
-                                                       test_data_loader,
-                                                       desired_error=self.desired_error,
-                                                       max_time=self.stop_after,
-                                                       callback=self._train_callback,
-                                                       eval_every_x_epochs=1,
-                                                       max_unimproving_models=5)
+        best_model, error, training_time = gym.fit(train_data_loader,
+                                                    test_data_loader,
+                                                    desired_error=self.desired_error,
+                                                    max_time=self.stop_after,
+                                                    callback=self._train_callback,
+                                                    eval_every_x_epochs=1,
+                                                    max_unimproving_models=5)
 
-            self.net = best_model.to(self.net.device)
+        self.net = best_model.to(self.net.device)
 
-            modules = [module for module in self.net.modules() if type(
-                module) != torch.nn.Sequential and type(module) != DefaultNet]
-            self.encoder = torch.nn.Sequential(*modules[0:2]).eval()
-            self.decoder = torch.nn.Sequential(*modules[2:3]).eval()
-            log.info('Categorical autoencoder ready')
+        modules = [module for module in self.net.modules() if type(
+            module) != torch.nn.Sequential and type(module) != DefaultNet]
+        self.encoder = torch.nn.Sequential(*modules[0:2]).eval()
+        self.decoder = torch.nn.Sequential(*modules[2:3]).eval()
+        log.info('Categorical autoencoder ready')
 
         self.output_size = self.onehot_encoder._lang.n_words
-        if self.use_autoencoder:
-            self.output_size = self.max_encoded_length
+        self.output_size = self.max_encoded_length
         self._prepared = True
 
     def encode(self, column_data):
         oh_encoded_tensor = self.onehot_encoder.encode(column_data)
-        if not self.use_autoencoder:
-            return oh_encoded_tensor
-        else:
-            with torch.no_grad():
-                oh_encoded_tensor = oh_encoded_tensor.to(self.net.device)
-                embeddings = self.encoder(oh_encoded_tensor)
-                return embeddings.to('cpu')
+
+        with torch.no_grad():
+            oh_encoded_tensor = oh_encoded_tensor.to(self.net.device)
+            embeddings = self.encoder(oh_encoded_tensor)
+            return embeddings.to('cpu')
 
     def decode(self, encoded_data):
-        if not self.use_autoencoder:
-            return self.onehot_encoder.decode(encoded_data)
-        else:
-            with torch.no_grad():
-                encoded_data = encoded_data.to(self.net.device)
-                oh_encoded_tensor = self.decoder(encoded_data)
-                oh_encoded_tensor = oh_encoded_tensor.to('cpu')
-                return self.onehot_encoder.decode(oh_encoded_tensor)
+        with torch.no_grad():
+            encoded_data = encoded_data.to(self.net.device)
+            oh_encoded_tensor = self.decoder(encoded_data)
+            oh_encoded_tensor = oh_encoded_tensor.to('cpu')
+            return self.onehot_encoder.decode(oh_encoded_tensor)

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -29,7 +29,8 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.max_encoded_length = max_encoded_length
 
     def _train_callback(self, error, real_buff, predicted_buff):
-        log.info(f'{self.name} reached a loss of {error} while training !')
+        pass
+        #  log.info(f'{self.name} reached a loss of {error} while training !')
 
     def _encoder_targets(self, data):
         oh_encoded_categories = self.onehot_encoder.encode(data)

--- a/lightwood/encoder/categorical/autoencoder.py
+++ b/lightwood/encoder/categorical/autoencoder.py
@@ -28,10 +28,6 @@ class CategoricalAutoEncoder(BaseEncoder):
         self.output_size = None
         self.max_encoded_length = max_encoded_length
 
-    def _train_callback(self, error, real_buff, predicted_buff):
-        pass
-        #  log.info(f'{self.name} reached a loss of {error} while training !')
-
     def _encoder_targets(self, data):
         oh_encoded_categories = self.onehot_encoder.encode(data)
         target = oh_encoded_categories.cpu().numpy()
@@ -79,7 +75,6 @@ class CategoricalAutoEncoder(BaseEncoder):
                                    test_data_loader,
                                    desired_error=self.desired_error,
                                    max_time=self.stop_after,
-                                   callback=self._train_callback,
                                    eval_every_x_epochs=1,
                                    max_unimproving_models=5)
 

--- a/lightwood/encoder/categorical/gym.py
+++ b/lightwood/encoder/categorical/gym.py
@@ -24,7 +24,7 @@ class Gym:
 
         self.best_model = None
 
-    def fit(self, train_data_loader, test_data_loader, desired_error, max_time, callback,
+    def fit(self, train_data_loader, test_data_loader, desired_error, max_time, callback=None,
             eval_every_x_epochs=1, max_unimproving_models=10, custom_train_func=None, custom_test_func=None):
         started = time.time()
         epoch = 0
@@ -126,7 +126,7 @@ class Gym:
                     delta_mean = np.mean(test_error_delta_buff[-max_unimproving_models:])
                     if delta_mean <= 0:
                         keep_training = False
-
-                callback(test_error, real_buff, predicted_buff)
+                if callback is not None:
+                    callback(test_error, real_buff, predicted_buff)
 
         return self.best_model, lowest_test_error, int(time.time() - started)

--- a/lightwood/encoder/text/short.py
+++ b/lightwood/encoder/text/short.py
@@ -87,10 +87,7 @@ class ShortTextEncoder(BaseEncoder):
     def decode(self, vectors):
         if self._mode == 'concat':
 
-            if self.cae.use_autoencoder:
-                vec_size = self.cae.max_encoded_length
-            else:
-                vec_size = len(self.cae.onehot_encoder._lang.index2word)
+            vec_size = self.cae.max_encoded_length
 
             output = []
             for vec in vectors:

--- a/tests/unit_tests/encoder/text/test_short.py
+++ b/tests/unit_tests/encoder/text/test_short.py
@@ -89,7 +89,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=True)
         enc.prepare(priming_data)
 
-        assert not enc.cae.use_autoencoder
         assert enc.is_target is True
 
         # _combine is expected to be 'concat' when is_target is True
@@ -113,7 +112,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=True)
         enc.prepare(priming_data)
 
-        assert not enc.cae.use_autoencoder
         assert enc.is_target is True
 
         # _combine is expected to be 'concat' when is_target is True
@@ -137,7 +135,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=False)
         enc.prepare(priming_data)
 
-        assert not enc.cae.use_autoencoder
         assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
@@ -157,7 +154,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=False)
         enc.prepare(priming_data)
 
-        assert enc.cae.use_autoencoder
         assert enc.is_target is False
 
         # _combine is expected to be 'mean' when is_target is False
@@ -177,7 +173,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=False, mode='concat')
         enc.prepare(priming_data)
 
-        assert not enc.cae.use_autoencoder
         assert enc.is_target is False
         assert enc._mode == 'concat'
 
@@ -199,7 +194,6 @@ class TestShortTextEncoder(unittest.TestCase):
         enc = ShortTextEncoder(is_target=False, mode='concat')
         enc.prepare(priming_data)
 
-        assert enc.cae.use_autoencoder
         assert enc.is_target is False
         assert enc._mode == 'concat'
 


### PR DESCRIPTION
Categorical AE and implicitly Short text encoder no longer switch to OHE mode for < 100 categories

Fixed bugs where pandas is replacing `None` with various stuff that's something else by aggressively checking all values pandas might replace `None` with and converting them back to `None` at cleaning time.

Addresses #547 