### PR TITLE
[FIX] Pandas copy warnings in TS logic

### DIFF
--- a/lightwood/analysis/explain.py
+++ b/lightwood/analysis/explain.py
@@ -54,7 +54,7 @@ def explain(data: pd.DataFrame,
             for col in timeseries_settings.group_by:
                 row_insights[f'group_{col}'] = data[col]
 
-        row_insights[f'order_{timeseries_settings.order_by}'] = data[timeseries_settings.order_by]
+        row_insights[f'order_{timeseries_settings.order_by}'] = data[timeseries_settings.order_by].copy(deep=True)
         row_insights[f'order_{timeseries_settings.order_by}'] = get_inferred_timestamps(
             row_insights, timeseries_settings.order_by, ts_analysis['deltas'], timeseries_settings)
 


### PR DESCRIPTION
# Why
To follow best Pandas usage practices.

# How
Slight reformatting to avoid `SettingWithCopyWarning`s within TS-specific methods.