### PR TITLE
Various fixes based on mindsdb CI

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -354,11 +354,13 @@ def generate_json_ai(
 
 
 def merge_implicit_values(field, implicit_value):
+    exec(IMPORTS, globals())
+    exec(IMPORT_EXTERNAL_DIRS, globals())
     module = eval(field['module'])
     if inspect.isclass(module):
-        args = inspect.getargspec(module.__init__).args[1:]
+        args = list(inspect.signature(module.__init__).parameters.keys())[1:]
     else:
-        args = eval(field['module']).__code__.co_varnames
+        args = module.__code__.co_varnames
 
     for arg in args:
         if 'args' not in field:

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -740,6 +740,11 @@ for mixer in self.mixers:
     learn_body = align(learn_body, 2)
 
     predict_common_body = f"""
+log.info(f'Dropping features: {{self.problem_definition.ignore_features}}')
+data = data.drop(columns=self.problem_definition.ignore_features)
+for col in self.input_cols:
+    if col not in data.columns:
+        data[col] = [None] * len(data)
 self.mode = 'predict'
 log.info('Cleaning the data')
 data = {call(json_ai.cleaner)}
@@ -789,15 +794,11 @@ class Predictor(PredictorInterface):
 {learn_body}
 
     def predict(self, data: pd.DataFrame) -> pd.DataFrame:
-        log.info(f'Dropping features: {{self.problem_definition.ignore_features}}')
-        data = data.drop(columns=self.problem_definition.ignore_features)
 {predict_common_body}
 {predict_body}
 
 
     def predict_proba(self, data: pd.DataFrame) -> pd.DataFrame:
-        log.info(f'Dropping features: {{self.problem_definition.ignore_features}}')
-        data = data.drop(columns=self.problem_definition.ignore_features)
 {predict_common_body}
 {predict_proba_body}
 """

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -12,14 +12,13 @@ from lightwood.helpers.general import evaluate_accuracy
 
 class BestOf(BaseEnsemble):
     indexes_by_accuracy: List[float]
-    
 
     def __init__(self, target, mixers: List[BaseMixer], data: EncodedDs, accuracy_functions,
                  ts_analysis: Optional[dict] = None) -> None:
         super().__init__(target, mixers, data)
 
         score_list = []
-        for idx, mixer in enumerate(mixers):
+        for _, mixer in enumerate(mixers):
             score_dict = evaluate_accuracy(
                 data.data_frame,
                 mixer(data)['prediction'],

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -11,14 +11,14 @@ from lightwood.helpers.general import evaluate_accuracy
 
 
 class BestOf(BaseEnsemble):
-    best_index: int
+    indexes_by_accuracy: List[float]
+    
 
     def __init__(self, target, mixers: List[BaseMixer], data: EncodedDs, accuracy_functions,
                  ts_analysis: Optional[dict] = None) -> None:
         super().__init__(target, mixers, data)
-        # @TODO: Need some shared accuracy functionality to determine mixer selection here
-        self.maximize = True
-        best_score = -pow(2, 32) if self.maximize else pow(2, 32)
+
+        score_list = []
         for idx, mixer in enumerate(mixers):
             score_dict = evaluate_accuracy(
                 data.data_frame,
@@ -28,16 +28,23 @@ class BestOf(BaseEnsemble):
                 ts_analysis=ts_analysis
             )
             avg_score = np.mean(list(score_dict.values()))
-            log.info(f'Mixer {type(mixer).__name__} obtained a best-of evaluation score of {round(avg_score,4)}')
-            if self.improves(avg_score, best_score, accuracy_functions):
-                best_score = avg_score
-                self.best_index = idx
+            score_list.append(avg_score)
 
-        self.supports_proba = self.mixers[self.best_index].supports_proba
-        log.info(f'Picked best mixer: {type(self.mixers[self.best_index]).__name__}')
+        self.indexes_by_accuracy = np.array(score_list).argsort()
+
+        self.supports_proba = self.mixers[self.indexes_by_accuracy[0]].supports_proba
+        log.info(f'Picked best mixer: {type(self.mixers[self.indexes_by_accuracy[0]]).__name__}')
 
     def __call__(self, ds: EncodedDs, predict_proba: bool = False) -> pd.DataFrame:
-        return self.mixers[self.best_index](ds, predict_proba=predict_proba)
+        for mixer_index in self.indexes_by_accuracy:
+            try:
+                return self.mixers[mixer_index](ds, predict_proba=predict_proba)
+            except Exception as e:
+                if self.mixers.stable:
+                    raise(e)
+                else:
+                    log.warning(f'Unstable mixer {type(self.mixers[mixer_index]).__name__} failed with exception: {e}.\
+                    Trying next best')
 
     def improves(self, new, old, functions):
         return new > old if self.maximize else new < old

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -44,6 +44,3 @@ class BestOf(BaseEnsemble):
                 else:
                     log.warning(f'Unstable mixer {type(self.mixers[mixer_index]).__name__} failed with exception: {e}.\
                     Trying next best')
-
-    def improves(self, new, old, functions):
-        return new > old if self.maximize else new < old

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -40,7 +40,7 @@ class BestOf(BaseEnsemble):
             try:
                 return self.mixers[mixer_index](ds, predict_proba=predict_proba)
             except Exception as e:
-                if self.mixers.stable:
+                if self.mixers[mixer_index].stable:
                     raise(e)
                 else:
                     log.warning(f'Unstable mixer {type(self.mixers[mixer_index]).__name__} failed with exception: {e}.\

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -29,8 +29,7 @@ class BestOf(BaseEnsemble):
             avg_score = np.mean(list(score_dict.values()))
             score_list.append(avg_score)
 
-        self.indexes_by_accuracy = np.array(score_list).argsort()
-
+        self.indexes_by_accuracy = list(reversed(np.array(score_list).argsort()))
         self.supports_proba = self.mixers[self.indexes_by_accuracy[0]].supports_proba
         log.info(f'Picked best mixer: {type(self.mixers[self.indexes_by_accuracy[0]]).__name__}')
 


### PR DESCRIPTION
* Unstable mixers can fail without the `predict` method throwing when `BestOf` ensemble is used
* If columns are missing in the `predict` data frame we replace them with an array of `None`
* Made json ai custom modules / editing work when lightwood is launched  as a mindsdb subprocess