### PR TITLE
Changing doc_build trigger during pull_request

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -7,10 +7,12 @@ on:
       - staging
   pull_request:
     types: [ closed ]
+    branches:
+      - staging
 
 jobs:
   doc_build:
-    if: github.event.pull_request.merged == true or github.event.pull_request.merged == nil
+    if: (github.event.pull_request.merged == true || github.event.pull_request.merged == nil)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #651 (hopefully)

Removing option to run pull_request trigger in doc_build.yml. Effectively allowing the workflow to build / run during the merge of the related pull_request (reducing confusion).