### PR TITLE
[ENH] New defaults for sktime mixer, new AutoETS and AutoARIMA mixers

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -303,6 +303,20 @@ def generate_json_ai(
                                 "stop_after": "$problem_definition.seconds_per_mixer",
                                 "horizon": "$problem_definition.timeseries_settings.horizon",
                             },
+                        },
+                        {
+                            "module": "ETSMixer",
+                            "args": {
+                                "stop_after": "$problem_definition.seconds_per_mixer",
+                                "horizon": "$problem_definition.timeseries_settings.horizon",
+                            },
+                        },
+                        {
+                            "module": "ARIMAMixer",
+                            "args": {
+                                "stop_after": "$problem_definition.seconds_per_mixer",
+                                "horizon": "$problem_definition.timeseries_settings.horizon",
+                            },
                         }
                     ]
                 )
@@ -585,7 +599,7 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
             )
             problem_definition.fit_on_all = False  # takes too long otherwise
 
-        elif mixers[i]["module"] in ("SkTime", "ProphetMixer"):
+        elif mixers[i]["module"] in ("SkTime", "ProphetMixer", "ETSMixer", "ARIMAMixer"):
             mixers[i]["args"]["target"] = mixers[i]["args"].get("target", "$target")
             mixers[i]["args"]["dtype_dict"] = mixers[i]["args"].get(
                 "dtype_dict", "$dtype_dict"

--- a/lightwood/data/timeseries_analyzer.py
+++ b/lightwood/data/timeseries_analyzer.py
@@ -79,7 +79,7 @@ def get_naive_residuals(target_data: pd.DataFrame, m: int = 1) -> Tuple[List, fl
     :return: (list of naive residuals, average residual value)
     """  # noqa
     # @TODO: support categorical series as well
-    residuals = np.abs(target_data.values[1:] - target_data.values[0])
+    residuals = np.abs(target_data.values[1:] - target_data.values[0]).flatten()
     scale_factor = np.average(residuals)
     return residuals.tolist(), scale_factor
 

--- a/lightwood/data/timeseries_analyzer.py
+++ b/lightwood/data/timeseries_analyzer.py
@@ -10,7 +10,7 @@ from sktime.transformations.series.detrend import ConditionalDeseasonalizer
 
 from lightwood.api.types import TimeseriesSettings
 from lightwood.api.dtype import dtype
-from lightwood.helpers.ts import get_ts_groups, get_delta, get_group_matches, Differencer, max_pacf
+from lightwood.helpers.ts import get_ts_groups, get_delta, get_group_matches, Differencer
 from lightwood.helpers.log import log
 from lightwood.encoder.time_series.helpers.common import generate_target_group_normalizers
 
@@ -36,12 +36,11 @@ def timeseries_analyzer(data: Dict[str, pd.DataFrame], dtype_dict: Dict[str, str
     """  # noqa
     tss = timeseries_settings
     groups = get_ts_groups(data['train'], tss)
-    deltas, periods, freqs = get_delta(data['train'], dtype_dict, groups, tss)
+    deltas, periods, freqs = get_delta(data['train'], dtype_dict, groups, target, tss)
 
     normalizers = generate_target_group_normalizers(data['train'], target, dtype_dict, groups, tss)
 
     if dtype_dict[target] in (dtype.integer, dtype.float, dtype.num_tsarray):
-        periods = max_pacf(data['train'], groups, target, tss)  # override with PACF output
         naive_forecast_residuals, scale_factor = get_grouped_naive_residuals(data['dev'],
                                                                              target,
                                                                              tss,

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -60,11 +60,12 @@ def transform_timeseries(
     subsets = []
     for group in groups:
         if (tss.group_by and group != '__default') or not tss.group_by:
-            if periods[group] == 0:
-                raise Exception(
-                    f"Partition is not valid, faulty group {group}. Please make sure you group by a set of columns that ensures unique measurements for each grouping through time.")  # noqa
             idxs, subset = get_group_matches(data, group, tss.group_by)
             if subset.shape[0] > 0:
+                if periods[group] == 0 and subset.shape[0] > 1:
+                    raise Exception(
+                        f"Partition is not valid, faulty group {group}. Please make sure you group by a set of columns that ensures unique measurements for each grouping through time.")  # noqa
+
                 index = pd.to_datetime(subset[oby_col], unit='s')
                 subset.index = pd.date_range(start=index.iloc[0], freq=freqs[group], periods=len(subset))
                 subset['__mdb_inferred_freq'] = subset.index.freq   # sets constant column because pd.concat forgets freq (see: https://github.com/pandas-dev/pandas/issues/3232)  # noqa

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -51,7 +51,7 @@ def transform_timeseries(
     oby_col = tss.order_by
     groups = get_ts_groups(data, tss)
     if not ts_analysis:
-        _, periods, freqs = get_delta(data, dtype_dict, groups, tss)
+        _, periods, freqs = get_delta(data, dtype_dict, groups, target, tss)
     else:
         periods = ts_analysis['periods']
         freqs = ts_analysis['sample_freqs']

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -75,7 +75,7 @@ def get_delta(
                     if period:
                         periods[group] = [period]
                     else:
-                        periods[group] = [max_pacf(df, group_combinations, target, tss)[0]]
+                        periods[group] = [max_pacf(df, group_combinations, target, tss)[group][0]]
                 else:
                     deltas[group] = 1.0
                     periods[group] = [1]

--- a/lightwood/mixer/__init__.py
+++ b/lightwood/mixer/__init__.py
@@ -5,6 +5,8 @@ from lightwood.mixer.neural_ts import NeuralTs
 from lightwood.mixer.lightgbm import LightGBM
 from lightwood.mixer.lightgbm_array import LightGBMArray
 from lightwood.mixer.sktime import SkTime
+from lightwood.mixer.arima import ARIMAMixer
+from lightwood.mixer.ets import ETSMixer
 from lightwood.mixer.nhits import NHitsMixer
 from lightwood.mixer.prophet import ProphetMixer
 from lightwood.mixer.regression import Regression
@@ -15,4 +17,4 @@ except Exception:
     QClassic = None
 
 __all__ = ['BaseMixer', 'Neural', 'NeuralTs', 'LightGBM', 'LightGBMArray', 'Unit', 'Regression',
-           'SkTime', 'QClassic', 'ProphetMixer', 'NHitsMixer']
+           'SkTime', 'QClassic', 'ProphetMixer', 'ETSMixer', 'ARIMAMixer', 'NHitsMixer']

--- a/lightwood/mixer/arima.py
+++ b/lightwood/mixer/arima.py
@@ -13,7 +13,7 @@ class ARIMAMixer(SkTime):
                  model_path: str = 'statsforecast.StatsForecastAutoARIMA',
                  auto_size: bool = True,
                  hyperparam_search: bool = False,
-                 use_stl: bool = True
+                 use_stl: bool = False
                  ):
         hyperparam_search = False
         super().__init__(stop_after, target, dtype_dict, horizon, ts_analysis,

--- a/lightwood/mixer/arima.py
+++ b/lightwood/mixer/arima.py
@@ -13,7 +13,7 @@ class ARIMAMixer(SkTime):
                  model_path: str = 'statsforecast.StatsForecastAutoARIMA',
                  auto_size: bool = True,
                  hyperparam_search: bool = False,
-                 use_stl: bool = False
+                 use_stl: bool = True
                  ):
         hyperparam_search = False
         super().__init__(stop_after, target, dtype_dict, horizon, ts_analysis,

--- a/lightwood/mixer/arima.py
+++ b/lightwood/mixer/arima.py
@@ -3,14 +3,14 @@ from typing import Dict
 from lightwood.mixer.sktime import SkTime
 
 
-class ETSMixer(SkTime):
+class ARIMAMixer(SkTime):
     def __init__(self,
                  stop_after: float,
                  target: str,
                  dtype_dict: Dict[str, str],
                  horizon: int,
                  ts_analysis: Dict,
-                 model_path: str = 'ets.AutoETS',
+                 model_path: str = 'statsforecast.StatsForecastAutoARIMA',
                  auto_size: bool = True,
                  hyperparam_search: bool = False,
                  use_stl: bool = False
@@ -18,7 +18,7 @@ class ETSMixer(SkTime):
         hyperparam_search = False
         super().__init__(stop_after, target, dtype_dict, horizon, ts_analysis,
                          model_path, auto_size, hyperparam_search, use_stl)
-        self.name = 'AutoETS'
+        self.name = 'AutoARIMA'
         self.stable = False
         self.model_path = model_path
         self.possible_models = [self.model_path]

--- a/lightwood/mixer/ets.py
+++ b/lightwood/mixer/ets.py
@@ -1,0 +1,24 @@
+from typing import Dict
+
+from lightwood.mixer.sktime import SkTime
+
+
+class ETSMixer(SkTime):
+    def __init__(self,
+                 stop_after: float,
+                 target: str,
+                 dtype_dict: Dict[str, str],
+                 horizon: int,
+                 ts_analysis: Dict,
+                 model_path: str = 'ets.AutoETS',
+                 auto_size: bool = True,
+                 hyperparam_search: bool = False,
+                 use_stl: bool = False
+                 ):
+        hyperparam_search = False
+        super().__init__(stop_after, target, dtype_dict, horizon, ts_analysis,
+                         model_path, auto_size, hyperparam_search, use_stl)
+        self.stable = False
+        self.model_path = model_path
+        self.possible_models = [self.model_path]
+        self.n_trials = len(self.possible_models)

--- a/lightwood/mixer/ets.py
+++ b/lightwood/mixer/ets.py
@@ -13,7 +13,7 @@ class ETSMixer(SkTime):
                  model_path: str = 'ets.AutoETS',
                  auto_size: bool = True,
                  hyperparam_search: bool = False,
-                 use_stl: bool = False
+                 use_stl: bool = True
                  ):
         hyperparam_search = False
         super().__init__(stop_after, target, dtype_dict, horizon, ts_analysis,

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -149,9 +149,9 @@ class SkTime(BaseMixer):
             print()
             kwargs = {}
             options = {
-                'sp': self.ts_analysis['periods'].get(group, '__default'),  # seasonality period
-                'suppress_warnings': True,                                     # ignore warnings if possible
-                'error_action': 'raise',                                       # avoids fit() failing silently
+                'sp': self.ts_analysis['periods'].get(group, '__default')[0],   # seasonality period
+                'suppress_warnings': True,                                      # ignore warnings if possible
+                'error_action': 'raise',                                        # avoids fit() failing silently
             }
             if self.model_path == 'fbprophet.Prophet':
                 options['freq'] = self.freq

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -146,11 +146,12 @@ class SkTime(BaseMixer):
             model_class = AutoARIMA  # use AutoARIMA when the provided class does not exist
 
         for group in self.ts_analysis['group_combinations']:
+            print()
             kwargs = {}
             options = {
                 'sp': self.ts_analysis['periods'].get(group, '__default'),  # seasonality period
-                'suppress_warnings': True,                                  # ignore warnings if possible
-                'error_action': 'raise',                                    # avoids fit() failing silently
+                'suppress_warnings': True,                                     # ignore warnings if possible
+                'error_action': 'raise',                                       # avoids fit() failing silently
             }
             if self.model_path == 'fbprophet.Prophet':
                 options['freq'] = self.freq
@@ -160,7 +161,7 @@ class SkTime(BaseMixer):
 
             model_pipeline = [("forecaster", model_class(**kwargs))]
 
-            if self.use_stl:
+            if self.use_stl and self.ts_analysis['stl_transforms'].get(group, False):
                 model_pipeline.insert(0, ("detrender",
                                           self.ts_analysis['stl_transforms'][group]["transformer"].detrender))
                 model_pipeline.insert(0, ("deseasonalizer",
@@ -189,7 +190,7 @@ class SkTime(BaseMixer):
 
                 # if data is huge, filter out old records for quicker fitting
                 if self.auto_size:
-                    cutoff = min(len(series), max(500, max(options['sp']) * self.cutoff_factor))
+                    cutoff = min(len(series), max(500, options['sp'] * self.cutoff_factor))
                     series = series.iloc[-cutoff:]
                 try:
                     self.models[group].fit(series, fh=self.fh)

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -35,9 +35,9 @@ class SkTime(BaseMixer):
             dtype_dict: Dict[str, str],
             horizon: int,
             ts_analysis: Dict,
-            model_path: str = 'statsforecast.StatsForecastAutoARIMA',
+            model_path: str = None,
             auto_size: bool = True,
-            hyperparam_search: bool = False,
+            hyperparam_search: bool = True,
             use_stl: bool = False
     ):
         """
@@ -71,6 +71,15 @@ class SkTime(BaseMixer):
         self.prepared = False
         self.supports_proba = False
         self.target = target
+        self.name = 'AutoSKTime'
+
+        default_possible_models = [
+            'croston.Croston',
+            'theta.ThetaForecaster',
+            'trend.STLForecaster',
+            'trend.PolynomialTrendForecaster',
+            'naive.NaiveForecaster'
+        ]
 
         self.dtype_dict = dtype_dict
         self.ts_analysis = ts_analysis
@@ -84,10 +93,10 @@ class SkTime(BaseMixer):
         self.models = {}
         self.study = None
         self.hyperparam_dict = {}
-        self.model_path = model_path
+        self.model_path = model_path if model_path else 'trend.STLForecaster'
         self.hyperparam_search = hyperparam_search
         self.trial_error_fn = MeanAbsolutePercentageError(symmetric=True)
-        self.possible_models = ['ets.AutoETS', 'theta.ThetaForecaster', 'statsforecast.StatsForecastAutoARIMA']
+        self.possible_models = default_possible_models if not model_path else [model_path]
         self.n_trials = len(self.possible_models)
         self.freq = self._get_freq(self.ts_analysis['deltas']['__default'])
 
@@ -101,7 +110,7 @@ class SkTime(BaseMixer):
 
         Forecaster type can be specified by providing the `model_class` argument in `__init__()`. It can also be determined by hyperparameter optimization based on dev data validation error.
         """  # noqa
-        log.info('Started fitting sktime forecaster for array prediction')
+        log.info(f'Started fitting {self.name} forecaster for array prediction')
 
         if self.hyperparam_search:
             search_space = {'class': self.possible_models}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ dataclasses_json >=0.5.4
 autopep8 >=1.5.7
 dill ==0.3.4
 sktime >=0.11.0,<0.12.0
-statsforecast ==0.5.6
+statsforecast ==0.7.0
 torch_optimizer ==0.1.0
 black >=21.9b0
 typing_extensions

--- a/tests/integration/basic/test_model_selection.py
+++ b/tests/integration/basic/test_model_selection.py
@@ -69,6 +69,6 @@ class TestMixerSelection(unittest.TestCase):
                 'window': 5
             }
         }
-        expected_mixers = ['NeuralTs', 'LightGBMArray', 'SkTime']
+        expected_mixers = ['NeuralTs', 'LightGBMArray', 'SkTime', 'ARIMAMixer', 'ETSMixer']
         mixers = self.get_mixers(df, target, prob_kwargs=prob_kwargs)
         self.assertEqual(set(mixers), set(expected_mixers))

--- a/tests/unit_tests/data/test_transform_ts.py
+++ b/tests/unit_tests/data/test_transform_ts.py
@@ -36,8 +36,8 @@ class TestTransformTS(unittest.TestCase):
 
         target = [i for i in range(data_len)]
         all_residuals, mean = get_naive_residuals(pd.DataFrame(target))
-        self.assertEqual(all_residuals, [1.0 for _ in range(data_len - 1)])
-        self.assertEqual(mean, 1)
+        self.assertEqual(all_residuals, [i for i in range(1, data_len)])
+        self.assertEqual(mean, np.mean([i for i in range(1, data_len)]))
 
         target = [0 for _ in range(data_len)]
         all_residuals, mean = get_naive_residuals(pd.DataFrame(target))
@@ -46,8 +46,8 @@ class TestTransformTS(unittest.TestCase):
 
         target = [1, 4, 2, 5, 3]
         all_residuals, mean = get_naive_residuals(pd.DataFrame(target))
-        self.assertEqual(all_residuals, [3.0, 2.0, 3.0, 2.0])
-        self.assertEqual(mean, 2.5)
+        self.assertEqual(all_residuals, [3.0, 1.0, 4.0, 2.0])
+        self.assertEqual(mean, np.mean([3.0, 1.0, 4.0, 2.0]))
 
     def test_evaluate_array_r2_accuracy(self):
         true = np.array([[10, 20, 30, 40, 50], [60, 70, 80, 90, 100]])

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -15,4 +15,4 @@ def train_and_check_time_aim(predictor: PredictorInterface, train_df: pd.DataFra
     if time_aim_expected is not None:
         if((time_aim_expected * 2.5) < time_aim_actual):
             error = f'time_aim is set to {time_aim_expected} seconds, however learning took {time_aim_actual}'
-            raise ValueError(error)
+            # raise ValueError(error)

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -15,4 +15,4 @@ def train_and_check_time_aim(predictor: PredictorInterface, train_df: pd.DataFra
     if time_aim_expected is not None:
         if((time_aim_expected * 2.5) < time_aim_actual):
             error = f'time_aim is set to {time_aim_expected} seconds, however learning took {time_aim_actual}'
-            # raise ValueError(error)
+            raise ValueError(error)


### PR DESCRIPTION
# Why
To offer a broader set of forecasting mixers, and to leverage the `BestOf` model selection phase as default behavior.

# How
- Subclass `sktime` mixer for new classes that specifically use `AutoETS` and `AutoARIMA`, respectively. Both are added to the default set of mixers in forecasting tasks.
- `sktime` now by default tries `Croston`, `STL`, `Theta`, `Polynomial` and `Naive` internally. Any of these may be made a new mixer in the future by following in the steps taken in the aforementioned new mixers.
- Changed naive residuals to account for "true" T+N tasks (currently does T+1, and so has an unfair advantage compared to the actual mixers). This should provide a better indication of the mixer performance with unseen data.
- Added check for malformed partitions that, given some set of group-by columns, presents repeated measurements in any given sub-series. Current behavior against this is to raise an error, but this should be automated so that the situation is handled internally.
- Revert `max_pacf` usage to trigger only if default `sp` is larger than provided window.
- Some new default `sp` values in `detect_freq_period`