### PR TITLE
Fixes

### DIFF
--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -162,4 +162,6 @@ class BinaryEncoder(BaseEncoder):
         :param vec: Assigned weights for each category
         """  # noqa
         total = sum(vec)
+        if total == 0:
+            return vec
         return [i / total for i in vec]

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -65,8 +65,8 @@ class BinaryEncoder(BaseEncoder):
         self.rev_map = {indx: cat for cat, indx in self.map.items()}
 
         # Enforce only binary; map must have exactly 2 classes.
-        if len(self.map) != 2:
-            raise ValueError('Issue with dtype; data has > 2 classes.')
+        if len(self.map) > 2:
+            raise ValueError(f'Issue with dtype; data has > 2 classes. All classes are: {self.map}')
 
         # For target-only, report on relative weights of classes
         if self.is_target:

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -178,4 +178,6 @@ class OneHotEncoder(BaseEncoder):
         :param vec: Assigned weights for each category
         """
         total = sum(vec)
+        if total == 0:
+            return vec
         return [i / total for i in vec]

--- a/lightwood/helpers/text.py
+++ b/lightwood/helpers/text.py
@@ -257,7 +257,7 @@ def get_identifier_description(data: Iterable, column_name: str, data_dtype: dty
                 return 'Unknown identifier'
 
     # Everything is unique and it's too short to be rich text
-    if data_dtype in (dtype.categorical, dtype.short_text, dtype.rich_text) and \
+    if data_dtype in (dtype.categorical, dtype.binary, dtype.short_text, dtype.rich_text) and \
             unique_pct > 0.99999 and mean_spaces < 1:
         return 'Unknown identifier'
 


### PR DESCRIPTION
- binary encoder accepts either 1 or 2 classes now
- identifier detection correctly takes `binary` type into account in an if where it was only accounting for categorical (realistically this should make no difference to current datasets, but good to fix)
- returning probabilities for OH and Binary now account for all zero vectors (though this likely makes little sense to ever happen and we should find out why)