### PR TITLE
[ENH] Add tn_conf for categorical targets

### DIFF
--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -9,7 +9,7 @@ from sklearn.preprocessing import OneHotEncoder
 
 from lightwood.api.dtype import dtype
 from lightwood.api.types import PredictionArguments
-from lightwood.helpers.ts import add_tn_conf_bounds
+from lightwood.helpers.ts import add_tn_num_conf_bounds, add_tn_cat_conf_bounds
 
 from lightwood.data import EncodedDs
 from lightwood.analysis.base import BaseAnalysisBlock
@@ -380,8 +380,11 @@ class ICP(BaseAnalysisBlock):
                                               cooldown=ns.pred_args.anomaly_cooldown)
                     row_insights['anomaly'] = anomalies
 
-            if ns.tss.is_timeseries and ns.tss.horizon > 1 and is_numerical:
-                row_insights = add_tn_conf_bounds(row_insights, ns.tss)
+            if ns.tss.is_timeseries and ns.tss.horizon > 1:
+                if is_numerical:
+                    row_insights = add_tn_num_conf_bounds(row_insights, ns.tss)
+                else:
+                    row_insights = add_tn_cat_conf_bounds(row_insights, ns.tss)
 
             # clip bounds if necessary
             if is_numerical:

--- a/lightwood/helpers/__init__.py
+++ b/lightwood/helpers/__init__.py
@@ -3,7 +3,8 @@ from lightwood.helpers.device import is_cuda_compatible, get_devices
 from lightwood.helpers.general import mase, is_none, evaluate_accuracy, evaluate_num_array_accuracy,\
     evaluate_array_accuracy, evaluate_multilabel_accuracy, evaluate_regression_accuracy, evaluate_cat_array_accuracy, \
     bounded_evaluate_array_accuracy
-from lightwood.helpers.ts import get_group_matches, get_ts_groups, get_inferred_timestamps, add_tn_conf_bounds
+from lightwood.helpers.ts import get_group_matches, get_ts_groups, get_inferred_timestamps, add_tn_num_conf_bounds, \
+    add_tn_cat_conf_bounds
 from lightwood.helpers.io import read_from_path_or_url
 from lightwood.helpers.parallelism import get_nr_procs, mut_method_call, run_mut_method
 from lightwood.helpers.numeric import is_nan_numeric, filter_nan_and_none
@@ -20,6 +21,6 @@ __all__ = ['to_binary', 'f1_score', 'recall_score', 'precision_score', 'r2_score
            'evaluate_multilabel_accuracy', 'evaluate_regression_accuracy', 'read_from_path_or_url', 'get_nr_procs',
            'mut_method_call', 'run_mut_method', 'tokenize_text', 'analyze_sentences', 'decontracted', 'contains_alnum',
            'get_identifier_description', 'get_identifier_description_mp', 'get_pct_auto_increment',
-           'extract_digits', 'isascii', 'get_inferred_timestamps', 'add_tn_conf_bounds',
+           'extract_digits', 'isascii', 'get_inferred_timestamps', 'add_tn_num_conf_bounds', 'add_tn_cat_conf_bounds',
            'hashtext', 'splitRecursive', 'cast_string_to_python_type', 'gen_chars', 'clean_float', 'word_tokenize',
            'get_language_dist', 'average_vectors', 'concat_vectors_and_pad', 'LightwoodAutocast', 'is_nan_numeric', 'filter_nan_and_none', 'seed']  # noqa

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -99,7 +99,7 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss) -> pd
     return df[f'order_{col}']
 
 
-def add_tn_conf_bounds(data: pd.DataFrame, tss_args):
+def add_tn_num_conf_bounds(data: pd.DataFrame, tss_args):
     """
     Add confidence (and bounds if applicable) to t+n predictions, for n>1
     TODO: active research question: how to guarantee 1-e coverage for t+n, n>1
@@ -119,6 +119,13 @@ def add_tn_conf_bounds(data: pd.DataFrame, tss_args):
         data['lower'].iloc[idx] = [pred - (width / 2) * modifier for pred, modifier in zip(preds, error_increase)]
         data['upper'].iloc[idx] = [pred + (width / 2) * modifier for pred, modifier in zip(preds, error_increase)]
 
+    return data
+
+
+def add_tn_cat_conf_bounds(data: pd.DataFrame, tss_args):
+    data['confidence'] = data['confidence'].astype(object)
+    for idx, row in data.iterrows():
+        data['confidence'].iloc[idx] = [row['confidence'] for _ in range(tss_args.horizon)]
     return data
 
 


### PR DESCRIPTION
# Why
To improve support for categorical forecasters.

# How
Adds a baseline method to extend the confidence level across the entire horizon so that the output type is consistent with the numerical target case.