### PR TITLE
Implement colored logging with colorlog

### DIFF
--- a/lightwood/helpers/log.py
+++ b/lightwood/helpers/log.py
@@ -1,10 +1,15 @@
 import logging
 import os
+import colorlog
 
 
 def initialize_log():
     pid = os.getpid()
-    logging.basicConfig()
+
+    handler = colorlog.StreamHandler()
+    handler.setFormatter(colorlog.ColoredFormatter())
+
+    logging.basicConfig(handlers=[handler])
     log = logging.getLogger(f'lightwood-{pid}')
     log.setLevel(logging.DEBUG)
     return log

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ torch_optimizer == 0.1.0
 pmdarima >= 1.8.0
 black >= 21.9b0
 typing_extensions
+colorlog==6.5.0


### PR DESCRIPTION
# Why is it needed ?

Closes #606

# What does it do ?

Uses the [`colorlog`](https://github.com/borntyping/python-colorlog) library to add colored output.

# Screenshots

![image](https://user-images.githubusercontent.com/8144521/136767849-3943aa95-acfb-409d-8672-8de33c310c94.png)
