### PR TITLE
Predictor interface

### DIFF
--- a/lightwood/api/encode.py
+++ b/lightwood/api/encode.py
@@ -3,8 +3,9 @@ import pandas as pd
 from lightwood.encoder.base import BaseEncoder
 from lightwood.data.encoded_ds import EncodedDs
 
+InputData = Union[pd.DataFrame, List[pd.DataFrame]]
 
-def encode(encoders: List[BaseEncoder], subsets: List[pd.DataFrame], target: str) -> List[EncodedDs]:
+def encode(encoders: List[BaseEncoder], subsets: InputData, target: str) -> List[EncodedDs]:
     """
     Given a list of Lightwood encoders, and data subsets, applies the encoders onto each subset.
 

--- a/lightwood/api/encode.py
+++ b/lightwood/api/encode.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 import pandas as pd
 from lightwood.encoder.base import BaseEncoder
 from lightwood.data.encoded_ds import EncodedDs

--- a/lightwood/api/high_level.py
+++ b/lightwood/api/high_level.py
@@ -18,9 +18,9 @@ import time
 
 def predictor_from_problem(df: pd.DataFrame, problem_definition: ProblemDefinition) -> PredictorInterface:
     """
-    Creates a ready-to-train ``Predictor`` object from some raw data and a ``ProblemDefinition``. Do not use this if you want to edit the JsonAI first. Usually you'd want to next train this predictor by calling the ``learn`` method on the same dataframe used to create it.
+    Creates a ready-to-train ``Predictor`` object from some unprocessed data and a ``ProblemDefinition``. Do not use this if you want to edit the JsonAI first. Usually you'd want to next train this predictor by calling the ``learn`` method on the same dataframe used to create it.
 
-    :param df: The raw data
+    :param df: The unprocessed dataset
     :param problem_definition: The manual specifications for your predictive problem
 
     :returns: A lightwood ``Predictor`` object
