### PR TITLE
Linear tree for LightGBM array mixer

### DIFF
--- a/lightwood/encoder/helpers.py
+++ b/lightwood/encoder/helpers.py
@@ -19,8 +19,8 @@ class MinMaxNormalizer:
         if len(x.shape) < 2:
             x = np.expand_dims(x, axis=1)
 
-        x = x.astype(float)
         x[x == None] = 0 # noqa
+        x = x.astype(float)
         self.abs_mean = np.mean(np.abs(x))
         self.scaler.fit(x.reshape(x.size, -1))
 

--- a/lightwood/encoder/time_series/ts.py
+++ b/lightwood/encoder/time_series/ts.py
@@ -37,7 +37,7 @@ class TimeSeriesEncoder(ArrayEncoder):
         if self.original_type in (dtype.integer, dtype.float, dtype.quantity, dtype.num_tsarray):
             mavgs = []
             for offset in range(self.max_mavg_offset):
-                ma = torch.mean(base_encode[:, self.max_mavg_offset - (offset + 1):self.max_mavg_offset], 1)
+                ma = torch.mean(base_encode[:, offset:self.max_mavg_offset], 1)
                 mavgs.append(ma.unsqueeze(1))
             base_encode[:, (self.output_size - self.max_mavg_offset):] = torch.cat(mavgs, dim=1)
 

--- a/lightwood/mixer/lightgbm.py
+++ b/lightwood/mixer/lightgbm.py
@@ -185,6 +185,8 @@ class LightGBM(BaseMixer):
         if objective == 'multiclass':
             self.all_classes = self.ordinal_encoder.categories_[0]
             self.params['num_class'] = self.all_classes.size
+        elif output_dtype == dtype.num_tsarray:
+            self.params['linear_tree'] = True
         if self.device_str == 'gpu':
             self.params['gpu_use_dp'] = True
 

--- a/lightwood/mixer/lightgbm_array.py
+++ b/lightwood/mixer/lightgbm_array.py
@@ -27,7 +27,6 @@ class LightGBMArray(BaseMixer):
         super().__init__(stop_after)
         self.submodel_stop_after = stop_after / horizon
         self.target = target
-        # dtype_dict[target] = dtype.float  @TODO: figure out if this can be removed
         self.models = [LightGBM(self.submodel_stop_after, target, dtype_dict, input_cols, fit_on_dev,
                                 False, target_encoder)
                        for _ in range(horizon)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ schema >=0.6.8
 torch >=1.9.0,<1.10.0
 requests >=2.0.0
 transformers >=4.5.0,<=4.11.3
-lightgbm >=3.1.1,<=3.3.0
+lightgbm >=3.2.1,<=3.3.0
 optuna >=2.8.0,<2.10.0
 scipy >=1.5.4,<=1.7.1
 psutil >=5.7.0


### PR DESCRIPTION
## Why
To achieve better trend modelling (for when test data is outside of the previously seen range) in the `LightGBMArray` mixer.

## How
Forces `linear_tree` param to be true.