### PR TITLE
Restore icp args

### DIFF
--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -325,15 +325,16 @@ class ICP(BaseAnalysisBlock):
                                                                                   error_rate=error_rate)
 
                                     # only replace where grouped ICP is more informative (i.e. tighter)
-                                    default_icp_widths = result.loc[X.index, 'upper'] - result.loc[X.index, 'lower']
-                                    grouped_widths = np.subtract(confs[:, 1], confs[:, 0])
-                                    insert_index = (default_icp_widths > grouped_widths)[lambda x: x.isin([True])].index
-                                    conf_index = (default_icp_widths.reset_index(drop=True) >
-                                                  grouped_widths)[lambda x: x.isin([True])].index
+                                    if ns.fixed_confidence is None:
+                                        default_widths = result.loc[X.index, 'upper'] - result.loc[X.index, 'lower']
+                                        grouped_widths = np.subtract(confs[:, 1], confs[:, 0])
+                                        insert_index = (default_widths > grouped_widths)[lambda x: x.isin([True])].index
+                                        conf_index = (default_widths.reset_index(drop=True) >
+                                                      grouped_widths)[lambda x: x.isin([True])].index
 
-                                    result.loc[insert_index, 'lower'] = confs[conf_index, 0]
-                                    result.loc[insert_index, 'upper'] = confs[conf_index, 1]
-                                    result.loc[insert_index, 'significance'] = significances[conf_index]
+                                        result.loc[insert_index, 'lower'] = confs[conf_index, 0]
+                                        result.loc[insert_index, 'upper'] = confs[conf_index, 1]
+                                        result.loc[insert_index, 'significance'] = significances[conf_index]
 
                                 else:
                                     conf_candidates = list(range(20)) + list(range(20, 100, 10))

--- a/lightwood/api/__init__.py
+++ b/lightwood/api/__init__.py
@@ -9,6 +9,7 @@ from lightwood.api.types import (
     TimeseriesSettings,
     ModelAnalysis,
     DataAnalysis,
+    PredictionArguments,
 )
 from lightwood.api.predictor import PredictorInterface
 from lightwood.api.encode import encode
@@ -38,6 +39,7 @@ __all__ = [
     "TimeseriesSettings",
     "ModelAnalysis",
     "DataAnalysis",
+    "PredictionArguments",
     "PredictorInterface",
     "encode",
     "dtype",

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -1,6 +1,9 @@
-from lightwood.api.types import ModelAnalysis
+from typing import Dict
 import dill
+
 import pandas as pd
+
+from lightwood.api.types import ModelAnalysis
 
 
 # Interface that must be respected by predictor objects generated from JSON ML and/or compatible with Mindsdb
@@ -45,21 +48,23 @@ class PredictorInterface:
         """ # noqa
         pass
 
-    def predict(self, data: pd.DataFrame) -> pd.DataFrame:
+    def predict(self, data: pd.DataFrame, args: Dict[str, object] = {}) -> pd.DataFrame:
         """
         Intakes raw data to provide predicted values for your trained model.
 
         :param data: Data (n_samples, n_columns) that the model(s) will evaluate on and provide the target prediction.
+        :param args: parameters needed to update the predictor ``PredictionArguments`` object, which holds any parameters relevant for prediction.
 
         :returns: A dataframe of predictions of the same length of input.
-        """
+        """  # noqa
         pass
 
-    def predict_proba(self, data: pd.DataFrame) -> pd.DataFrame:
+    def predict_proba(self, data: pd.DataFrame, args: Dict[str, object] = {}) -> pd.DataFrame:
         """
         Intakes raw data to provide some element of confidence/explainability metric to gauge your model's predictive abilities.
 
         :param data: Data that the model(s) will evaluate on; provides the some element of predictive strength (ex: how "confident" the model is).
+        :param args: parameters needed to update the predictor ``PredictionArguments`` object, which holds any parameters relevant for prediction.
 
         :returns: A dataframe of confidence metrics for each datapoint provided in the input (n_samples, n_classes)
         """ # noqa

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -85,6 +85,13 @@ class TestTimeseries(unittest.TestCase):
             for timestamp in row[f'order_{order_by}']:
                 assert timestamp > latest_timestamp
 
+        # Check custom ICP params
+        test.pop('__mdb_make_predictions')
+        preds = pred.predict(test, {'fixed_confidence': 0.01, 'anomaly_cooldown': 100, 'anomaly_error_rate': 1})
+        assert all([all([v == 0.01 for v in f]) for f in preds['confidence'].values])
+        assert pred.pred_args.anomaly_error_rate == 1
+        assert pred.pred_args.anomaly_cooldown == 100
+
     def test_1_time_series_regression(self):
         data = pd.read_csv('tests/data/arrivals.csv')
         train, test = self.split_arrivals(data, grouped=False)

--- a/tests/integration/basic/test_boston_housing.py
+++ b/tests/integration/basic/test_boston_housing.py
@@ -35,9 +35,6 @@ class TestBasic(unittest.TestCase):
 
         # check customizable ICP fixed confidence param
         fixed_conf = 0.8
-        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 30, 'fixed_confidence': fixed_conf})
-        predictor = predictor_from_problem(df, pdef)
-        predictor.learn(df)
-        fixed_predictions = predictor.predict(df)
+        fixed_predictions = predictor.predict(df, {'fixed_confidence': fixed_conf})
 
         assert all([v == fixed_conf for v in fixed_predictions['confidence'].values])

--- a/tests/integration/basic/test_boston_housing.py
+++ b/tests/integration/basic/test_boston_housing.py
@@ -19,8 +19,9 @@ class TestBasic(unittest.TestCase):
 
         # Make this a quantity
         df[target] = [f'{x}$' for x in df[target]]
+        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 200})
 
-        predictor = predictor_from_problem(df, ProblemDefinition.from_dict({'target': target, 'time_aim': 200}))
+        predictor = predictor_from_problem(df, pdef)
         predictor.learn(df)
 
         assert predictor.model_analysis.dtypes[target] == dtype.quantity
@@ -31,3 +32,12 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(r2_score([float(x.rstrip('$')) for x in df[target]], predictions['prediction']) > 0.8)
         self.assertTrue(all([0 <= p <= 1 for p in predictions['confidence']]))
         self.assertTrue(all([p['lower'] <= p['prediction'] <= p['upper'] for _, p in predictions.iterrows()]))
+
+        # check customizable ICP fixed confidence param
+        fixed_conf = 0.8
+        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 30, 'fixed_confidence': fixed_conf})
+        predictor = predictor_from_problem(df, pdef)
+        predictor.learn(df)
+        fixed_predictions = predictor.predict(df)
+
+        assert all([v == fixed_conf for v in fixed_predictions['confidence'].values])


### PR DESCRIPTION
## Why 

To fix #562.

## How

Introduces a `PredictionArguments` dataclass that aims at generating defaults and setting any user-defined arguments for a `predict()` call. A couple statements are added in existing tests to account for the correct setting of these arguments.

Also, fixes a bug in the ICP block where the `fixed_confidence` setting would be incorrectly overridden in grouped TS tasks.
