### PR TITLE
Fix 858

### DIFF
--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -1,10 +1,12 @@
+from copy import deepcopy as dc
+from typing import Dict, List, Iterable, Tuple
+
 import torch
 import numpy as np
+from scipy.special import softmax
+
 from lightwood.encoder.base import BaseEncoder
 from lightwood.helpers.constants import _UNCOMMON_WORD
-from copy import deepcopy as dc
-
-from typing import Dict, List, Iterable, Tuple
 
 
 class BinaryEncoder(BaseEncoder):
@@ -157,11 +159,8 @@ class BinaryEncoder(BaseEncoder):
     @staticmethod
     def _norm_vec(vec: List[float]):
         """
-        Given a vector, normalizes so that the sum of elements is 1.
+        Given a vector, normalizes so that the sum of elements is 1, using softmax.
 
         :param vec: Assigned weights for each category
         """  # noqa
-        total = sum(vec)
-        if total == 0:
-            return vec
-        return [i / total for i in vec]
+        return softmax(vec)

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -1,11 +1,13 @@
+from copy import deepcopy
+from typing import Dict, List, Iterable, Tuple
+
 import torch
 import numpy as np
+from scipy.special import softmax
+
 from lightwood.helpers.log import log
 from lightwood.encoder.base import BaseEncoder
 from lightwood.helpers.constants import _UNCOMMON_WORD
-from copy import deepcopy
-
-from typing import Dict, List, Iterable, Tuple
 
 
 class OneHotEncoder(BaseEncoder):
@@ -173,11 +175,8 @@ class OneHotEncoder(BaseEncoder):
     @staticmethod
     def _norm_vec(vec: List[float]):
         """
-        Given a vector, normalizes so that the sum of elements is 1.
+        Given a vector, normalizes so that the sum of elements is 1, using softmax.
 
         :param vec: Assigned weights for each category
         """
-        total = sum(vec)
-        if total == 0:
-            return vec
-        return [i / total for i in vec]
+        return softmax(vec)


### PR DESCRIPTION
## Why

To fix #858 

## How

Switches `_norm_vec` in `onehot` and `binary` encoders to use `scipy.special.softmax` instead of a bespoke approach that had not accounted for the edge case with negative entries in the vector.