### PR TITLE
Extend default layout to include GTM scripts

### DIFF
--- a/docssrc/source/_templates/layout.html
+++ b/docssrc/source/_templates/layout.html
@@ -1,0 +1,20 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MNN47J3');</script>
+    <!-- End Google Tag Manager -->
+{% endblock %}
+
+{% block extrahead %}
+{{ super() }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNN47J3"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+{% endblock %}


### PR DESCRIPTION
This PR adds two GTM scripts to the default layout so they will be injected in all autogenerated pages.