### PR TITLE
Fix torchvision

### DIFF
--- a/lightwood/encoder/image/img_2_vec.py
+++ b/lightwood/encoder/image/img_2_vec.py
@@ -45,8 +45,8 @@ class Img2VecEncoder(BaseEncoder):
         ])
         self.stop_after = stop_after
 
-        #pil_logger = logging.getLogger('PIL')
-        #pil_logger.setLevel(logging.ERROR)
+        # pil_logger = logging.getLogger('PIL')
+        # pil_logger.setLevel(logging.ERROR)
 
     def prepare(self, train_priming_data: pd.Series, dev_priming_data: pd.Series):
         # @TODO: finetune here? depending on time aim

--- a/lightwood/encoder/image/img_2_vec.py
+++ b/lightwood/encoder/image/img_2_vec.py
@@ -45,8 +45,8 @@ class Img2VecEncoder(BaseEncoder):
         ])
         self.stop_after = stop_after
 
-        pil_logger = logging.getLogger('PIL')
-        pil_logger.setLevel(logging.ERROR)
+        #pil_logger = logging.getLogger('PIL')
+        #pil_logger.setLevel(logging.ERROR)
 
     def prepare(self, train_priming_data: pd.Series, dev_priming_data: pd.Series):
         # @TODO: finetune here? depending on time aim


### PR DESCRIPTION
Torchvision (and PIL) is required for image encoding but is an optional dependency for lightwood altogether; since it was removed from the default requirements, those without torchvision will not be able to install lightwood due to a failed import in the img encoder; this includes a simple try-exception around the imports and outputs a log that suggests these encoders cannot be used if the user does not install torchvision, and PIL