### PR TITLE
Hotfix

### DIFF
--- a/lightwood/data/timeseries_analyzer.py
+++ b/lightwood/data/timeseries_analyzer.py
@@ -121,21 +121,22 @@ def get_stls(train_df: pd.DataFrame,
              groups: list,
              tss: TimeseriesSettings
              ) -> Dict[str, object]:
-    stls = {}
+    stls = {'__default': None}
     for group in groups:
-        _, tr_subset = get_group_matches(train_df, group, tss.group_by)
-        _, dev_subset = get_group_matches(dev_df, group, tss.group_by)
-        if tr_subset.shape[0] > 0 and dev_subset.shape[0] > 0 and sps.get(group, False):
-            group_freq = tr_subset['__mdb_inferred_freq'].iloc[0]
-            tr_subset = deepcopy(tr_subset)[target]
-            dev_subset = deepcopy(dev_subset)[target]
-            tr_subset.index = pd.date_range(start=tr_subset.iloc[0], freq=group_freq,
-                                            periods=len(tr_subset)).to_period()
-            dev_subset.index = pd.date_range(start=dev_subset.iloc[0], freq=group_freq,
-                                             periods=len(dev_subset)).to_period()
-            stl = _pick_ST(tr_subset, dev_subset, sps[group])
-            log.info(f'Best STL decomposition params for group {group} are: {stl["best_params"]}')
-            stls[group] = stl
+        if group != '__default':
+            _, tr_subset = get_group_matches(train_df, group, tss.group_by)
+            _, dev_subset = get_group_matches(dev_df, group, tss.group_by)
+            if tr_subset.shape[0] > 0 and dev_subset.shape[0] > 0 and sps.get(group, False):
+                group_freq = tr_subset['__mdb_inferred_freq'].iloc[0]
+                tr_subset = deepcopy(tr_subset)[target]
+                dev_subset = deepcopy(dev_subset)[target]
+                tr_subset.index = pd.date_range(start=tr_subset.iloc[0], freq=group_freq,
+                                                periods=len(tr_subset)).to_period()
+                dev_subset.index = pd.date_range(start=dev_subset.iloc[0], freq=group_freq,
+                                                 periods=len(dev_subset)).to_period()
+                stl = _pick_ST(tr_subset, dev_subset, sps[group])
+                log.info(f'Best STL decomposition params for group {group} are: {stl["best_params"]}')
+                stls[group] = stl
     return stls
 
 

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -51,14 +51,18 @@ def transform_timeseries(
     oby_col = tss.order_by
     groups = get_ts_groups(data, tss)
     if not ts_analysis:
-        _, _, freqs = get_delta(data, dtype_dict, groups, tss)
+        _, periods, freqs = get_delta(data, dtype_dict, groups, tss)
     else:
+        periods = ts_analysis['periods']
         freqs = ts_analysis['sample_freqs']
 
     # pass seconds to timestamps according to each group's inferred freq, and force this freq on index
     subsets = []
     for group in groups:
         if (tss.group_by and group != '__default') or not tss.group_by:
+            if periods[group] == 0:
+                raise Exception(
+                    f"Partition is not valid. Please make sure you group by a set of columns that ensures unique measurements for each grouping through time.")  # noqa
             idxs, subset = get_group_matches(data, group, tss.group_by)
             if subset.shape[0] > 0:
                 index = pd.to_datetime(subset[oby_col], unit='s')

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -62,7 +62,7 @@ def transform_timeseries(
         if (tss.group_by and group != '__default') or not tss.group_by:
             if periods[group] == 0:
                 raise Exception(
-                    f"Partition is not valid. Please make sure you group by a set of columns that ensures unique measurements for each grouping through time.")  # noqa
+                    f"Partition is not valid, faulty group {group}. Please make sure you group by a set of columns that ensures unique measurements for each grouping through time.")  # noqa
             idxs, subset = get_group_matches(data, group, tss.group_by)
             if subset.shape[0] > 0:
                 index = pd.to_datetime(subset[oby_col], unit='s')

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -71,6 +71,10 @@ def get_delta(
                     freq, period = detect_freq_period(deltas[group], tss)
                     periods[group] = period
                     freqs[group] = freq
+                else:
+                    deltas[group] = deltas['__default']
+                    periods[group] = periods['__default']
+                    freqs[group] = freqs['__default']
 
     return deltas, periods, freqs
 

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -72,9 +72,9 @@ def get_delta(
                     periods[group] = period
                     freqs[group] = freq
                 else:
-                    deltas[group] = deltas['__default']
-                    periods[group] = periods['__default']
-                    freqs[group] = freqs['__default']
+                    deltas[group] = 1.0
+                    periods[group] = 1
+                    freqs[group] = 'S'
 
     return deltas, periods, freqs
 

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -205,6 +205,9 @@ def detect_freq_period(deltas: pd.DataFrame, tss) -> tuple:
         'hourly': 60 * 60,
         'minute': 60,
         'second': 1,
+        'millisecond': 0.001,
+        'microsecond': 1e-6,
+        'nanosecond': 1e-9,
         'constant': 0
     }
     freq_to_period = {interval: period for (interval, period) in tss.interval_periods}
@@ -220,7 +223,10 @@ def detect_freq_period(deltas: pd.DataFrame, tss) -> tuple:
 
 def freq_to_pandas(freq, sample_row=None):
     mapping = {
-        'constant': 'S',
+        'constant': 'N',
+        'nanosecond': 'N',
+        'microsecond': 'us',
+        'millisecond': 'ms',
         'second': 'S',
         'minute': 'T',
         'hourly': 'H',  # custom logic

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -273,7 +273,7 @@ class TestTimeseries(unittest.TestCase):
         tsteps = 100
         target = 'Value'
         horizon = 20
-        t = np.linspace(0, 1, tsteps, endpoint=False)
+        t = np.linspace(0, 100, tsteps, endpoint=False)
         ts = [i + f for i, f in enumerate(signal.sawtooth(2 * np.pi * 5 * t, width=0.5))]
         df = pd.DataFrame(columns=['Time', target])
         df['Time'] = t
@@ -362,7 +362,7 @@ class TestTimeseries(unittest.TestCase):
         horizon = 20
         # added random noise for irregular sampling
         np.random.seed(0)
-        t = np.linspace(0, 1, tsteps, endpoint=False) + np.random.uniform(size=(tsteps,), low=-0.005, high=0.005)
+        t = np.linspace(0, 100, tsteps, endpoint=False) + np.random.uniform(size=(tsteps,), low=-0.005, high=0.005)
         ts = [i + f for i, f in enumerate(signal.sawtooth(2 * np.pi * 5 * t, width=0.5))]
         df = pd.DataFrame(columns=['Time', target])
         df['Time'] = t

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -398,12 +398,7 @@ class TestTimeseries(unittest.TestCase):
         order_by = 'saledate'
         window = 8
         horizon = 4
-        train, _, test = stratify(data,
-                                  pct_train=0.8,
-                                  pct_dev=0,
-                                  pct_test=0.2,
-                                  stratify_on=gby,
-                                  seed=1,
+        train, _, test = stratify(data, pct_train=0.8, pct_dev=0, pct_test=0.2, stratify_on=gby, seed=1,
                                   reshuffle=False)
         jai = json_ai_from_problem(train,
                                    ProblemDefinition.from_dict({'target': target,


### PR DESCRIPTION
Changelog:

- Increased default `atol` for successful stratified splits
- No STL for default group
- Check for correct partitions in TS transform procedure
- Check `mase` for only-novel groups in `dev` split. If so, revert back to R2 as default
- Default period, freq and delta for non-default novel group
- Add new levels of possible frequencies
- More robust PACF check