### PR TITLE
Fix no analysis blocks option

### DIFF
--- a/lightwood/analysis/analyze.py
+++ b/lightwood/analysis/analyze.py
@@ -89,7 +89,7 @@ def model_analyzer(
         accuracy_samples=runtime_analyzer.get('acc_samples', {}),
         train_sample_size=len(encoded_train_data),
         test_sample_size=len(encoded_val_data),
-        confusion_matrix=runtime_analyzer['cm'],
+        confusion_matrix=runtime_analyzer.get('cm', []),
         column_importances=runtime_analyzer.get('column_importances', {}),
         histograms=stats_info.histograms,
         dtypes=dtype_dict

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -632,7 +632,7 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
                 "module": "AccStats",
                 "args": {"deps": ["ICP"]},
             },
-        ],
+        ] if problem_definition.use_default_analysis else [],
         "timeseries_transformer": {
             "module": "transform_timeseries",
             "args": {

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -325,6 +325,7 @@ class ProblemDefinition:
         series.
     :param ignore_features: The names of the columns the user wishes to ignore in the ML pipeline. Any column name \
         found in this list will be automatically removed from subsequent steps in the ML pipeline.
+    :param use_default_analysis: whether default analysis blocks are enabled.
     :param fit_on_all: Whether to fit the model on the held-out validation data. Validation data is strictly \
         used to evaluate how well a model is doing and is NEVER trained. However, in cases where users anticipate new \
             incoming data over time, the user may train the model further using the entire dataset.
@@ -343,6 +344,7 @@ class ProblemDefinition:
     positive_domain: bool
     timeseries_settings: TimeseriesSettings
     anomaly_detection: bool
+    use_default_analysis: bool
     ignore_features: List[str]
     fit_on_all: bool
     strict_mode: bool
@@ -375,6 +377,7 @@ class ProblemDefinition:
         anomaly_detection = obj.get('anomaly_detection', False)
         ignore_features = obj.get('ignore_features', [])
         fit_on_all = obj.get('fit_on_all', True)
+        use_default_analysis = obj.get('use_default_analysis', True)
         strict_mode = obj.get('strict_mode', True)
         seed_nr = obj.get('seed_nr', 420)
         problem_definition = ProblemDefinition(
@@ -390,6 +393,7 @@ class ProblemDefinition:
             timeseries_settings=timeseries_settings,
             anomaly_detection=anomaly_detection,
             ignore_features=ignore_features,
+            use_default_analysis=use_default_analysis,
             fit_on_all=fit_on_all,
             strict_mode=strict_mode,
             seed_nr=seed_nr

--- a/tests/integration/basic/test_categorical.py
+++ b/tests/integration/basic/test_categorical.py
@@ -53,3 +53,15 @@ class TestBasic(unittest.TestCase):
         # test predict all mixers with some data
         predictions = predictor.predict(df[:10], args={'all_mixers': True})
         assert '__mdb_mixer_Neural' in predictions.columns
+
+    def test_2_binary_no_analysis(self):
+        df = pd.read_csv('tests/data/ionosphere.csv')[:100]
+        mask = np.random.rand(len(df)) < 0.8
+        train = df[mask]
+        test = df[~mask]
+        predictor = predictor_from_problem(df, ProblemDefinition.from_dict(
+            {'target': 'target', 'time_aim': 20, 'use_default_analysis': False}))
+        predictor.learn(train)
+        predictions = predictor.predict(test)
+        self.assertTrue(balanced_accuracy_score(test['target'], predictions['prediction']) > 0.5)
+        self.assertTrue('confidence' not in predictions.columns)


### PR DESCRIPTION
## Why

To enable lean predictors that do not run an analysis phase at all.

## How
Added an argument in the problem definition to explicitly ask for _no_ analysis blocks to be deployed. Also, fixed a missing default value for the `cm` key in the runtime analyzer.