### PR TITLE
Fix #877 - Improved quantity cleaner

### DIFF
--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -264,7 +264,9 @@ def _clean_quantity(element: object) -> Optional[float]:
     """
     Given a quantity, clean and convert it into float numeric format. If element is NaN, or inf, then returns None.
     """
-    element = float(re.sub("[^0-9.,]", "", str(element)).replace(",", "."))
+    no_symbols = re.sub("[^0-9.,]", "", str(element)).replace(",", ".")
+    no_symbols = '0' if no_symbols == '' else no_symbols
+    element = float(no_symbols)
     return _clean_float(element)
 
 


### PR DESCRIPTION
Fixes #877. Simply imputes `0` if the cleaned string (without quantity symbols) has no content at all.