### PR TITLE
Move array/TS normalizers to generic helpers

### DIFF
--- a/lightwood/encoder/array/array.py
+++ b/lightwood/encoder/array/array.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 from lightwood.encoder.base import BaseEncoder
 from lightwood.api import dtype
-from lightwood.encoder.time_series.helpers.common import MinMaxNormalizer, CatNormalizer
+from lightwood.encoder.helpers import MinMaxNormalizer, CatNormalizer
 
 
 class ArrayEncoder(BaseEncoder):
@@ -12,9 +12,12 @@ class ArrayEncoder(BaseEncoder):
     Fits a normalizer for array data. To encode, `ArrayEncoder` returns a normalized window of previous data.
     It can be used for generic arrays, as well as for handling historical target values in time series tasks.
 
+    Currently supported normalizing strategies are minmax for numerical arrays, and a simple one-hot for categorical arrays. See `lightwood.encoder.helpers` for more details on each approach.
+
     :param stop_after: time budget in seconds.
     :param window: expected length of array data.
-    """
+    :param original_dtype: element-wise data type
+    """  # noqa
 
     is_trainable_encoder: bool = True
 

--- a/lightwood/encoder/datetime/datetime.py
+++ b/lightwood/encoder/datetime/datetime.py
@@ -6,6 +6,11 @@ from lightwood.encoder.base import BaseEncoder
 
 
 class DatetimeEncoder(BaseEncoder):
+    """
+    This encoder produces an encoded representation for timestamps.
+
+    The approach consists on decomposing the timestamp objects into its constituent units (e.g. day-of-week, month, year, etc), and describing each of those with a single value that represents the magnitude in a sensible cycle length.
+    """  # noqa
     def __init__(self, is_target: bool = False):
         super().__init__(is_target)
         self.fields = ['year', 'month', 'day', 'weekday', 'hour', 'minute', 'second']

--- a/lightwood/encoder/helpers.py
+++ b/lightwood/encoder/helpers.py
@@ -1,0 +1,74 @@
+import torch
+import numpy as np
+from sklearn.preprocessing import MinMaxScaler, OneHotEncoder, OrdinalEncoder
+
+
+class MinMaxNormalizer:
+    def __init__(self, combination=()):
+        self.scaler = MinMaxScaler()
+        self.abs_mean = None
+        self.combination = combination  # tuple with values in grouped-by columns
+        self.output_size = 1
+
+    def prepare(self, x: np.ndarray) -> None:
+        # @TODO: streamline input type
+        if isinstance(x[0], list):
+            x = np.vstack(x)
+        if isinstance(x[0], torch.Tensor):
+            x = torch.stack(x).numpy()
+        if len(x.shape) < 2:
+            x = np.expand_dims(x, axis=1)
+
+        x = x.astype(float)
+        x[x == None] = 0 # noqa
+        self.abs_mean = np.mean(np.abs(x))
+        self.scaler.fit(x)
+
+    def encode(self, y: np.ndarray) -> torch.Tensor:
+        if isinstance(y[0], list):
+            y = np.vstack(y)
+        if isinstance(y[0], torch.Tensor):
+            y = torch.stack(y).numpy()
+        if len(y.shape) < 2:
+            y = np.expand_dims(y, axis=1)
+
+        shape = y.shape
+        y = y.astype(float).reshape(-1, self.scaler.n_features_in_)
+        out = torch.reshape(torch.Tensor(self.scaler.transform(y)), shape)
+        return out
+
+    def decode(self, y):
+        return self.scaler.inverse_transform(y)
+
+
+class CatNormalizer:
+    def __init__(self, encoder_class='one_hot'):
+        self.encoder_class = encoder_class
+        if encoder_class == 'one_hot':
+            self.scaler = OneHotEncoder(sparse=False, handle_unknown='ignore')
+        else:
+            self.scaler = OrdinalEncoder()
+
+        self.unk = "<UNK>"
+
+    def prepare(self, x):
+        X = []
+        for i in x:
+            for j in i:
+                X.append(j if j is not None else self.unk)
+        self.scaler.fit(np.array(X).reshape(-1, 1))
+        self.output_size = len(self.scaler.categories_[0]) if self.encoder_class == 'one_hot' else 1
+
+    def encode(self, Y):
+        y = np.array([[str(j) if j is not None else self.unk for j in i] for i in Y])
+        out = []
+        for i in y:
+            transformed = self.scaler.transform(i.reshape(-1, 1))
+            if isinstance(self.scaler, OrdinalEncoder):
+                transformed = transformed.flatten()
+            out.append(transformed)
+
+        return torch.Tensor(out)
+
+    def decode(self, y):
+        return [[i[0] for i in self.scaler.inverse_transform(o)] for o in y]

--- a/lightwood/encoder/time_series/helpers/common.py
+++ b/lightwood/encoder/time_series/helpers/common.py
@@ -1,82 +1,9 @@
 from itertools import product
 
-import torch
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import MinMaxScaler, OneHotEncoder, OrdinalEncoder
 
 from lightwood.api.dtype import dtype
