### PR TITLE
Use `LIGHTWOOD_LOG` environment variable to set logging level

### DIFF
--- a/lightwood/helpers/log.py
+++ b/lightwood/helpers/log.py
@@ -6,7 +6,8 @@ def initialize_log():
     pid = os.getpid()
     logging.basicConfig()
     log = logging.getLogger(f'lightwood-{pid}')
-    log.setLevel(logging.DEBUG)
+    log_level = os.environ.get('LIGHTWOOD_LOG', 'DEBUG')
+    log.setLevel(log_level)
     return log
 
 


### PR DESCRIPTION
(Fixes #600)

We use `os.environ.get` to obtain the value of the `LIGHTWOOD_LOG` environment variable. If this is not set, we default to `DEBUG` logging level (is this OK?).

If the environment variable contains a string which is not in:
```
_nameToLevel = {
    'CRITICAL': CRITICAL,
    'FATAL': FATAL,
    'ERROR': ERROR,
    'WARN': WARNING,
    'WARNING': WARNING,
    'INFO': INFO,
    'DEBUG': DEBUG,
    'NOTSET': NOTSET,
}
```
(from `logging/__init__.py`)

then a `ValueError` will be raised.