### PR TITLE
OH and Binary Encoders weighting fix

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'lightwood'
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 __description__ = "Lightwood is a toolkit for automatic machine learning model building"
 __email__ = "community@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -119,7 +119,7 @@ def lookup_encoder(
             if problem_defintion.unbias_target:
                 encoder_dict["args"][
                     "target_weights"
-                ] = "$statistical_analysis.target_class_distribution"
+                ] = "$statistical_analysis.assumed_target_class_weight"
             if problem_defintion.target_weights is not None:
                 encoder_dict["args"][
                     "target_weights"

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -119,7 +119,7 @@ def lookup_encoder(
             if problem_defintion.unbias_target:
                 encoder_dict["args"][
                     "target_weights"
-                ] = "$statistical_analysis.assumed_target_class_weight"
+                ] = "$statistical_analysis.suggested_target_class_weight"
             if problem_defintion.target_weights is not None:
                 encoder_dict["args"][
                     "target_weights"

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -119,7 +119,7 @@ def lookup_encoder(
             if problem_defintion.unbias_target:
                 encoder_dict["args"][
                     "target_weights"
-                ] = "$statistical_analysis.suggested_target_class_weight"
+                ] = "$statistical_analysis.target_weights"
             if problem_defintion.target_weights is not None:
                 encoder_dict["args"][
                     "target_weights"

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -174,6 +174,7 @@ class StatisticalAnalysis:
     df_target_stddev: Optional[float]
     train_observed_classes: object  # Union[None, List[str]]
     target_class_distribution: object  # Dict[str, float]
+    assumed_target_class_weight: object  # Dict[str, float]
     histograms: object  # Dict[str, Dict[str, List[object]]]
     buckets: object  # Dict[str, Dict[str, List[object]]]
     missing: object

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -161,7 +161,7 @@ class StatisticalAnalysis:
     :param df_target_stddev: The standard deviation of the target of the dataset
     :param train_observed_classes:
     :param target_class_distribution:
-    :param suggested_target_class_weight: What weight the analysis suggests to assign each class by in the case of classification problems. Note: target_weights in the problem definition overides this
+    :param target_weights: What weight the analysis suggests to assign each class by in the case of classification problems. Note: target_weights in the problem definition overides this
     :param histograms:
     :param buckets:
     :param missing:
@@ -175,7 +175,7 @@ class StatisticalAnalysis:
     df_target_stddev: Optional[float]
     train_observed_classes: object  # Union[None, List[str]]
     target_class_distribution: object  # Dict[str, float]
-    suggested_target_class_weight: object  # Dict[str, float]
+    target_weights: object  # Dict[str, float]
     histograms: object  # Dict[str, Dict[str, List[object]]]
     buckets: object  # Dict[str, Dict[str, List[object]]]
     missing: object

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -161,6 +161,7 @@ class StatisticalAnalysis:
     :param df_target_stddev: The standard deviation of the target of the dataset
     :param train_observed_classes:
     :param target_class_distribution:
+    :param suggested_target_class_weight: What weight the analysis suggests to assign each class by in the case of classification problems. Note: target_weights in the problem definition overides this
     :param histograms:
     :param buckets:
     :param missing:
@@ -168,13 +169,13 @@ class StatisticalAnalysis:
     :param bias:
     :param avg_words_per_sentence:
     :param positive_domain:
-    """
+    """ # noqa
 
     nr_rows: int
     df_target_stddev: Optional[float]
     train_observed_classes: object  # Union[None, List[str]]
     target_class_distribution: object  # Dict[str, float]
-    assumed_target_class_weight: object  # Dict[str, float]
+    suggested_target_class_weight: object  # Dict[str, float]
     histograms: object  # Dict[str, Dict[str, List[object]]]
     buckets: object  # Dict[str, Dict[str, List[object]]]
     missing: object

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -133,12 +133,12 @@ def statistical_analysis(data: pd.DataFrame,
 
     # get observed classes, used in analysis
     target_class_distribution = None
-    suggested_target_class_weight = None
+    target_weights = None
     if dtypes[target] in (dtype.categorical, dtype.binary):
         target_class_distribution = dict(df[target].value_counts().apply(lambda x: x / len(df[target])))
-        suggested_target_class_weight = {}
+        target_weights = {}
         for k in target_class_distribution:
-            suggested_target_class_weight[k] = 1 / target_class_distribution[k]
+            target_weights[k] = 1 / target_class_distribution[k]
         train_observed_classes = list(target_class_distribution.keys())
     elif dtypes[target] == dtype.tags:
         train_observed_classes = None  # @TODO: pending call to tags logic -> get all possible tags
@@ -171,7 +171,7 @@ def statistical_analysis(data: pd.DataFrame,
         df_target_stddev=df_std,
         train_observed_classes=train_observed_classes,
         target_class_distribution=target_class_distribution,
-        suggested_target_class_weight=suggested_target_class_weight,
+        target_weights=target_weights,
         positive_domain=positive_domain,
         histograms=histograms,
         buckets=buckets,

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict
 import pandas as pd
 import numpy as np
@@ -133,8 +134,12 @@ def statistical_analysis(data: pd.DataFrame,
 
     # get observed classes, used in analysis
     target_class_distribution = None
+    assumed_target_class_weight = None
     if dtypes[target] in (dtype.categorical, dtype.binary):
         target_class_distribution = dict(df[target].value_counts().apply(lambda x: x / len(df[target])))
+        assumed_target_class_weight = deepcopy(target_class_distribution)
+        for k in assumed_target_class_weight:
+            assumed_target_class_weight[k] = 1 / assumed_target_class_weight[k]
         train_observed_classes = list(target_class_distribution.keys())
     elif dtypes[target] == dtype.tags:
         train_observed_classes = None  # @TODO: pending call to tags logic -> get all possible tags
@@ -167,6 +172,7 @@ def statistical_analysis(data: pd.DataFrame,
         df_target_stddev=df_std,
         train_observed_classes=train_observed_classes,
         target_class_distribution=target_class_distribution,
+        assumed_target_class_weight=assumed_target_class_weight,
         positive_domain=positive_domain,
         histograms=histograms,
         buckets=buckets,

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -137,9 +137,9 @@ def statistical_analysis(data: pd.DataFrame,
     assumed_target_class_weight = None
     if dtypes[target] in (dtype.categorical, dtype.binary):
         target_class_distribution = dict(df[target].value_counts().apply(lambda x: x / len(df[target])))
-        assumed_target_class_weight = deepcopy(target_class_distribution)
-        for k in assumed_target_class_weight:
-            assumed_target_class_weight[k] = 1 / assumed_target_class_weight[k]
+        assumed_target_class_weight = {}
+        for k in target_class_distribution:
+            assumed_target_class_weight[k] = 1 / target_class_distribution[k]
         train_observed_classes = list(target_class_distribution.keys())
     elif dtypes[target] == dtype.tags:
         train_observed_classes = None  # @TODO: pending call to tags logic -> get all possible tags

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -133,12 +133,12 @@ def statistical_analysis(data: pd.DataFrame,
 
     # get observed classes, used in analysis
     target_class_distribution = None
-    assumed_target_class_weight = None
+    suggested_target_class_weight = None
     if dtypes[target] in (dtype.categorical, dtype.binary):
         target_class_distribution = dict(df[target].value_counts().apply(lambda x: x / len(df[target])))
-        assumed_target_class_weight = {}
+        suggested_target_class_weight = {}
         for k in target_class_distribution:
-            assumed_target_class_weight[k] = 1 / target_class_distribution[k]
+            suggested_target_class_weight[k] = 1 / target_class_distribution[k]
         train_observed_classes = list(target_class_distribution.keys())
     elif dtypes[target] == dtype.tags:
         train_observed_classes = None  # @TODO: pending call to tags logic -> get all possible tags
@@ -171,7 +171,7 @@ def statistical_analysis(data: pd.DataFrame,
         df_target_stddev=df_std,
         train_observed_classes=train_observed_classes,
         target_class_distribution=target_class_distribution,
-        assumed_target_class_weight=assumed_target_class_weight,
+        suggested_target_class_weight=suggested_target_class_weight,
         positive_domain=positive_domain,
         histograms=histograms,
         buckets=buckets,

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Dict
 import pandas as pd
 import numpy as np

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -38,8 +38,7 @@ class BinaryEncoder(BaseEncoder):
             self.index_weights = [None, None]
             for word in self.map:
                 if self.target_weights is not None:
-                    self.index_weights[self.map[word]] = \
-                        self.target_weights[word] / np.max(list(self.target_weights.values()))
+                    self.index_weights[self.map[word]] = self.target_weights[word]
                 else:
                     self.index_weights[self.map[word]] = 1
 

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -35,7 +35,6 @@ class BinaryEncoder(BaseEncoder):
                 break
 
         if self.is_target:
-            print(self.target_weights)
             self.index_weights = [None, None]
             for word in self.map:
                 if self.target_weights is not None:
@@ -58,7 +57,6 @@ class BinaryEncoder(BaseEncoder):
             ret.append([0, 0])
             if index is not None:
                 ret[-1][index] = 1
-        print(ret, self.index_weights)
         return torch.Tensor(ret)
 
     def decode(self, encoded_data, return_raw=False):

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -40,7 +40,7 @@ class BinaryEncoder(BaseEncoder):
             for word in self.map:
                 if self.target_weights is not None:
                     self.index_weights[self.map[word]] = \
-                        self.target_weights[word] / np.max(self.target_weights.values())
+                        self.target_weights[word] / np.max(list(self.target_weights.values()))
                 else:
                     self.index_weights[self.map[word]] = 1
 

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -35,10 +35,12 @@ class BinaryEncoder(BaseEncoder):
                 break
 
         if self.is_target:
+            print(self.target_weights)
             self.index_weights = [None, None]
             for word in self.map:
                 if self.target_weights is not None:
-                    self.index_weights[self.map[word]] = 1 / self.target_weights[word]
+                    self.index_weights[self.map[word]] = \
+                        self.target_weights[word] / np.max(self.target_weights.values())
                 else:
                     self.index_weights[self.map[word]] = 1
 
@@ -56,7 +58,7 @@ class BinaryEncoder(BaseEncoder):
             ret.append([0, 0])
             if index is not None:
                 ret[-1][index] = 1
-
+        print(ret, self.index_weights)
         return torch.Tensor(ret)
 
     def decode(self, encoded_data, return_raw=False):

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -79,7 +79,8 @@ class OneHotEncoder(BaseEncoder):
                 self.target_weights[UNCOMMON_WORD] = uncommon_weight
             for word in set(priming_data):
                 if self.target_weights is not None:
-                    self.index_weights[self._lang.word2index[str(word)]] = 1 / self.target_weights[word]
+                    self.index_weights[self._lang.word2index[str(word)]] = \
+                        self.target_weights[word] / np.max(self.target_weights.values())
 
             self.index_weights = torch.Tensor(self.index_weights)
 

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -80,7 +80,7 @@ class OneHotEncoder(BaseEncoder):
             for word in set(priming_data):
                 if self.target_weights is not None:
                     self.index_weights[self._lang.word2index[str(word)]] = \
-                        self.target_weights[word] / np.max(self.target_weights.values())
+                        self.target_weights[word] / np.max(list(self.target_weights.values()))
 
             self.index_weights = torch.Tensor(self.index_weights)
 

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -79,8 +79,7 @@ class OneHotEncoder(BaseEncoder):
                 self.target_weights[UNCOMMON_WORD] = uncommon_weight
             for word in set(priming_data):
                 if self.target_weights is not None:
-                    self.index_weights[self._lang.word2index[str(word)]] = \
-                        self.target_weights[word] / np.max(list(self.target_weights.values()))
+                    self.index_weights[self._lang.word2index[str(word)]] = self.target_weights[word]
 
             self.index_weights = torch.Tensor(self.index_weights)
 

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -32,6 +32,7 @@ class BestOf(BaseEnsemble):
                 accuracy_functions,
                 ts_analysis=ts_analysis
             )
+            print(mixer, score_dict)
             avg_score = np.mean(list(score_dict.values()))
             log.info(f'Mixer: {type(mixer).__name__} got accuracy: {avg_score}')
 

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -32,7 +32,7 @@ class BestOf(BaseEnsemble):
                 accuracy_functions,
                 ts_analysis=ts_analysis
             )
-            print(mixer, score_dict)
+
             avg_score = np.mean(list(score_dict.values()))
             log.info(f'Mixer: {type(mixer).__name__} got accuracy: {avg_score}')
 


### PR DESCRIPTION
What's the bug here?

The One hot encoder and the binary were **inverting** the target weights argument when creating the weights-per-index tensor (used by the Neural mixer).

Why was this not affecting accuracy?

- Because we never weighted manually, only automatically, and instead of passing the *reverse* occurrence of every class to the encoders we were passing the occurrence of every class ... so double investing => all is good

This fix means that the `target_weight` argument now works with the `Neural` encoder *and* might increase accuracy in the case where implicit weights were passed to LightGBM, since the latest release it takes weight into account.

I'm actually surprised we didn't see more of an accuracy drop due to passing the wrong weights to LGBM in the previous PR, but I guess it shows that Neural is able to pick up the slack... and probably that we need a better benchmarks methodology.
