### PR TITLE
Do not drop single-group-by column (fix #756)

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -185,17 +185,18 @@ def generate_json_ai(
     exec(IMPORT_EXTERNAL_DIRS, globals())
     target = problem_definition.target
     input_cols = []
+    tss = problem_definition.timeseries_settings
+
     for col_name, col_dtype in type_information.dtypes.items():
         if (
                 (col_name not in type_information.identifiers
                  and col_dtype not in (dtype.invalid, dtype.empty)
                  and col_name != target)
                 or
-                col_name in problem_definition.timeseries_settings.group_by
+                (tss.group_by is not None and col_name in tss.group_by)
         ):
             input_cols.append(col_name)
 
-    tss = problem_definition.timeseries_settings
     is_target_predicting_encoder = False
     is_ts = problem_definition.timeseries_settings.is_timeseries
     # Single text column classification

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -187,9 +187,11 @@ def generate_json_ai(
     input_cols = []
     for col_name, col_dtype in type_information.dtypes.items():
         if (
-            col_name not in type_information.identifiers
-            and col_dtype not in (dtype.invalid, dtype.empty)
-            and col_name != target
+                (col_name not in type_information.identifiers
+                 and col_dtype not in (dtype.invalid, dtype.empty)
+                 and col_name != target)
+                or
+                col_name in problem_definition.timeseries_settings.group_by
         ):
             input_cols.append(col_name)
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -280,8 +280,8 @@ def _remove_columns(data: pd.DataFrame, identifiers: Dict[str, object], target: 
     data = deepcopy(data)
     to_drop = [*[x for x in identifiers.keys() if x != target],
                *[x for x in data.columns if x in dtype_dict and dtype_dict[x] == dtype.invalid]]
-    exceptions = ["__mdb_make_predictions"]
-    to_drop = [x for x in to_drop if x in data.columns]
+    exceptions = ["__mdb_make_predictions", *timeseries_settings.group_by]
+    to_drop = [x for x in to_drop if x in data.columns and x not in exceptions]
     data = data.drop(columns=to_drop)
 
     if mode == "train":
@@ -298,7 +298,6 @@ def _remove_columns(data: pd.DataFrame, identifiers: Dict[str, object], target: 
     for name in list(data.columns):
         if name not in dtype_dict and name not in exceptions:
             data = data.drop(columns=[name])
-
     return data
 
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -280,7 +280,11 @@ def _remove_columns(data: pd.DataFrame, identifiers: Dict[str, object], target: 
     data = deepcopy(data)
     to_drop = [*[x for x in identifiers.keys() if x != target],
                *[x for x in data.columns if x in dtype_dict and dtype_dict[x] == dtype.invalid]]
-    exceptions = ["__mdb_make_predictions", *timeseries_settings.group_by]
+
+    exceptions = ["__mdb_make_predictions"]
+    if timeseries_settings.group_by is not None:
+        exceptions += [group for group in timeseries_settings.group_by]
+
     to_drop = [x for x in to_drop if x in data.columns and x not in exceptions]
     data = data.drop(columns=to_drop)
 

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -283,7 +283,7 @@ def _remove_columns(data: pd.DataFrame, identifiers: Dict[str, object], target: 
 
     exceptions = ["__mdb_make_predictions"]
     if timeseries_settings.group_by is not None:
-        exceptions += [group for group in timeseries_settings.group_by]
+        exceptions += timeseries_settings.group_by
 
     to_drop = [x for x in to_drop if x in data.columns and x not in exceptions]
     data = data.drop(columns=to_drop)

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -117,8 +117,8 @@ class SkTime(BaseMixer):
                 series = series.reset_index(drop=True)
 
                 for idx, _ in enumerate(series.iteritems()):
-                    ydf['prediction'].iloc[series_idxs[idx]] = forecaster.predict(
-                        np.arange(idx, idx + self.n_ts_predictions)).tolist()
+                    preds = forecaster.predict(np.arange(idx, idx + self.n_ts_predictions)).squeeze()
+                    ydf['prediction'].iloc[series_idxs[idx]] = preds.tolist()
 
             if self.grouped_by == ['__default']:
                 break


### PR DESCRIPTION
## Why

See #756 for more details.

## How

Adding `tss.group_by` columns to list of exceptions that should not be dropped.

Unrelated, this fixes sktime mixer's behavior so that it outputs a single number (instead of a list wrapping around it) if `nr_predictions == 1`.