### PR TITLE
Remove type mapping

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -134,27 +134,22 @@ def lookup_encoder(
             encoder_dict["args"]["original_type"] = f'"{col_dtype}"'
             encoder_dict["args"]["target"] = "self.target"
             encoder_dict["args"]["grouped_by"] = f"{gby}"
-            encoder_dict["args"]["data_dtype"] = col_dtype
 
         if is_target:
             if col_dtype in [dtype.integer]:
                 encoder_dict["args"]["grouped_by"] = f"{gby}"
                 encoder_dict["module"] = "TsNumericEncoder"
-                encoder_dict["args"]["data_dtype"] = dtype.integer
             if col_dtype in [dtype.float]:
                 encoder_dict["args"]["grouped_by"] = f"{gby}"
                 encoder_dict["module"] = "TsNumericEncoder"
-                encoder_dict["args"]["data_dtype"] = dtype.float
             if tss.nr_predictions > 1:
                 encoder_dict["args"]["grouped_by"] = f"{gby}"
                 encoder_dict["args"]["timesteps"] = f"{tss.nr_predictions}"
                 encoder_dict["module"] = "TsArrayNumericEncoder"
-                encoder_dict["args"]["data_dtype"] = dtype.tsarray
         if "__mdb_ts_previous" in col_name:
             encoder_dict["module"] = "ArrayEncoder"
             encoder_dict["args"]["original_type"] = f'"{tss.target_type}"'
             encoder_dict["args"]["window"] = f"{tss.window}"
-            encoder_dict["args"]["data_dtype"] = dtype.array
 
     # Set arguments for the encoder
     if encoder_dict["module"] == "Rich_Text.PretrainedLangEncoder" and not is_target:

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -152,7 +152,7 @@ def lookup_encoder(
             encoder_dict["args"]["window"] = f"{tss.window}"
 
     # Set arguments for the encoder
-    if encoder_dict["module"] == "Rich_Text.PretrainedLangEncoder" and not is_target:
+    if encoder_dict["module"] == "PretrainedLangEncoder" and not is_target:
         encoder_dict["args"]["output_type"] = "$dtype_dict[$target]"
 
     if eval(encoder_dict["module"]).is_trainable_encoder:

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -41,7 +41,7 @@ class Feature:
     """
 
     encoder: Module
-    data_dtype: str = None
+    data_dtype: str
     dependency: List[str] = None
 
     @staticmethod

--- a/lightwood/encoder/__init__.py
+++ b/lightwood/encoder/__init__.py
@@ -16,8 +16,6 @@ from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
 from lightwood.encoder.array.array import ArrayEncoder
 from lightwood.encoder.categorical.multihot import MultiHotEncoder
 from lightwood.encoder.text.pretrained import PretrainedLangEncoder
-from lightwood.encoder.type_encoder_maps import (Array, Binary, Categorical, Date, Datetime, Float, Image, Integer,
-                                                 TimeSeries, Quantity, Rich_Text, Short_Text, Tags, Audio)
 
 from lightwood.encoder.audio import MFCCEncoder
 
@@ -25,6 +23,4 @@ from lightwood.encoder.audio import MFCCEncoder
 __all__ = ['BaseEncoder', 'DatetimeEncoder', 'Img2VecEncoder', 'NumericEncoder', 'TsNumericEncoder',
            'TsArrayNumericEncoder', 'ShortTextEncoder', 'VocabularyEncoder', 'TextRnnEncoder', 'OneHotEncoder',
            'CategoricalAutoEncoder', 'TimeSeriesEncoder', 'ArrayEncoder', 'MultiHotEncoder',
-           'PretrainedLangEncoder', 'BinaryEncoder', 'DatetimeNormalizerEncoder', 'MFCCEncoder',
-           'Array', 'TimeSeries', 'Binary', 'Categorical', 'Date', 'Datetime', 'Float', 'Image', 'Integer',
-           'Quantity', 'Rich_Text', 'Short_Text', 'Tags', 'Audio']
+           'PretrainedLangEncoder', 'BinaryEncoder', 'DatetimeNormalizerEncoder', 'MFCCEncoder']

--- a/lightwood/encoder/type_encoder_maps/Array.py
+++ b/lightwood/encoder/type_encoder_maps/Array.py
@@ -1,4 +1,0 @@
-from lightwood.encoder.array.array import ArrayEncoder
-
-
-__all__ = ['ArrayEncoder']

--- a/lightwood/encoder/type_encoder_maps/Audio.py
+++ b/lightwood/encoder/type_encoder_maps/Audio.py
@@ -1,5 +1,0 @@
-from lightwood.encoder.audio import MFCCEncoder
-
-
-__all__ = ['MFCCEncoder']
-

--- a/lightwood/encoder/type_encoder_maps/Binary.py
+++ b/lightwood/encoder/type_encoder_maps/Binary.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.categorical.onehot import OneHotEncoder
-from lightwood.encoder.categorical.binary import BinaryEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-from lightwood.encoder.identity.identity import IdentityEncoder
-
-__all__ = ['BinaryEncoder', 'OneHotEncoder', 'TimeSeriesEncoder', 'ArrayEncoder', 'IdentityEncoder']

--- a/lightwood/encoder/type_encoder_maps/Categorical.py
+++ b/lightwood/encoder/type_encoder_maps/Categorical.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.categorical.onehot import OneHotEncoder
-from lightwood.encoder.categorical.autoencoder import CategoricalAutoEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-
-
-__all__ = ['OneHotEncoder', 'CategoricalAutoEncoder', 'TimeSeriesEncoder', 'ArrayEncoder']

--- a/lightwood/encoder/type_encoder_maps/Date.py
+++ b/lightwood/encoder/type_encoder_maps/Date.py
@@ -1,6 +1,0 @@
-from lightwood.encoder.datetime.datetime import DatetimeEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-
-
-__all__ = ['DatetimeEncoder', 'TimeSeriesEncoder', 'ArrayEncoder']

--- a/lightwood/encoder/type_encoder_maps/Datetime.py
+++ b/lightwood/encoder/type_encoder_maps/Datetime.py
@@ -1,6 +1,0 @@
-from lightwood.encoder.datetime.datetime import DatetimeEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-
-
-__all__ = ['DatetimeEncoder', 'TimeSeriesEncoder', 'ArrayEncoder']

--- a/lightwood/encoder/type_encoder_maps/Float.py
+++ b/lightwood/encoder/type_encoder_maps/Float.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.numeric.numeric import NumericEncoder
-from lightwood.encoder.numeric.ts_numeric import TsNumericEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-from lightwood.encoder.identity.identity import IdentityEncoder
-
-__all__ = ['NumericEncoder', 'TsNumericEncoder', 'TimeSeriesEncoder', 'ArrayEncoder', 'IdentityEncoder']

--- a/lightwood/encoder/type_encoder_maps/Image.py
+++ b/lightwood/encoder/type_encoder_maps/Image.py
@@ -1,4 +1,0 @@
-from lightwood.encoder.image.img_2_vec import Img2VecEncoder
-
-
-__all__ = ['Img2VecEncoder']

--- a/lightwood/encoder/type_encoder_maps/Integer.py
+++ b/lightwood/encoder/type_encoder_maps/Integer.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.numeric.numeric import NumericEncoder
-from lightwood.encoder.numeric.ts_numeric import TsNumericEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-from lightwood.encoder.identity.identity import IdentityEncoder
-
-__all__ = ['NumericEncoder', 'TsNumericEncoder', 'TimeSeriesEncoder', 'ArrayEncoder', 'IdentityEncoder']

--- a/lightwood/encoder/type_encoder_maps/Quantity.py
+++ b/lightwood/encoder/type_encoder_maps/Quantity.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.numeric.numeric import NumericEncoder
-from lightwood.encoder.numeric.ts_numeric import TsNumericEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-from lightwood.encoder.identity.identity import IdentityEncoder
-
-__all__ = ['NumericEncoder', 'TsNumericEncoder', 'TimeSeriesEncoder', 'ArrayEncoder', 'IdentityEncoder']

--- a/lightwood/encoder/type_encoder_maps/Rich_Text.py
+++ b/lightwood/encoder/type_encoder_maps/Rich_Text.py
@@ -1,8 +1,0 @@
-from lightwood.encoder.text.short import ShortTextEncoder
-from lightwood.encoder.text.vocab import VocabularyEncoder
-from lightwood.encoder.text.rnn import RnnEncoder as TextRnnEncoder
-from lightwood.encoder.categorical.autoencoder import CategoricalAutoEncoder
-from lightwood.encoder.text.pretrained import PretrainedLangEncoder
-
-
-__all__ = ['ShortTextEncoder', 'VocabularyEncoder', 'TextRnnEncoder', 'CategoricalAutoEncoder', 'PretrainedLangEncoder']

--- a/lightwood/encoder/type_encoder_maps/Short_Text.py
+++ b/lightwood/encoder/type_encoder_maps/Short_Text.py
@@ -1,8 +1,0 @@
-from lightwood.encoder.text.short import ShortTextEncoder
-from lightwood.encoder.text.vocab import VocabularyEncoder
-from lightwood.encoder.text.rnn import RnnEncoder as TextRnnEncoder
-from lightwood.encoder.categorical.autoencoder import CategoricalAutoEncoder
-from lightwood.encoder.text.pretrained import PretrainedLangEncoder
-
-
-__all__ = ['ShortTextEncoder', 'VocabularyEncoder', 'TextRnnEncoder', 'CategoricalAutoEncoder', 'PretrainedLangEncoder']

--- a/lightwood/encoder/type_encoder_maps/Tags.py
+++ b/lightwood/encoder/type_encoder_maps/Tags.py
@@ -1,7 +1,0 @@
-from lightwood.encoder.categorical.multihot import MultiHotEncoder
-from lightwood.encoder.text.pretrained import PretrainedLangEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-from lightwood.encoder.array.array import ArrayEncoder
-
-
-__all__ = ['MultiHotEncoder', 'PretrainedLangEncoder', 'TimeSeriesEncoder', 'ArrayEncoder']

--- a/lightwood/encoder/type_encoder_maps/TimeSeries.py
+++ b/lightwood/encoder/type_encoder_maps/TimeSeries.py
@@ -1,5 +1,0 @@
-from lightwood.encoder.numeric.ts_array_numeric import TsArrayNumericEncoder
-from lightwood.encoder.time_series.rnn import TimeSeriesEncoder
-
-
-__all__ = ['TsArrayNumericEncoder', 'TimeSeriesEncoder']


### PR DESCRIPTION
- Json ai now *requires* explicit `data_type`s for all the features instead of sourcing them from the namespace of the encoder
- Removed "typed" encoder namespaces and their usage