### PR TITLE
Optimized classifier ICP block for confidence estimation

### DIFF
--- a/lightwood/analysis/nc/base.py
+++ b/lightwood/analysis/nc/base.py
@@ -134,6 +134,7 @@ class CachedClassifierAdapter(ClassifierAdapter):
     def __init__(self, model, fit_params=None):
         super(CachedClassifierAdapter, self).__init__(model, fit_params)
         self.prediction_cache = None
+        self.tempscale = False
 
     def fit(self, x=None, y=None):
         """ At this point, the predictor has already been trained, but this
@@ -143,4 +144,7 @@ class CachedClassifierAdapter(ClassifierAdapter):
     def predict(self, x=None):
         """ Same as in .fit()
         :return: np.array (n_test, n_classes) with class probability estimates """
-        return t_softmax(self.prediction_cache, t=0.5)
+        if self.tempscale:
+            return t_softmax(self.prediction_cache, t=0.5)
+        else:
+            return self.prediction_cache

--- a/lightwood/analysis/nc/base.py
+++ b/lightwood/analysis/nc/base.py
@@ -134,7 +134,7 @@ class CachedClassifierAdapter(ClassifierAdapter):
     def __init__(self, model, fit_params=None):
         super(CachedClassifierAdapter, self).__init__(model, fit_params)
         self.prediction_cache = None
-        self.tempscale = False
+        self.tempscale = True
 
     def fit(self, x=None, y=None):
         """ At this point, the predictor has already been trained, but this

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -346,10 +346,9 @@ class ICP(BaseAnalysisBlock):
                                         result.loc[insert_index, 'significance'] = significances[conf_index]
 
                                 else:
-                                    conf_candidates = list(range(20)) + list(range(20, 100, 10))
                                     all_ranges = np.array([icp.predict(X.values)])
                                     all_confs = np.swapaxes(np.swapaxes(all_ranges, 0, 2), 0, 1)
-                                    significances = get_categorical_conf(all_confs, conf_candidates)
+                                    significances = get_categorical_conf(all_confs, len(base_icp.classes))
                                     result.loc[X.index, 'significance'] = significances
 
                 row_insights['confidence'] = result['significance'].astype(float).tolist()

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -277,7 +277,6 @@ class ICP(BaseAnalysisBlock):
 
                     base_icp.nc_function.model.prediction_cache = class_dists
 
-                    conf_candidates = list(range(20)) + list(range(20, 100, 10))
                     all_ranges = np.array([base_icp.predict(icp_values)])
                     all_confs = np.swapaxes(np.swapaxes(all_ranges, 0, 2), 0, 1)
 

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -268,7 +268,8 @@ class ICP(BaseAnalysisBlock):
                 else:
                     predicted_proba = True if any(['__mdb_proba' in col for col in ns.predictions.columns]) else False
                     if predicted_proba:
-                        all_cat_cols = [col for col in ns.predictions.columns if '__mdb_proba' in col]
+                        all_cat_cols = [col for col in ns.predictions.columns
+                                        if '__mdb_proba' in col and '__mdb_unknown_cat' not in col]
                         class_dists = ns.predictions[all_cat_cols].values
                         for icol, cat_col in enumerate(all_cat_cols):
                             row_insights.loc[X.index, cat_col] = class_dists[:, icol]
@@ -294,7 +295,7 @@ class ICP(BaseAnalysisBlock):
                     result.loc[X.index, 'lower'] = confs[:, 0]
                     result.loc[X.index, 'upper'] = confs[:, 1]
                 else:
-                    significances = get_categorical_conf(all_confs.squeeze(), len(base_icp.classes))
+                    significances = get_categorical_conf(all_confs.squeeze())
 
                 result.loc[X.index, 'significance'] = significances
 
@@ -347,7 +348,7 @@ class ICP(BaseAnalysisBlock):
                                 else:
                                     all_ranges = np.array([icp.predict(X.values)])
                                     all_confs = np.swapaxes(np.swapaxes(all_ranges, 0, 2), 0, 1)