-
-
-class MinMaxNormalizer:
-    def __init__(self, combination=()):
-        self.scaler = MinMaxScaler()
-        self.abs_mean = None
-        self.combination = combination  # tuple with values in grouped-by columns
-        self.output_size = 1
-
-    def prepare(self, x: np.ndarray) -> None:
-        # @TODO: streamline input type
-        if isinstance(x[0], list):
-            x = np.vstack(x)
-        if isinstance(x[0], torch.Tensor):
-            x = torch.stack(x).numpy()
-        if len(x.shape) < 2:
-            x = np.expand_dims(x, axis=1)
-
-        x = x.astype(float)
-        x[x == None] = 0 # noqa
-        self.abs_mean = np.mean(np.abs(x))
-        self.scaler.fit(x)
-
-    def encode(self, y: np.ndarray) -> torch.Tensor:
-        if isinstance(y[0], list):
-            y = np.vstack(y)
-        if isinstance(y[0], torch.Tensor):
-            y = torch.stack(y).numpy()
-        if len(y.shape) < 2:
-            y = np.expand_dims(y, axis=1)
-
-        shape = y.shape
-        y = y.astype(float).reshape(-1, self.scaler.n_features_in_)
-        out = torch.reshape(torch.Tensor(self.scaler.transform(y)), shape)
-        return out
-
-    def decode(self, y):
-        return self.scaler.inverse_transform(y)
-
-
-class CatNormalizer:
-    def __init__(self, encoder_class='one_hot'):
-        self.encoder_class = encoder_class
-        if encoder_class == 'one_hot':
-            self.scaler = OneHotEncoder(sparse=False, handle_unknown='ignore')
-        else:
-            self.scaler = OrdinalEncoder()
-
-        self.unk = "<UNK>"
-
-    def prepare(self, x):
-        X = []
-        for i in x:
-            for j in i:
-                X.append(j if j is not None else self.unk)
-        self.scaler.fit(np.array(X).reshape(-1, 1))
-        self.output_size = len(self.scaler.categories_[0]) if self.encoder_class == 'one_hot' else 1
-
-    def encode(self, Y):
-        y = np.array([[str(j) if j is not None else self.unk for j in i] for i in Y])
-        out = []
-        for i in y:
-            transformed = self.scaler.transform(i.reshape(-1, 1))
-            if isinstance(self.scaler, OrdinalEncoder):
-                transformed = transformed.flatten()
-            out.append(transformed)
-
-        return torch.Tensor(out)
-
-    def decode(self, y):
-        return [[i[0] for i in self.scaler.inverse_transform(o)] for o in y]
 
 
 def get_group_matches(data, combination):

--- a/lightwood/encoder/time_series/helpers/common.py
+++ b/lightwood/encoder/time_series/helpers/common.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from lightwood.api.dtype import dtype
+from lightwood.encoder.helpers import MinMaxNormalizer, CatNormalizer
 
 
 def get_group_matches(data, combination):

--- a/lightwood/encoder/time_series/rnn.py
+++ b/lightwood/encoder/time_series/rnn.py
@@ -16,7 +16,8 @@ from lightwood.helpers.device import get_devices
 from lightwood.helpers.torch import LightwoodAutocast
 from lightwood.encoder.datetime import DatetimeNormalizerEncoder
 from lightwood.encoder.time_series.helpers.rnn_helpers import EncoderRNNNumerical, DecoderRNNNumerical
-from lightwood.encoder.time_series.helpers.common import MinMaxNormalizer, CatNormalizer, get_group_matches
+from lightwood.encoder.helpers import MinMaxNormalizer, CatNormalizer
+from lightwood.encoder.time_series.helpers.common import get_group_matches
 from lightwood.encoder.time_series.helpers.transformer_helpers import TransformerEncoder, get_chunk, len_to_mask
 
 

--- a/lightwood/encoder/time_series/rnn.py
+++ b/lightwood/encoder/time_series/rnn.py
@@ -22,6 +22,11 @@ from lightwood.encoder.time_series.helpers.transformer_helpers import Transforme
 
 
 class TimeSeriesEncoder(BaseEncoder):
+    """
+    Time series encoder. This module can learn features for any `order_by` temporal column, both with and without accompanying target data.
+
+    The backbone of this encoder is either a recurrent neural network or a transformer; both structured in an encoder-decoder fashion.
+    """  # noqa
     is_timeseries_encoder: bool = True
     is_trainable_encoder: bool = True
 

--- a/tests/unit_tests/encoder/time_series/test_timeseries_rnn.py
+++ b/tests/unit_tests/encoder/time_series/test_timeseries_rnn.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import torch
 from lightwood.encoder.time_series import TimeSeriesEncoder
-from lightwood.encoder.time_series.helpers.common import MinMaxNormalizer, CatNormalizer
+from lightwood.encoder.helpers import MinMaxNormalizer, CatNormalizer
 import pandas as pd
 
 


### PR DESCRIPTION
## Why
To streamline the codebase.

## How
As these normalizers are no longer TS-only blocks, so it makes sense to move them to `lightwood/encoders/helpers`.

Additionally, added/modified docstrings of:
- `ArrayEncoder`
- `DatetimeEncoder`
- `TimeSeriesEncoder`