### PR TITLE
Upgrade cla bot version

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
         # Alpha Release
-        uses: cla-assistant/github-action@v2.0.3-alpha
+        uses: cla-assistant/github-action@v2.1.3-beta
         env: 
           GITHUB_TOKEN: ${{ secrets.CLA_TOKEN }}          
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_TOKEN }}


### PR DESCRIPTION
Use a new version of the cla assistant bot since the old version was not triggering the agreement.