### PR TITLE
Add original query index column in output

### DIFF
--- a/lightwood/analysis/explain.py
+++ b/lightwood/analysis/explain.py
@@ -48,6 +48,7 @@ def explain(data: pd.DataFrame,
 
     row_insights = pd.DataFrame()
     global_insights = {}
+    row_insights['original_index'] = data['__mdb_original_index']
     row_insights['prediction'] = predictions['prediction']
 
     if timeseries_settings.is_timeseries:

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -1,17 +1,17 @@
 import re
-from copy import deepcopy
-
-import pandas as pd
 import datetime
+from copy import deepcopy
 from dateutil.parser import parse as parse_dt
+from typing import Dict, List, Optional, Tuple, Callable, Union
+
+import numpy as np
+import pandas as pd
 
 from lightwood.api.dtype import dtype
 from lightwood.helpers import text
 from lightwood.helpers.log import log
 from lightwood.api.types import TimeseriesSettings
 from lightwood.helpers.numeric import is_nan_numeric
-
-from typing import Dict, List, Optional, Tuple, Callable, Union
 
 
 def cleaner(
@@ -42,6 +42,8 @@ def cleaner(
 
     data = _remove_columns(data, identifiers, target, mode, timeseries_settings,
                            anomaly_detection, dtype_dict)
+
+    data['__mdb_original_index'] = np.arange(len(data))
 
     for col in _get_columns_to_clean(data, dtype_dict, mode, target):
 

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -76,7 +76,7 @@ class TestTimeseries(unittest.TestCase):
             "args": {
                 "stop_after": "$problem_definition.seconds_per_mixer",
                 "n_ts_predictions": "$problem_definition.timeseries_settings.nr_predictions",
-                "model_path": "'trend.TrendForecaster'",  # use a cheap forecasater
+                "model_path": "'trend.TrendForecaster'",  # use a cheap forecaster
                 "hyperparam_search": False,  # disable this as it's expensive and covered in test #3
             },
         }
@@ -129,7 +129,8 @@ class TestTimeseries(unittest.TestCase):
                                                                        'window': window}
                                                                    }))
         pred.learn(train_df)
-        preds = pred.predict(data[0:10])
+        preds = pred.predict(data.sample(frac=1)[0:10])
+        self.assertTrue('original_index' in preds.columns)
         self.check_ts_prediction_df(preds, nr_preds, [order_by])
 
         # test incomplete history, should not be possible


### PR DESCRIPTION
## Why
MindsDB needs this information to join predictions back with original queries. Lightwood, on the other hand, offers no guarantee regarding output order for timeseries use cases because it prioritizes sorting by the `order_by` columns.

This PR adds an extra column that will let MindsDB align predictions back to whatever the original row order of the query was.

## How

Add an index column to the DF at the start of the cleaning process. It is not used in the rest of the pipeline, but stays there and is added to the output DF in the base explainer.

Also, add a check in one of the time series tests to ensure this column is added to the output.