### PR TITLE
Build and deploy wheel file

### DIFF
--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -70,5 +70,5 @@ jobs:
         TWINE_USERNAME:  __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
+        python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
# Why

To try and add lightwood in offline Kaggle kernels, having a wheel file _might_ be useful.

# How

Modifies the existing command to generate a .whl file too.