### PR TITLE
fix: try-catches import of img encoder to bypass module issue

### DIFF
--- a/lightwood/encoder/image/helpers/img_to_vec.py
+++ b/lightwood/encoder/image/helpers/img_to_vec.py
@@ -1,8 +1,14 @@
 import torch
 import torch.nn as nn
-import torchvision.models as models
 from lightwood.helpers.device import get_devices
 from lightwood.helpers.torch import LightwoodAutocast
+
+from lightwood.helpers.log import log
+
+try:
+    import torchvision.models as models
+except ModuleNotFoundError:
+    log.info("No torchvision detected, image helpers not supported.")
 
 
 class ChannelPoolAdaptiveAvg1d(torch.nn.AdaptiveAvgPool1d):

--- a/lightwood/encoder/image/img_2_vec.py
+++ b/lightwood/encoder/image/img_2_vec.py
@@ -1,11 +1,16 @@
 from typing import List
-import logging
 import torch
-import torchvision.transforms as transforms
-from PIL import Image
 import pandas as pd
 from lightwood.encoder.image.helpers.img_to_vec import Img2Vec
 from lightwood.encoder.base import BaseEncoder
+
+from lightwood.helpers.log import log
+
+try:
+    import torchvision.transforms as transforms
+    from PIL import Image
+except ModuleNotFoundError:
+    log.info("No torchvision/pillow detected, image encoder not supported")
 
 
 class Img2VecEncoder(BaseEncoder):
@@ -40,8 +45,8 @@ class Img2VecEncoder(BaseEncoder):
         ])
         self.stop_after = stop_after
 
-        pil_logger = logging.getLogger('PIL')
-        pil_logger.setLevel(logging.ERROR)
+        # pil_logger = logging.getLogger('PIL')  # noqa
+        # pil_logger.setLevel(logging.ERROR)  # noqa
 
     def prepare(self, train_priming_data: pd.Series, dev_priming_data: pd.Series):
         # @TODO: finetune here? depending on time aim


### PR DESCRIPTION
Torchvision (and PIL) is required for image encoding but is an optional dependency for lightwood altogether; we opt to remove it from default installation as image-encoding is not a generic task. 

Since it was removed from the default requirements, users without torchvision can run into issues nstalling lightwood due to a failed import in the img encoder; this PR includes a simple try-exception around the imports and outputs a log that suggests these encoders cannot be used if the user does not install torchvision, and PIL