-                                    significances = get_categorical_conf(all_confs, len(icp.classes))
+                                    significances = get_categorical_conf(all_confs)
                                     result.loc[X.index, 'significance'] = significances
 
                 row_insights['confidence'] = result['significance'].astype(float).tolist()

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -348,7 +348,7 @@ class ICP(BaseAnalysisBlock):
                                 else:
                                     all_ranges = np.array([icp.predict(X.values)])
                                     all_confs = np.swapaxes(np.swapaxes(all_ranges, 0, 2), 0, 1)
-                                    significances = get_categorical_conf(all_confs, len(base_icp.classes))
+                                    significances = get_categorical_conf(all_confs, len(icp.classes))
                                     result.loc[X.index, 'significance'] = significances
 
                 row_insights['confidence'] = result['significance'].astype(float).tolist()

--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -106,7 +106,7 @@ class BaseIcp(BaseEstimator):
             self.cal_scores = self._reduce_scores()
 
     def _reduce_scores(self):
-        return {k: cs[::int(len(cs)/self.cal_size)+1] for k, cs in self.cal_scores.items()}
+        return {k: cs[::int(len(cs) / self.cal_size) + 1] for k, cs in self.cal_scores.items()}
 
     def _update_calibration_set(self, x: np.array, y: np.array, increment: bool) -> None:
         if increment and self.cal_x is not None and self.cal_y is not None:

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -128,7 +128,7 @@ class MarginErrFunc(ClassificationErrFunc):
         super(MarginErrFunc, self).__init__()
 
     def apply(self, prediction, y):
-        prediction = deepcopy(prediction)
+        prediction = deepcopy(prediction).astype(float)
         prob = np.zeros(y.size, dtype=np.float32)
         for i, y_ in enumerate(y):
             if y_ >= prediction.shape[1]:

--- a/lightwood/analysis/nc/nc.py
+++ b/lightwood/analysis/nc/nc.py
@@ -128,6 +128,7 @@ class MarginErrFunc(ClassificationErrFunc):
         super(MarginErrFunc, self).__init__()
 
     def apply(self, prediction, y):
+        prediction = deepcopy(prediction)
         prob = np.zeros(y.size, dtype=np.float32)
         for i, y_ in enumerate(y):
             if y_ >= prediction.shape[1]:

--- a/lightwood/analysis/nc/util.py
+++ b/lightwood/analysis/nc/util.py
@@ -166,8 +166,8 @@ def get_categorical_conf(raw_confs: np.ndarray, n_classes: int):
 
     :return: confidence for each data instance
     """
-    base_conf = 1/n_classes
-    confs = base_conf + np.max(raw_confs, axis=1)/n_classes
+    base_conf = 1 / n_classes
+    confs = base_conf + np.max(raw_confs, axis=1) / n_classes
     return confs
 
 

--- a/lightwood/analysis/nc/util.py
+++ b/lightwood/analysis/nc/util.py
@@ -87,7 +87,10 @@ def set_conf_range(
     # categorical
     elif target_type in (dtype.binary, dtype.categorical):
         pvals = icp.predict(X.values)  # p-values at which each class is included in the predicted set
-        conf = np.subtract(1, pvals.min(axis=1))
+
+        # one minus 2nd best p-value yields confidence for predicted label
+        second_best = np.sort(pvals, axis=1)[:, -2]
+        conf = np.clip(np.subtract(1, second_best), 0.0001, 0.9999)
         return conf, pvals
 
     # default
@@ -154,27 +157,18 @@ def get_numeric_conf_range(
     return np.array(significances), conf_ranges
 
 
-def get_categorical_conf(all_confs: np.ndarray, conf_candidates: list):
+def get_categorical_conf(raw_confs: np.ndarray, n_classes: int):
     """
