### PR TITLE
Offset handling for TS predictions

### DIFF
--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -332,7 +332,7 @@ def _remove_columns(data: pd.DataFrame, identifiers: Dict[str, object], target: 
     to_drop = [*[x for x in identifiers.keys() if x != target],
                *[x for x in data.columns if x in dtype_dict and dtype_dict[x] == dtype.invalid]]
 
-    exceptions = ["__mdb_make_predictions"]
+    exceptions = ["__mdb_forecast_offset"]
     if timeseries_settings.group_by is not None:
         exceptions += timeseries_settings.group_by
 


### PR DESCRIPTION
## Why
To enable greater control of row selection to generate forecasts from MindsDB, enabling efficient usage of syntax like `WHERE T = LATEST`

## How
Add special column `__mdb_forecast_offset` that can be either None or an integer. If this column is passed, then the TS transformation will react to the values within:

* If all rows have it set to `None`, then we proceed as usual
* If all rows have the same value `N <= 0`, then we cutoff the dataframe latest `-N` rows after TS shaping and prime the DF (via `__make_predictions` column) so that a forecast is generated only for the last row. This enables `WHERE T = LATEST - K` with `0 <= K < WINDOW` syntax, though realistically any `K != 0` will probably not be useful.
* If all rows have the same value `N = 1`, then we activate streaming inference mode where a single forecast will be emitted for the timestamp inferred by the `_ts_infer_next_row` method. This enables the (already supported) `WHERE T > LATEST` syntax.