### PR TITLE
Documentation for /most/ lightwood modules

### DIFF
--- a/docssrc/source/analysis.rst
+++ b/docssrc/source/analysis.rst
@@ -1,0 +1,7 @@
+:mod:`Analysis`
+==========================
+
+Analyse mixer ensembles to extract static insights and train predict-time models for dynamic insights.
+
+.. automodule:: analysis
+   :members:

--- a/docssrc/source/api.rst
+++ b/docssrc/source/api.rst
@@ -1,15 +1,15 @@
-:mod:`API Module`
+:mod:`API`
 ==========================
 
-The Lightwood API Table of Contents
---------------------------------------
 The API module is how Lightwood interfaces with the user.
 
 .. toctree::
    :maxdepth: 1
    :caption: Table of Contents:
 
+   api/high_level
    api/dtype
    api/types
    api/predictor
    api/json_ai
+   api/encode

--- a/docssrc/source/data.rst
+++ b/docssrc/source/data.rst
@@ -1,0 +1,7 @@
+:mod:`Data`
+==========================
+
+The focus of these modules is on storing, transforming, cleaning, splitting, merging, getting and removing data.
+
+.. automodule:: data
+   :members:

--- a/docssrc/source/data/cleaner.rst
+++ b/docssrc/source/data/cleaner.rst
@@ -1,0 +1,5 @@
+Data Cleaning
+--------------------
+
+.. automodule:: data.cleaner
+   :members:

--- a/docssrc/source/encoder.rst
+++ b/docssrc/source/encoder.rst
@@ -1,0 +1,7 @@
+:mod:`Encoders`
+==========================
+
+Used for encoding data into pytorch tensorsand decoding it from pytorch tensors
+
+.. automodule:: encoder
+   :members:

--- a/docssrc/source/encoder.rst
+++ b/docssrc/source/encoder.rst
@@ -1,7 +1,7 @@
 :mod:`Encoders`
 ==========================
 
-Used for encoding data into pytorch tensorsand decoding it from pytorch tensors
+Used for encoding data into PyTorch tensors and decoding it from pytorch tensors
 
 .. automodule:: encoder
    :members:

--- a/docssrc/source/ensemble.rst
+++ b/docssrc/source/ensemble.rst
@@ -1,0 +1,7 @@
+:mod:`Ensemble`
+==========================
+
+Ensemble mixers together in order to generate predictions
+
+.. automodule:: ensemble
+   :members:

--- a/docssrc/source/helpers.rst
+++ b/docssrc/source/helpers.rst
@@ -1,0 +1,7 @@
+:mod:`Helpers`
+==========================
+
+Various helper functions
+
+.. automodule:: helpers
+   :members:

--- a/docssrc/source/index.rst
+++ b/docssrc/source/index.rst
@@ -269,3 +269,9 @@ Other Links
    lightwood_philosophy
    tutorials
    api
+   data
+   encoder
+   mixer
+   ensemble
+   analysis
+   helpers

--- a/docssrc/source/mixer.rst
+++ b/docssrc/source/mixer.rst
@@ -1,0 +1,7 @@
+:mod:`Mixers`
+==========================
+
+Machine learning models which train to map features to the target, usually using the encoded representations.
+
+.. automodule:: mixer
+   :members:

--- a/docssrc/source/mixer.rst
+++ b/docssrc/source/mixer.rst
@@ -1,7 +1,7 @@
 :mod:`Mixers`
 ==========================
 
-Machine learning models which train to map features to the target, usually using the encoded representations.
+Machine learning models which learn to predict the target value using the encoded representations.
 
 .. automodule:: mixer
    :members:


### PR DESCRIPTION
We need to migrate to the latest sphinx to use something like autosummary in order to not document like we're in the stone age.

*But* until we can do that we need to at least display most of what's documented in the actual docs.

This adds the doctree for the `__init__.py` file of each top-level lightwood directory to the index.

It also removes some extra headings which caused really nasty hierarchies with 1 to 3 elements that had a single child.