### PR TITLE
[MAINT] `order_by` is now a single column

### DIFF
--- a/lightwood/analysis/explain.py
+++ b/lightwood/analysis/explain.py
@@ -54,12 +54,9 @@ def explain(data: pd.DataFrame,
             for col in timeseries_settings.group_by:
                 row_insights[f'group_{col}'] = data[col]
 
-        for col in timeseries_settings.order_by:
-            row_insights[f'order_{col}'] = data[col]
-
-        for col in timeseries_settings.order_by:
-            row_insights[f'order_{col}'] = get_inferred_timestamps(
-                row_insights, col, ts_analysis['deltas'], timeseries_settings)
+        row_insights[f'order_{timeseries_settings.order_by}'] = data[timeseries_settings.order_by]
+        row_insights[f'order_{timeseries_settings.order_by}'] = get_inferred_timestamps(
+            row_insights, timeseries_settings.order_by, ts_analysis['deltas'], timeseries_settings)
 
     kwargs = {
         'data': data,

--- a/lightwood/analysis/helpers/feature_importance.py
+++ b/lightwood/analysis/helpers/feature_importance.py
@@ -38,7 +38,7 @@ class GlobalFeatureImportance(BaseAnalysisBlock):
         else:
             empty_input_accuracy = {}
             ignorable_input_cols = [x for x in ns.input_cols if (not ns.tss.is_timeseries or
-                                                                 (x not in ns.tss.order_by and
+                                                                 (x != ns.tss.order_by and
                                                                   x not in ns.tss.historical_columns))]
             for col in ignorable_input_cols:
                 partial_data = deepcopy(ns.encoded_val_data)

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -120,7 +120,7 @@ class ICP(BaseAnalysisBlock):
             # fit additional ICPs in time series tasks with grouped columns
             if ns.tss.is_timeseries and ns.tss.group_by:
                 # generate a multiindex
-                midx = pd.MultiIndex.from_frame(icp_df[[*ns.tss.group_by, f'__mdb_original_{ns.tss.order_by[0]}']])
+                midx = pd.MultiIndex.from_frame(icp_df[[*ns.tss.group_by, f'__mdb_original_{ns.tss.order_by}']])
                 icp_df.index = midx
 
                 # create an ICP for each possible group
@@ -157,7 +157,7 @@ class ICP(BaseAnalysisBlock):
 
                 # add all predictions to DF
                 icps_df = deepcopy(ns.data)
-                midx = pd.MultiIndex.from_frame(icps_df[[*ns.tss.group_by, f'__mdb_original_{ns.tss.order_by[0]}']])
+                midx = pd.MultiIndex.from_frame(icps_df[[*ns.tss.group_by, f'__mdb_original_{ns.tss.order_by}']])
                 icps_df.index = midx
                 if ns.is_multi_ts or pred_is_list:
                     icps_df[f'__predicted_{ns.target}'] = np.array([p[0] for p in ns.normal_predictions['prediction']])

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -135,7 +135,7 @@ def lookup_encoder(
     # Time-series representations require more advanced flags
     if tss.is_timeseries:
         gby = tss.group_by if tss.group_by is not None else []
-        if col_name in tss.order_by:
+        if col_name == tss.order_by:
             encoder_dict["module"] = "ArrayEncoder"
             encoder_dict["args"]["original_type"] = f'"{tss.target_type}"'
             encoder_dict["args"]["window"] = f"{tss.window}"
@@ -753,27 +753,28 @@ def code_from_json_ai(json_ai: JsonAI) -> str:
         encoder_dict[col_name] = call(encoder)
 
     # Populate time-series specific details
+    # TODO: consider moving this to a `JsonAI override` phase
     tss = json_ai.problem_definition.timeseries_settings
-    if tss.is_timeseries and tss.use_previous_target:
-        col_name = f"__mdb_ts_previous_{json_ai.problem_definition.target}"
-        target_type = json_ai.dtype_dict[json_ai.problem_definition.target]
-        json_ai.problem_definition.timeseries_settings.target_type = target_type
-        encoder_dict[col_name] = call(
-            lookup_encoder(
-                target_type,
-                col_name,
-                False,
-                json_ai.problem_definition,
-                False,
-                None,
+    if tss.is_timeseries:
+        if tss.use_previous_target:
+            col_name = f"__mdb_ts_previous_{json_ai.problem_definition.target}"
+            target_type = json_ai.dtype_dict[json_ai.problem_definition.target]
+            json_ai.problem_definition.timeseries_settings.target_type = target_type
+            encoder_dict[col_name] = call(
+                lookup_encoder(
+                    target_type,
+                    col_name,
+                    False,
+                    json_ai.problem_definition,
+                    False,
+                    None,
+                )
             )
-        )
 
-        dtype_dict[col_name] = target_type
-        # @TODO: Is populating the json_ai at this stage even necessary?
-        json_ai.encoders[col_name] = encoder_dict[col_name]
-        json_ai.dtype_dict[col_name] = target_type
-        json_ai.dependency_dict[col_name] = []
+            dtype_dict[col_name] = target_type
+            json_ai.encoders[col_name] = encoder_dict[col_name]
+            json_ai.dtype_dict[col_name] = target_type
+            json_ai.dependency_dict[col_name] = []
 
     # ----------------- #
 

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -776,6 +776,24 @@ def code_from_json_ai(json_ai: JsonAI) -> str:
             json_ai.dtype_dict[col_name] = target_type
             json_ai.dependency_dict[col_name] = []
 
+        # TODO: generalize this
+        oby_additional_col = f"__mdb_ts_datetime_{json_ai.problem_definition.timeseries_settings.order_by}"
+        oby_dtype = 'datetime'
+        dtype_dict[oby_additional_col] = oby_dtype
+        encoder_dict[oby_additional_col] = call(
+            lookup_encoder(
+                oby_dtype,
+                oby_additional_col,
+                False,
+                json_ai.problem_definition,
+                False,
+                None,
+            )
+        )
+        json_ai.encoders[oby_additional_col] = encoder_dict[oby_additional_col]
+        json_ai.dtype_dict[oby_additional_col] = oby_dtype
+        json_ai.dependency_dict[oby_additional_col] = []
+
     # ----------------- #
 
     input_cols = [x.replace("'", "\\'").replace('"', '\\"') for x in json_ai.encoders

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -772,27 +772,10 @@ def code_from_json_ai(json_ai: JsonAI) -> str:
             )
 
             dtype_dict[col_name] = target_type
+            # @TODO: Is populating the json_ai at this stage even necessary?
             json_ai.encoders[col_name] = encoder_dict[col_name]
             json_ai.dtype_dict[col_name] = target_type
             json_ai.dependency_dict[col_name] = []
-
-        # TODO: generalize this
-        oby_additional_col = f"__mdb_ts_datetime_{json_ai.problem_definition.timeseries_settings.order_by}"
-        oby_dtype = 'datetime'
-        dtype_dict[oby_additional_col] = oby_dtype
-        encoder_dict[oby_additional_col] = call(
-            lookup_encoder(
-                oby_dtype,
-                oby_additional_col,
-                False,
-                json_ai.problem_definition,
-                False,
-                None,
-            )
-        )
-        json_ai.encoders[oby_additional_col] = encoder_dict[oby_additional_col]
-        json_ai.dtype_dict[oby_additional_col] = oby_dtype
-        json_ai.dependency_dict[oby_additional_col] = []
 
     # ----------------- #
 

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -114,7 +114,7 @@ class TimeseriesSettings:
     :param group_by: Optional list of columns by which the data should be grouped. Each different combination of values\
          for these columns will yield a different series.
     :param window: The temporal horizon (number of rows) that a model intakes to "look back" into when making a\
-         prediction, after the rows are ordered by order_by columns and split into groups if applicable.
+         prediction, after the rows are ordered by the order_by column and split into groups if applicable.
     :param horizon: The number of points in the future that predictions should be made for, defaults to 1. Once \
         trained, the model will be able to predict up to this many points into the future.
     :param historical_columns: The temporal dynamics of these columns will be used as additional context to train the \

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -110,7 +110,7 @@ class TimeseriesSettings:
 
     :param is_timeseries: Whether the input data should be treated as time series; if true, this flag is checked in \
         subsequent internal steps to ensure processing is appropriate for time-series data.
-    :param order_by: A list of columns by which the data should be ordered.
+    :param order_by: Column by which the data should be ordered.
     :param group_by: Optional list of columns by which the data should be grouped. Each different combination of values\
          for these columns will yield a different series.
     :param window: The temporal horizon (number of rows) that a model intakes to "look back" into when making a\
@@ -128,7 +128,7 @@ class TimeseriesSettings:
     """  # noqa
 
     is_timeseries: bool
-    order_by: List[str] = None
+    order_by: str = None
     window: int = None
     group_by: List[str] = None
     use_previous_target: bool = True

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -152,9 +152,13 @@ class TimeseriesSettings:
         :returns: A populated ``TimeseriesSettings`` object.
         """ # noqa
         if len(obj) > 0:
-            for mandatory_setting in ["order_by", "window"]:
+            for mandatory_setting, etype in zip(["order_by", "window"], [str, int]):
                 if mandatory_setting not in obj:
                     err = f"Missing mandatory timeseries setting: {mandatory_setting}"
+                    log.error(err)
+                    raise Exception(err)
+                if not isinstance(obj[mandatory_setting], etype):
+                    err = f"Wrong type for mandatory timeseries setting '{mandatory_setting}': found '{type(obj[mandatory_setting])}', expected '{etype}'"  # noqa
                     log.error(err)
                     raise Exception(err)
 

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -157,7 +157,7 @@ class TimeseriesSettings:
                     err = f"Missing mandatory timeseries setting: {mandatory_setting}"
                     log.error(err)
                     raise Exception(err)
-                if not isinstance(obj[mandatory_setting], etype):
+                if obj[mandatory_setting] and not isinstance(obj[mandatory_setting], etype):
                     err = f"Wrong type for mandatory timeseries setting '{mandatory_setting}': found '{type(obj[mandatory_setting])}', expected '{etype}'"  # noqa
                     log.error(err)
                     raise Exception(err)

--- a/lightwood/data/cleaner.py
+++ b/lightwood/data/cleaner.py
@@ -394,7 +394,7 @@ def clean_timeseries(df: pd.DataFrame, tss: TimeseriesSettings) -> pd.DataFrame:
     invalid_rows = []
 
     for idx, row in df.iterrows():
-        if pd.isna(row[tss.order_by[0]]):
+        if pd.isna(row[tss.order_by]):
             invalid_rows.append(idx)
 
     df = df.drop(invalid_rows)

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -19,7 +19,7 @@ def transform_timeseries(
     Block that transforms the dataframe of a time series task to a convenient format for use in posterior phases like model training.
     
     The main transformations performed by this block are:
-      - Type casting (e.g. to numerical for `order_by` columns).
+      - Type casting (e.g. to numerical for `order_by` column).
       - Windowing functions for historical context based on `TimeseriesSettings.window` parameter.
       - Explicitly add target columns according to the `TimeseriesSettings.horizon` parameter.
       - Flag all rows that are "predictable" based on all `TimeseriesSettings`.
@@ -265,10 +265,10 @@ def _ts_to_obj(df: pd.DataFrame, historical_columns: list) -> pd.DataFrame:
 
 def _ts_order_col_to_cell_lists(df: pd.DataFrame, order_cols: list) -> pd.DataFrame:
     """
-    Casts all data in `order_by` columns into cells.
+    Casts all data in the `order_by` column into cells.
 
     :param df: Input dataframe
-    :param order_cols: `order_by` columns
+    :param order_cols: `order_by` column and other columns flagged as `historical`.
 
     :return: Dataframe with all `order_cols` modified so that their values are cells, e.g. `1` -> `[1]`
     """
@@ -281,10 +281,10 @@ def _ts_order_col_to_cell_lists(df: pd.DataFrame, order_cols: list) -> pd.DataFr
 
 def _ts_add_previous_rows(df: pd.DataFrame, order_cols: list, window: int) -> pd.DataFrame:
     """
-    Adds previous rows (as determined by `TimeseriesSettings.window`) into the cells of all `order_by` columns.
+    Adds previous rows (as determined by `TimeseriesSettings.window`) into the cells of the `order_by` column.
 
     :param df: Input dataframe.
-    :param order_cols: `order_by` columns.
+    :param order_cols: `order_by` column and other columns flagged as `historical`.
     :param window: value of `TimeseriesSettings.window` parameter.
     
     :return: Dataframe with all `order_cols` modified so that their values are now arrays of historical context.

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -136,7 +136,6 @@ def transform_timeseries(
         log.info(f'Using {nr_procs} processes to reshape.')
         pool = mp.Pool(processes=nr_procs)
         # Make type `object` so that dataframe cells can be python lists
-        df_arr = pool.map(partial(_ts_repeat_oby, oby=tss.order_by), df_arr)
         df_arr = pool.map(partial(_ts_to_obj, historical_columns=[oby] + tss.historical_columns), df_arr)
         df_arr = pool.map(partial(_ts_order_col_to_cell_lists,
                           order_cols=[oby] + tss.historical_columns), df_arr)
@@ -157,7 +156,6 @@ def transform_timeseries(
         pool.join()
     else:
         for i in range(n_groups):
-            df_arr[i] = _ts_repeat_oby(df_arr[i], tss.order_by)
             df_arr[i] = _ts_to_obj(df_arr[i], historical_columns=[oby] + tss.historical_columns)
             df_arr[i] = _ts_order_col_to_cell_lists(df_arr[i], order_cols=[oby] + tss.historical_columns)
             df_arr[i] = _ts_add_previous_rows(df_arr[i],
@@ -360,12 +358,4 @@ def _ts_add_future_target(df, target, horizon, data_dtype, mode):
         df[col_name] = next_target_value_arr
         df[col_name] = df[col_name].fillna(value=np.nan)
 
-    return df
-
-
-def _ts_repeat_oby(df: pd.DataFrame, oby: str) -> pd.DataFrame:
-    """
-    Clones the order_by column for usage with a non-temporal encoder (e.g. DatetimeEncoder).
-    """
-    df[f'__mdb_ts_datetime_{oby}'] = df[oby]
     return df

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -55,9 +55,9 @@ def get_delta(
     Dictionary with group combination tuples as keys. Values are dictionaries with the inferred delta for each series.
     """  # noqa
     df = df.copy()
-    original_col = f'__mdb_original_{tss.order_by[0]}'
-    order_col = [original_col] if original_col in df.columns else [tss.order_by[0]]
-    deltas = {"__default": df[order_col].astype(float).rolling(window=2).apply(np.diff).value_counts().index[0][0]}
+    original_col = f'__mdb_original_{tss.order_by}'
+    order_col = original_col if original_col in df.columns else tss.order_by
+    deltas = {"__default": df[order_col].astype(float).rolling(window=2).apply(np.diff).value_counts().index[0]}
     freq, period = detect_freq_period(deltas["__default"], tss)
     periods = {"__default": period}
     freqs = {"__default": freq}
@@ -67,7 +67,7 @@ def get_delta(
             if group != "__default":
                 _, subset = get_group_matches(df, group, tss.group_by)
                 if subset.shape[0] > 1:
-                    deltas[group] = subset[order_col].rolling(window=2).apply(np.diff).value_counts().index[0][0]
+                    deltas[group] = subset[order_col].rolling(window=2).apply(np.diff).value_counts().index[0]
                     freq, period = detect_freq_period(deltas[group], tss)
                     periods[group] = period
                     freqs[group] = freq

--- a/lightwood/mixer/lightgbm_array.py
+++ b/lightwood/mixer/lightgbm_array.py
@@ -40,8 +40,8 @@ class LightGBMArray(BaseMixer):
         self.submodel_stop_after = stop_after / self.horizon
         self.target = target
         self.offset_pred_cols = [f'{self.target}_timestep_{i}' for i in range(1, self.horizon)]
-        if set(input_cols) != set(self.tss.order_by):
-            input_cols.remove(*self.tss.order_by)
+        if set(input_cols) != {self.tss.order_by}:
+            input_cols.remove(self.tss.order_by)
         for col in self.offset_pred_cols:
             dtype_dict[col] = dtype_dict[self.target]
         self.models = [LightGBM(self.submodel_stop_after,

--- a/lightwood/mixer/nhits.py
+++ b/lightwood/mixer/nhits.py
@@ -73,7 +73,7 @@ class NHitsMixer(BaseMixer):
         log.info('Started fitting N-HITS forecasting model')
 
         cat_ds = ConcatedEncodedDs([train_data, dev_data])
-        oby_col = self.ts_analysis["tss"].order_by[0]
+        oby_col = self.ts_analysis["tss"].order_by
         df = cat_ds.data_frame.sort_values(by=f'__mdb_original_{oby_col}')
 
         # 2. adapt data into the expected DFs
@@ -170,7 +170,7 @@ class NHitsMixer(BaseMixer):
         return ydf
 
     def _make_initial_df(self, df):
-        oby_col = self.ts_analysis["tss"].order_by[0]
+        oby_col = self.ts_analysis["tss"].order_by
         Y_df = pd.DataFrame()
         Y_df['y'] = df[self.target]
         Y_df['ds'] = pd.to_datetime(df[f'__mdb_original_{oby_col}'], unit='s')

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -118,7 +118,7 @@ class SkTime(BaseMixer):
         """
         Internal method that fits forecasters to a given dataframe.
         """
-        df = data.data_frame.sort_values(by=f'__mdb_original_{self.ts_analysis["tss"].order_by[0]}')
+        df = data.data_frame.sort_values(by=f'__mdb_original_{self.ts_analysis["tss"].order_by}')
 
         if not self.hyperparam_search and not self.study:
             module_name = self.model_path
@@ -159,7 +159,7 @@ class SkTime(BaseMixer):
 
             self.models[group] = TransformedTargetForecaster(model_pipeline)
 
-            oby_col = self.ts_analysis['tss'].order_by[0]
+            oby_col = self.ts_analysis['tss'].order_by
             if self.grouped_by == ['__default']:
                 series_data = df
                 series_oby = df[oby_col]

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -71,7 +71,7 @@ class TestTimeseries(unittest.TestCase):
                                                                         'allow_incomplete_history': True,
                                                                         'group_by': ['Country'],
                                                                         'horizon': horizon,
-                                                                        'order_by': [order_by],
+                                                                        'order_by': order_by,
                                                                         'period_intervals': (('daily', 7),),
                                                                         'window': window
                                                                     }}))
@@ -139,7 +139,7 @@ class TestTimeseries(unittest.TestCase):
                                                                         'use_previous_target': False,
                                                                         'allow_incomplete_history': False,
                                                                         'horizon': horizon,
-                                                                        'order_by': [order_by],
+                                                                        'order_by': order_by,
                                                                         'window': window}
                                                                     }))
             jai.model['args']['submodels'] = [jai.model['args']['submodels'][0]]
@@ -196,7 +196,7 @@ class TestTimeseries(unittest.TestCase):
                                                                         'time_aim': 80,
                                                                         'anomaly_detection': False,
                                                                         'timeseries_settings': {
-                                                                            'order_by': ['T'],
+                                                                            'order_by': 'T',
                                                                             'use_previous_target': True,
                                                                             'window': 5
                                                                         },
@@ -219,7 +219,7 @@ class TestTimeseries(unittest.TestCase):
                                                                         'time_aim': 80,
                                                                         'anomaly_detection': False,
                                                                         'timeseries_settings': {
-                                                                            'order_by': ['T'],
+                                                                            'order_by': 'T',
                                                                             'use_previous_target': True,
                                                                             'window': 5,
                                                                             'horizon': 2
@@ -247,7 +247,7 @@ class TestTimeseries(unittest.TestCase):
                                                                         'time_aim': 80,
                                                                         'anomaly_detection': False,
                                                                         'timeseries_settings': {
-                                                                            'order_by': ['T'],
+                                                                            'order_by': 'T',
                                                                             'use_previous_target': True,
                                                                             'window': 5,
                                                                             'horizon': 2
@@ -286,7 +286,7 @@ class TestTimeseries(unittest.TestCase):
         pdef = ProblemDefinition.from_dict({'target': target,
                                             'time_aim': 200,
                                             'timeseries_settings': {
-                                                'order_by': ['Time'],
+                                                'order_by': 'Time',
                                                 'window': 5,
                                                 'horizon': horizon,
                                                 'historical_columns': [f'{target}_2x']
@@ -375,7 +375,7 @@ class TestTimeseries(unittest.TestCase):
         pdef = ProblemDefinition.from_dict({'target': target,
                                             'time_aim': 200,
                                             'timeseries_settings': {
-                                                'order_by': ['Time'],
+                                                'order_by': 'Time',
                                                 'window': 5,
                                                 'horizon': horizon,
                                                 'historical_columns': [f'{target}_2x']
@@ -411,7 +411,7 @@ class TestTimeseries(unittest.TestCase):
                                                                 'timeseries_settings': {
                                                                     'group_by': gby,
                                                                     'horizon': horizon,
-                                                                    'order_by': [order_by],
+                                                                    'order_by': order_by,
                                                                     'window': window
                                                                 }}))
         code = code_from_json_ai(jai)

--- a/tests/integration/basic/test_model_selection.py
+++ b/tests/integration/basic/test_model_selection.py
@@ -49,7 +49,7 @@ class TestMixerSelection(unittest.TestCase):
                 'time_aim': 15,
                 'group_by': ['Country'],
                 'horizon': 1,
-                'order_by': ['T'],
+                'order_by': 'T',
                 'window': 5
             }
         }
@@ -65,7 +65,7 @@ class TestMixerSelection(unittest.TestCase):
             'timeseries_settings': {
                 'group_by': ['Country'],
                 'horizon': 3,
-                'order_by': ['T'],
+                'order_by': 'T',
                 'window': 5
             }
         }


### PR DESCRIPTION
# Why

Support for multiple order-by columns is not the most robust feature, and hasn't really seen usage, so this PR drops it to simplify the codebase.

# How

Refactored wherever it was necessary.