-    Gets ICP confidence estimation for categorical targets.
-    Prediction set is always unitary and includes only the predicted label.
+    Gets ICP confidence estimation for categorical targets from raw p-values per class.
 
-    :param all_confs: all possible label sets depending on confidence level
-    :param conf_candidates: includes preset confidence levels to check
+    :param all_confs: p-value for each class per data point
+    :param n_classes: amount of classes
 
     :return: confidence for each data instance
     """
-    significances = []
-    for sample_idx in range(all_confs.shape[0]):
-        sample = all_confs[sample_idx, :, :]
-        for idx in range(sample.shape[1]):
-            conf = (99 - conf_candidates[idx]) / 100
-            if np.sum(sample[:, idx]) == 1:
-                significances.append(conf)
-                break
-        else:
-            significances.append(0.005)  # default: not confident label is the predicted one
-    return significances
+    base_conf = 1/n_classes
+    confs = base_conf + np.max(raw_confs, axis=1)/n_classes
+    return confs
 
 
 def get_anomalies(insights: pd.DataFrame, observed_series: Union[pd.Series, list], cooldown: int = 1):

--- a/lightwood/analysis/nc/util.py
+++ b/lightwood/analysis/nc/util.py
@@ -87,10 +87,7 @@ def set_conf_range(
     # categorical
     elif target_type in (dtype.binary, dtype.categorical):
         pvals = icp.predict(X.values)  # p-values at which each class is included in the predicted set
-
-        # one minus 2nd best p-value yields confidence for predicted label
-        second_best = np.sort(pvals, axis=1)[:, -2]
-        conf = np.clip(np.subtract(1, second_best), 0.0001, 0.9999)
+        conf = get_categorical_conf(pvals)
         return conf, pvals
 
     # default
@@ -157,17 +154,15 @@ def get_numeric_conf_range(
     return np.array(significances), conf_ranges
 
 
-def get_categorical_conf(raw_confs: np.ndarray, n_classes: int):
+def get_categorical_conf(raw_confs: np.ndarray):
     """
     Gets ICP confidence estimation for categorical targets from raw p-values per class.
-
     :param all_confs: p-value for each class per data point
-    :param n_classes: amount of classes
-
     :return: confidence for each data instance
     """
-    base_conf = 1 / n_classes
-    confs = base_conf + np.max(raw_confs, axis=1) / n_classes
+    # one minus 2nd best p-value yields confidence for predicted label
+    second_best = np.sort(raw_confs, axis=1)[:, -2]
+    confs = np.clip(np.subtract(1, second_best), 0.0001, 0.9999)
     return confs
 
 

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -578,7 +578,7 @@ class PredictionArguments:
         detector.
     """  # noqa
 
-    predict_proba: bool = False
+    predict_proba: bool = True
     all_mixers: bool = False
     fixed_confidence: Union[int, float, None] = None
     anomaly_error_rate: Union[float, None] = None


### PR DESCRIPTION
## Why

To improve inductive conformal prediction runtime (both calibration and inference).

## How
Quite a few changes:
- `CachedClassifierAdapter` now returns raw probabilities to the ICP
- `BaseICP` now has a `validation_size` parameter (and the associated method `_reduce_scores()`) to keep the amount of reference nonconformity scores under the specified threshold. For now (and unless requested in the future and/or suggested by the pending confidence benchmarks), we are setting this value to 100. This improves the runtime.
- Removed inefficient procedure that would check classifier confidence more times than necessary. This alone yields 20x improvement in compute savings. Now the call is done once, and we retrieve the raw  p-values to build the final confidence estimate.
- Modified computation of "equal" and "greater than" count for confidence at inference time by replacing original routine with numpy calls.
- Fixed bug where changes in prediction cache would propagate as an unintended side effect.
- Improved robustness of confidence scores (clipped between 1e-4 and 0.9999, and computed against p-value of second best label instead of worst).
- Changed `predict_proba` prediction argument default value to `True`.