### PR TITLE
Fix: non-null TS delta analysis

### DIFF
--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -42,7 +42,7 @@ class TsNumericEncoder(NumericEncoder):
                 vector = [0] * 2
                 if group is not None and self.normalizers is not None:
                     try:
-                        mean = self.normalizers[frozenset(group)].abs_mean
+                        mean = self.normalizers[tuple(group)].abs_mean
                     except KeyError:
                         # novel group-by, we use default normalizer mean
                         mean = self.normalizers['__default'].abs_mean
@@ -99,7 +99,7 @@ class TsNumericEncoder(NumericEncoder):
                     else:
                         if group is not None and self.normalizers is not None:
                             try:
-                                mean = self.normalizers[frozenset(group)].abs_mean
+                                mean = self.normalizers[tuple(group)].abs_mean
                             except KeyError:
                                 # decode new group with default normalizer
                                 mean = self.normalizers['__default'].abs_mean

--- a/lightwood/encoder/time_series/helpers/common.py
+++ b/lightwood/encoder/time_series/helpers/common.py
@@ -28,7 +28,7 @@ def generate_target_group_normalizers(data):
         all_group_combinations = list(product(*[set(x) for x in data['group_info'].values()]))
         for combination in all_group_combinations:
             if combination != ():
-                combination = frozenset(combination)  # freeze so that we can hash with it
+                combination = tuple(combination)
                 _, subset = get_group_matches(data, combination)
                 if subset.size > 0:
                     normalizers[combination] = MinMaxNormalizer(combination=combination)

--- a/lightwood/encoder/time_series/rnn.py
+++ b/lightwood/encoder/time_series/rnn.py
@@ -374,7 +374,7 @@ class TimeSeriesEncoder(BaseEncoder):
                     all_idxs = set(range(len(dep_data)))
 
                     for combination in [c for c in self._group_combinations if c != '__default']:
-                        normalizer = self.dep_norms[dep].get(frozenset(combination), None)
+                        normalizer = self.dep_norms[dep].get(tuple(combination), None)
                         if normalizer is None:
                             normalizer = self.dep_norms[dep]['__default']
                         idxs, subset = get_group_matches(dep_info, normalizer.combination)

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -13,7 +13,7 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss: Times
 
         if tss.group_by:
             try:
-                series_delta = deltas[frozenset(row[gby].tolist())][col]
+                series_delta = deltas[tuple(row[gby].tolist())][col]
             except KeyError:
                 series_delta = deltas['__default'][col]
         else:

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -237,7 +237,7 @@ class SkTime(BaseMixer):
             series_idxs, series_data = get_group_matches(data, group)
 
             if series_data.size > 0:
-                group = frozenset(group)
+                group = tuple(group)
                 series_idxs = sorted(series_idxs)
                 if self.models.get(group, False) and self.models[group].is_fitted:
                     forecaster = self.models[group]


### PR DESCRIPTION
Fixes:
- Will choose most popular _non-null_ delta for each series
- Changes `frozenset` to `tuple` to avoid ordering issues and potentially missing out on training data