### PR TITLE
Compute & log time per phase

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1073,46 +1073,56 @@ class Predictor(PredictorInterface):
 
         # Initial stats analysis
         self.statistical_analysis = None
+        self.phase_times = dict()
 
-
+    @timed
     def analyze_data(self, data: pd.DataFrame) -> None:
         # Perform a statistical analysis on the unprocessed data
 {analyze_data_body}
 
+    @timed
     def preprocess(self, data: pd.DataFrame) -> pd.DataFrame:
         # Preprocess and clean data
 {clean_body}
 
+    @timed
     def split(self, data: pd.DataFrame) -> Dict[str, pd.DataFrame]:
         # Split the data into training/testing splits
 {split_body}
 
+    @timed
     def prepare(self, data: Dict[str, pd.DataFrame]) -> None:
         # Prepare encoders to featurize data
 {prepare_body}
 
+    @timed
     def featurize(self, split_data: Dict[str, pd.DataFrame]):
         # Featurize data into numerical representations for models
 {feature_body}
 
+    @timed
     def fit(self, enc_data: Dict[str, pd.DataFrame]) -> None:
         # Fit predictors to estimate target
 {fit_body}
 
+    @timed
     def analyze_ensemble(self, enc_data: Dict[str, pd.DataFrame]) -> None:
         # Evaluate quality of fit for the ensemble of mixers
 {analyze_ensemble}
 
+    @timed
     def learn(self, data: pd.DataFrame) -> None:
         log.info(f'Dropping features: {{self.problem_definition.ignore_features}}')
         data = data.drop(columns=self.problem_definition.ignore_features, errors='ignore')
 {learn_body}
 
+    @timed
     def adjust(self, new_data: Union[EncodedDs, ConcatedEncodedDs, pd.DataFrame],
         old_data: Optional[Union[EncodedDs, ConcatedEncodedDs, pd.DataFrame]] = None) -> None:
         # Update mixers with new information
 {adjust_body}
 
+    @timed
     def predict(self, data: pd.DataFrame, args: Dict = {{}}) -> pd.DataFrame:
 {predict_body}
 """

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1073,7 +1073,7 @@ class Predictor(PredictorInterface):
 
         # Initial stats analysis
         self.statistical_analysis = None
-        self.phase_times = dict()
+        self.runtime_log = dict()
 
     @timed
     def analyze_data(self, data: pd.DataFrame) -> None:

--- a/lightwood/helpers/log.py
+++ b/lightwood/helpers/log.py
@@ -5,8 +5,6 @@ from time import time
 from datetime import datetime
 from functools import wraps
 
-from lightwood.api.predictor import PredictorInterface
-
 
 def initialize_log():
     pid = os.getpid()
@@ -28,12 +26,11 @@ def timed(f):
     """
     @wraps(f)
     def wrap(predictor, *args, **kw):
-        assert isinstance(predictor, PredictorInterface)
         ts = time()
         result = f(predictor, *args, **kw)
         te = time()
         log.debug(f' `{f.__name__}` runtime: {round(te - ts, 2)} seconds')
-        predictor.phase_times[(f.__name__, datetime.fromtimestamp(ts))] = te - ts
+        predictor.runtime_log[(f.__name__, datetime.fromtimestamp(ts))] = te - ts
         return result
     return wrap
 

--- a/lightwood/helpers/log.py
+++ b/lightwood/helpers/log.py
@@ -1,6 +1,11 @@
-import logging
 import os
+import logging
 import colorlog
+from time import time
+from datetime import datetime
+from functools import wraps
+
+from lightwood.api.predictor import PredictorInterface
 
 
 def initialize_log():
@@ -14,6 +19,23 @@ def initialize_log():
     log_level = os.environ.get('LIGHTWOOD_LOG', 'DEBUG')
     log.setLevel(log_level)
     return log
+
+
+def timed(f):
+    """
+    Intended to be called from within lightwood predictor methods.
+    We use `wraps` to pass metadata into debuggers (as in stackoverflow.com/a/27737385)
+    """
+    @wraps(f)
+    def wrap(predictor, *args, **kw):
+        assert isinstance(predictor, PredictorInterface)
+        ts = time()
+        result = f(predictor, *args, **kw)
+        te = time()
+        log.debug(f' `{f.__name__}` runtime: {round(te - ts, 2)} seconds')
+        predictor.phase_times[(f.__name__, datetime.fromtimestamp(ts))] = te - ts
+        return result
+    return wrap
 
 
 log = initialize_log()


### PR DESCRIPTION
## Why
To communicate runtime of a predictor while training, predicting, etc. to a user.

## How

Added a decorator that is used in all `PredictorInterface` methods and will 1) log the runtime of each method at the `DEBUG` level and 2) store the runtime in the `runtime_log` field. 