@@ -34,9 +34,9 @@ def predictor_from_problem(df: pd.DataFrame, problem_definition: ProblemDefiniti
 
 def json_ai_from_problem(df: pd.DataFrame, problem_definition: ProblemDefinition) -> JsonAI:
     """
-    Creates a JsonAI from your raw data and problem definition. Usually you would use this when you want to subsequently edit the JsonAI, the easiest way to do this is to unload it to a dictionary via `to_dict`, modify it, and then create a new object from it using `lightwood.JsonAI.from_dict`. It's usually better to generate the JsonAI using this function rather than writing it from scratch.
+    Creates a JsonAI from your unprocessed dataset and problem definition. Usually you would use this when you want to subsequently edit the JsonAI, the easiest way to do this is to unload it to a dictionary via `to_dict`, modify it, and then create a new object from it using `lightwood.JsonAI.from_dict`. It's usually better to generate the JsonAI using this function rather than writing it from scratch.
 
-    :param df: The raw data
+    :param df: The unprocessed dataset
     :param problem_definition: The manual specifications for your predictive problem
 
     :returns: A ``JsonAI`` object generated based on your data and problem specifications
@@ -82,7 +82,7 @@ def analyze_dataset(df: pd.DataFrame) -> DataAnalysis:
     """
     You can use this to understand and visualize the data, it's not a part of the pipeline one would use for creating and training predictive models.
 
-    :param df: The raw data
+    :param df: The unprocessed data
 
     :returns: An object containing insights about the data (specifically the type information and statistical analysis)
     """ # noqa
@@ -101,7 +101,9 @@ def analyze_dataset(df: pd.DataFrame) -> DataAnalysis:
 
 def code_from_problem(df: pd.DataFrame, problem_definition: ProblemDefinition) -> str:
     """
-    :param df: The raw data
+    Create automatically generated python code from a ``ProblemDefinition`` object. Writes code according to specifications of the ``PredictorInterface``. 
+
+    :param df: The unprocessed data
     :param problem_definition: The manual specifications for your predictive problem
 
     :returns: The text code generated based on your data and problem specifications
@@ -113,6 +115,8 @@ def code_from_problem(df: pd.DataFrame, problem_definition: ProblemDefinition) -
 
 def predictor_from_state(state_file: str, code: str = None) -> PredictorInterface:
     """
+    Given a saved predictor/module, construct a Lightwood Predictor object. If code syntax is provided, it will create a Predictor object from the syntax.
+
     :param state_file: The file containing the pickle resulting from calling ``save`` on a ``Predictor`` object
     :param code: The ``Predictor``'s code in text form
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -1,7 +1,7 @@
 from lightwood.api.types import ModelAnalysis
 import dill
 import pandas as pd
-
+from typing import Dict
 
 # Interface that must be respected by predictor objects generated from JSON ML and/or compatible with Mindsdb
 class PredictorInterface:
@@ -24,13 +24,59 @@ class PredictorInterface:
     def __init__(self):
         pass
 
+    def analyze_data(self, data: pd.DataFrame) -> None:
+        """
+        Performs a statistical analysis on the data to identify distributions, imbalanced classes, and other nuances within the data.
+
+        :param data: Data used in training the model(s).
+        """ # noqa
+        pass
+
+    def preprocess(self, data: pd.DataFrame) -> pd.DataFrame:
+        """
+        Cleans the unprocessed dataset provided.
+
+        :param data: (Unprocessed) Data used in training the model(s).
+        :returns: The cleaned data frame
+        """ # noqa
+        pass
+
+    def split(self, clean_data: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        """
+        Categorizes the data into a training/testing split; if data is a classification problem, will stratify the data.
+
+        :param clean_data: Pre-processed data.
+        :returns: Dictionary containing training/testing fraction
+        """ # noqa
+        pass
+
+    def featurize(self, train_test: Dict[str, pd.DataFrame]):
+        """
+        Prepares the encoders for each column of data, and provides an encoded representation for each dataset in ``train_test``.
+
+        :param train_test: Pre-processed data from the dataset, split into train/test (or any other keys relevant)
+
+        :returns: For each dataset provided in ``train_test``, the encoded representations of the data.
+        """ # noqa
+        pass
+
+    def fit(self, enc_train_test: dict[str, pd.DataFrame]) -> None:
+        """
+        Fits "mixer" models to train predictors on the featurized data.
+
+        :param enc_train_test: Pre-processed and featurized data, split into the relevant train/test splits.
+        """
+        pass
+
     def learn(self, data: pd.DataFrame) -> None:
         """
         Trains the attribute model starting from raw data. Raw data is pre-processed and cleaned accordingly. As data is assigned a particular type (ex: numerical, categorical, etc.), the respective feature encoder will convert it into a representation useable for training ML models. Of all ML models requested, these models are compiled and fit on the training data.
 
-        :param data: Data used in training the model(s).
+        This step amalgates ``preprocess`` -> ``featurize`` -> ``fit`` with the necessary splitting + analyze_data that occurs. 
 
-        :returns: Provides best fit model.
+        :param data: (Unprocessed) Data used in training the model(s).
+
+        :returns: Nothing; instantiates with best fit model from ensemble.
         """ # noqa
         pass
 
@@ -41,7 +87,7 @@ class PredictorInterface:
         ..warnings:: Not tested yet - this is an experimental feature
         :param data: New data used to adjust a previously trained model.
 
-        :returns: Adjusts best-fit model
+        :returns: Nothing; adjusts best-fit model
         """ # noqa
         pass
 
@@ -52,7 +98,7 @@ class PredictorInterface:
         :param data: Data (n_samples, n_columns) that the model(s) will evaluate on and provide the target prediction.
 
         :returns: A dataframe of predictions of the same length of input.
-        """
+        """ # noqa
         pass
 
     def predict_proba(self, data: pd.DataFrame) -> pd.DataFrame:

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -50,9 +50,18 @@ class PredictorInterface:
         """ # noqa
         pass
 
+    def prepare(self,train_test: Dict[str, pd.DataFrame]) -> None:
+        """
+        Prepares the encoders for each column of data. 
+
+        :param train_test: Pre-processed data that has been split into train/test. Explicitly uses "train" in preparation of encoders.
+
+        :returns: Nothing; prepares the encoders for learned representations.
+        """
+
     def featurize(self, train_test: Dict[str, pd.DataFrame]):
         """
-        Prepares the encoders for each column of data, and provides an encoded representation for each dataset in ``train_test``.
+        Provides an encoded representation for each dataset in ``train_test``. Requires `self.encoders` to be prepared.
 
         :param train_test: Pre-processed data from the dataset, split into train/test (or any other keys relevant)
 
@@ -60,7 +69,7 @@ class PredictorInterface:
         """ # noqa
         pass
 
-    def fit(self, enc_train_test: dict[str, pd.DataFrame]) -> None:
+    def fit(self, enc_train_test: Dict[str, pd.DataFrame]) -> None:
         """
         Fits "mixer" models to train predictors on the featurized data.
 

--- a/lightwood/encoder/array/array.py
+++ b/lightwood/encoder/array/array.py
@@ -8,13 +8,13 @@ from lightwood.encoder.time_series.helpers.common import MinMaxNormalizer, CatNo
 
 
 class ArrayEncoder(BaseEncoder):
+    """
+    Fits a normalizer for an array (could be either a normal array or a time series).
+    When encoding, it returns a normalized window of previous data.
+    """
     is_trainable_encoder: bool = True
 
     def __init__(self, stop_after: int, window: int = None, is_target: bool = False, original_type: dtype = None):
-        """
-        Fits a normalizer for a time series previous historical data.
-        When encoding, it returns a normalized window of previous data.
-        """
         super().__init__(is_target)
         self.stop_after = stop_after
         self.original_type = original_type

--- a/lightwood/encoder/audio/amplitude_ts.py
+++ b/lightwood/encoder/audio/amplitude_ts.py
@@ -4,14 +4,18 @@ import requests
 import numpy as np
 import torch
 from lightwood.encoder.base import BaseEncoder
+from lightwood.encoder.array.array import ArrayEncoder
 from lightwood.helpers.log import log
 
 
 class AmplitudeTsEncoder(BaseEncoder):
+    """
+    Encodes a raw audio signal by wrapping the ArrayEncoder.
+    """
 
     def __init__(self, is_target: bool = False):
         super().__init__(is_target)
-        self._ts_encoder = TimeSeriesEncoder()
+        self._ts_encoder = ArrayEncoder()
         self._max_samples = 2000
 
     def encode(self, column_data):

--- a/lightwood/encoder/base.py
+++ b/lightwood/encoder/base.py
@@ -3,17 +3,40 @@ import torch
 
 
 class BaseEncoder:
-    """Base class for all encoders"""
-    is_target: bool
-    prepared: bool
+    """
+    Base class for all encoders.
 
+    An encoder should return encoded representations of any columnar data.
+    The procedure for this is defined inside the `encode()` method.
+
+    If this encoder is expected to handle an output column, then it also needs to
+    implement the respective `decode()` method that handles the inverse transformation
+    from encoded representations to the final prediction in the original column space.
+
+    For encoders that learn representations (as opposed to rule-based), the `prepare()`
+    method will handle all learning logic.
+
+    The `to()` method is used to move PyTorch-based encoders to and from a GPU.
+
+
+    Class attributes:
+        - is_target: Whether the data to encode is the target, as per the problem definition.
+        - _prepared: Internal flag to signal that the `prepare()` method has been successfully executed.
+        - is_nn_encoder: Whether the encoder is neural network-based.
+        - dependencies: list of additional columns that the encoder might need to encode.
+        - output_size: length of each encoding tensor for a single data point.
+
+    """
+    is_target: bool
     is_timeseries_encoder: bool = False
     is_trainable_encoder: bool = False
 
     def __init__(self, is_target=False) -> None:
+        """
+
+        """
         self.is_target = is_target
         self._prepared = False
-        self.uses_subsets = False
         self.is_nn_encoder = False
         self.dependencies = []
         self.output_size = None

--- a/lightwood/encoder/base.py
+++ b/lightwood/encoder/base.py
@@ -27,14 +27,13 @@ class BaseEncoder:
         - output_size: length of each encoding tensor for a single data point.
 
     """
+
     is_target: bool
     is_timeseries_encoder: bool = False
     is_trainable_encoder: bool = False
 
     def __init__(self, is_target=False) -> None:
-        """
-
-        """
+        """"""
         self.is_target = is_target
         self._prepared = False
         self.is_nn_encoder = False

--- a/lightwood/encoder/base.py
+++ b/lightwood/encoder/base.py
@@ -9,24 +9,24 @@ class BaseEncoder:
     An encoder should return encoded representations of any columnar data.
     The procedure for this is defined inside the `encode()` method.
 
-    If this encoder is expected to handle an output column, then it also needs to
-    implement the respective `decode()` method that handles the inverse transformation
-    from encoded representations to the final prediction in the original column space.
+    If this encoder is expected to handle an output column, then it also needs to implement the respective `decode()` method that handles the inverse transformation from encoded representations to the final prediction in the original column space.
 
-    For encoders that learn representations (as opposed to rule-based), the `prepare()`
-    method will handle all learning logic.
+    For encoders that learn representations (as opposed to rule-based), the `prepare()` method will handle all learning logic.
 
     The `to()` method is used to move PyTorch-based encoders to and from a GPU.
 
+    
+    :param  is_target: Whether the data to encode is the target, as per the problem definition.
+    :param is_timeseries_encoder: Whether encoder represents sequential/time-series data. Lightwood must provide specific treatment for this kind of encoder
+    :param is_trainable_encoder: Whether the encoder must return learned representations. Lightwood checks whether this flag is present in order to pass data to the feature representation via the ``prepare`` statement. 
 
-    Class attributes:
-        - is_target: Whether the data to encode is the target, as per the problem definition.
-        - _prepared: Internal flag to signal that the `prepare()` method has been successfully executed.
-        - is_nn_encoder: Whether the encoder is neural network-based.
-        - dependencies: list of additional columns that the encoder might need to encode.
-        - output_size: length of each encoding tensor for a single data point.
+    Class Attributes:
+    - _prepared: Internal flag to signal that the `prepare()` method has been successfully executed.
+    - is_nn_encoder: Whether the encoder is neural network-based.
+    - dependencies: list of additional columns that the encoder might need to encode.
+    - output_size: length of each encoding tensor for a single data point.
 
-    """
+    """ # noqa
 
     is_target: bool
     is_timeseries_encoder: bool = False


### PR DESCRIPTION
To encourage transparency in the `PredictorInterface`, I have abstracted several of the steps that learn does automatically. Main changes include:

(1) Preprocess function - solely handles data cleaning
(2) Split function - handles train/test split
(3) Prepare function - handles training of encoders
(4) Featurize function - handles creating features from trained encoders
(5) Fit function - trains mixers
(6) Learn function - calls the above 5 steps appropriately.

I have also moved some of the inits to the instantiation of the Predictor model. 

**THIS IS NOT FUNCTIONAL YET; IT IS A WIP.**