### PR TITLE
fix: throws log issue for missing librosa requirement

### DIFF
--- a/lightwood/encoder/audio/mfcc.py
+++ b/lightwood/encoder/audio/mfcc.py
@@ -1,10 +1,14 @@
-import librosa
 import torch
 import warnings
 from lightwood.encoder.base import BaseEncoder
 from lightwood.helpers.io import read_from_path_or_url
 import pandas as pd
 from lightwood.helpers.log import log
+
+try:
+    import librosa
+except ModuleNotFoundError:
+    log.info("No librosa detected, audio encoder not supported")
 
 
 class MFCCEncoder(BaseEncoder):


### PR DESCRIPTION
Librosa is no longer a required library; throws a log info about audio not being supported if librosa is unavailable