### PR TITLE
Streamlined predictor.adjust signature

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -979,8 +979,8 @@ self.mode = 'train'
 # Extract data
 # --------------- #
 # Extract the featurized data
-encoded_old_data = new_data['old']
-encoded_new_data = new_data['new']
+encoded_old_data = old_data if old_data is not None else pd.DataFrame()
+encoded_new_data = new_data
 
 # --------------- #
 # Adjust (Update) Mixers
@@ -997,7 +997,7 @@ for mixer in self.mixers:
     # Learn Body
     # ----------------- #
 
-    learn_body = f"""
+    learn_body = """
 self.mode = 'train'
 
 # Perform stats analysis
@@ -1030,9 +1030,7 @@ self.analyze_ensemble(enc_train_test)
 if self.problem_definition.fit_on_all:
 
     log.info("Adjustment on validation requested.")
-    update_data = {{"new": enc_train_test["test"], "old": ConcatedEncodedDs([enc_train_test["train"], enc_train_test["dev"]])}}  # noqa
-
-    self.adjust(update_data)
+    self.adjust(enc_train_test["test"], ConcatedEncodedDs([enc_train_test["train"], enc_train_test["dev"]]))
 
 """
     learn_body = align(learn_body, 2)
@@ -1130,7 +1128,7 @@ class Predictor(PredictorInterface):
         data = data.drop(columns=self.problem_definition.ignore_features, errors='ignore')
 {learn_body}
 
-    def adjust(self, new_data: Dict[str, pd.DataFrame]) -> None:
+    def adjust(self, new_data: pd.DataFrame, old_data: Optional[pd.DataFrame] = None) -> None:
         # Update mixers with new information
 {adjust_body}
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -1,5 +1,5 @@
 import dill
-from typing import Dict
+from typing import Dict, Optional
 
 import pandas as pd
 from lightwood.api.types import ModelAnalysis
@@ -111,15 +111,16 @@ class PredictorInterface:
         """  # noqa
         pass
 
-    def adjust(self, new_data: Dict[str, pd.DataFrame]) -> None:
+    def adjust(self, new_data: pd.DataFrame, old_data: Optional[pd.DataFrame] = None) -> None:
         """
         Adjusts a previously trained model on new data. Adopts the same process as ``learn`` but with the exception that the `adjust` function expects the best model to have been already trained.
 
         .. warning:: This is experimental and subject to change. 
-        :param new_data: New data used to adjust a previously trained model. Keys must reference "old" and "new" referencing to the old and new datasets. In some situations, the old data is still required to train a model (i.e. Regression) to ensure the new data doesn't entirely override it.
+        :param new_data: New data used to adjust a previously trained model.
+        :param old_data: In some situations, the old data is still required to train a model (i.e. Regression mixer) to ensure the new data doesn't entirely override it.
 
         :returns: Nothing; adjusts best-fit model
-        """ # noqa
+        """  # noqa
         pass
 
     def predict(self, data: pd.DataFrame, args: Dict[str, object] = {}) -> pd.DataFrame:


### PR DESCRIPTION
## Why

For a simplified signature in `predictor.adjust()`. "Fixes" #719. 

## How
Nothing weird going on. Simple modifications to `JsonAI` and `PredictorInterface`.