### PR TITLE
fix: fixes missing torchvision import

### DIFF
--- a/lightwood/encoder/image/helpers/img_to_vec.py
+++ b/lightwood/encoder/image/helpers/img_to_vec.py
@@ -1,8 +1,14 @@
 import torch
 import torch.nn as nn
-import torchvision.models as models
 from lightwood.helpers.device import get_devices
 from lightwood.helpers.torch import LightwoodAutocast
+
+from lightwood.helpers.log import log
+
+try:
+    import torchvision.models as models
+except ModuleNotFoundError:
+    log.info("No torchvision detected, image encoder not supported")
 
 
 class ChannelPoolAdaptiveAvg1d(torch.nn.AdaptiveAvgPool1d):

--- a/lightwood/encoder/image/img_2_vec.py
+++ b/lightwood/encoder/image/img_2_vec.py
@@ -1,11 +1,16 @@
 from typing import List
-import logging
 import torch
-import torchvision.transforms as transforms
-from PIL import Image
 import pandas as pd
 from lightwood.encoder.image.helpers.img_to_vec import Img2Vec
 from lightwood.encoder.base import BaseEncoder
+
+from lightwood.helpers.log import log
+
+try:
+    import torchvision.transforms as transforms
+    from PIL import Image
+except ModuleNotFoundError:
+    log.info("No torchvision/pillow detected, image encoder not supported")
 
 
 class Img2VecEncoder(BaseEncoder):


### PR DESCRIPTION
Fixes minor issue where if torchvision is not installed, will print a log message and enable execution; allows lightwood to be imported if no torchvision is found.