### PR TITLE
Fix: cast TS group by values to string to avoid TypeError

### DIFF
--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -162,7 +162,7 @@ def transform_timeseries(
         df_gb_list = list(combined_df.groupby(tss.group_by))
         df_gb_map = {}
         for gb, df in df_gb_list:
-            df_gb_map['_' + '_'.join(gb)] = df
+            df_gb_map['_' + '_'.join(str(gb))] = df
 
     timeseries_row_mapping = {}
     idx = 0


### PR DESCRIPTION
## Why
See title. This can happen when group by columns have e.g. integer values, so the following line will fail:

```python
df_gb_map['_' + '_'.join(gb)] = df
```

## How
Type cast to string all group by values before populating the map.