### PR TITLE
Precision recall and f1

### DIFF
--- a/lightwood/helpers/accuracy.py
+++ b/lightwood/helpers/accuracy.py
@@ -7,13 +7,21 @@ from sklearn.metrics import precision_score as sk_precision_score
 
 def to_binary(y: Iterable) -> List[int]:
     try:
-        y = [int(x) for x in y]
+        y_binarized = []
+        for ele in y:
+            if str(ele).lower() == 'true':
+                y_binarized.append(1)
+            elif str(ele).lower() == 'false':
+                y_binarized.append(0)
+            else:
+                y_binarized.append(int(ele))
+
         assert len(set(y)) < 3
         assert 1 in y
         assert 0 in y
     except Exception:
         raise Exception('To use precision, recall or f1 please make sure your target consists only of 1s and 0s')
-    return y
+    return y_binarized
 
 
 def f1_score(y_true, y_pred) -> float:

--- a/lightwood/helpers/accuracy.py
+++ b/lightwood/helpers/accuracy.py
@@ -15,11 +15,9 @@ def to_binary(y: Iterable) -> List[int]:
                 y_binarized.append(0)
             else:
                 y_binarized.append(int(ele))
-        print(y_binarized)
-        exit()
-        assert len(set(y)) < 3
-        assert 1 in y
-        assert 0 in y
+
+        assert len(set(y_binarized)) < 3
+        assert 1 in y_binarized or 0 in y_binarized
     except Exception:
         raise Exception('To use precision, recall or f1 please make sure your target consists only of 1s and 0s')
     return y_binarized

--- a/lightwood/helpers/accuracy.py
+++ b/lightwood/helpers/accuracy.py
@@ -15,7 +15,8 @@ def to_binary(y: Iterable) -> List[int]:
                 y_binarized.append(0)
             else:
                 y_binarized.append(int(ele))
-
+        print(y_binarized)
+        exit()
         assert len(set(y)) < 3
         assert 1 in y
         assert 0 in y

--- a/lightwood/helpers/accuracy.py
+++ b/lightwood/helpers/accuracy.py
@@ -1,4 +1,30 @@
+from typing import Iterable, List
 from sklearn.metrics import r2_score as sk_r2_score
+from sklearn.metrics import f1_score as sk_f1_score
+from sklearn.metrics import recall_score as sk_recall_score
+from sklearn.metrics import precision_score as sk_precision_score
+
+
+def to_binary(y: Iterable) -> List[int]:
+    try:
+        y = [int(x) for x in y]
+        assert len(set(y)) < 3
+        assert 1 in y
+        assert 0 in y
+    except Exception:
+        raise Exception('To use precision, recall or f1 please make sure your target consists only of 1s and 0s')
+
+
+def f1_score(y_true, y_pred) -> float:
+    return sk_f1_score(to_binary(y_true), to_binary(y_pred))
+
+
+def recall_score(y_true, y_pred) -> float:
+    return sk_recall_score(to_binary(y_true), to_binary(y_pred))
+
+
+def precision_score(y_true, y_pred) -> float:
+    return sk_precision_score(to_binary(y_true), to_binary(y_pred))
 
 
 def r2_score(y_true, y_pred) -> float:

--- a/lightwood/helpers/accuracy.py
+++ b/lightwood/helpers/accuracy.py
@@ -13,6 +13,7 @@ def to_binary(y: Iterable) -> List[int]:
         assert 0 in y
     except Exception:
         raise Exception('To use precision, recall or f1 please make sure your target consists only of 1s and 0s')
+    return y
 
 
 def f1_score(y_true, y_pred) -> float:


### PR DESCRIPTION
Added the aforementioned scores, they require some assertions for their usage to make sense *and* they require `int` conversion for sklearn interface compatibility.

In theory, we could have a more generic recall_for_{label} score, but for now, we are sticking with the "standard" that defines true/1 as "positive" and false/0 as negative.