### PR TITLE
[ENH] Enforce bounded_ts_accuracy as default

### DIFF
--- a/lightwood/analysis/helpers/acc_stats.py
+++ b/lightwood/analysis/helpers/acc_stats.py
@@ -21,8 +21,8 @@ class AccStats(BaseAnalysisBlock):
         ns = SimpleNamespace(**kwargs)
 
         if ns.accuracy_functions == ['evaluate_array_accuracy'] and ns.ts_analysis.get('ts_naive_mae', {}):
-            accuracy_functions = ['bounded_evaluate_num_array_accuracy']
-            log.info("AccStats will bound the array accuracy for reporting purposes. Check `bounded_evaluate_num_array_accuracy` for a description of the bounding procedure.")  # noqa
+            accuracy_functions = ['bounded_ts_accuracy']
+            log.info("AccStats will bound the array accuracy for reporting purposes. Check `bounded_ts_accuracy` for a description of the bounding procedure.")  # noqa
         else:
             accuracy_functions = ns.accuracy_functions
 

--- a/lightwood/analysis/helpers/acc_stats.py
+++ b/lightwood/analysis/helpers/acc_stats.py
@@ -21,8 +21,8 @@ class AccStats(BaseAnalysisBlock):
         ns = SimpleNamespace(**kwargs)
 
         if ns.accuracy_functions == ['evaluate_array_accuracy'] and ns.ts_analysis.get('ts_naive_mae', {}):
-            accuracy_functions = ['bounded_evaluate_array_accuracy']
-            log.info("AccStats will bound the array accuracy for reporting purposes. Check `bounded_evaluate_array_accuracy` for a description of the bounding procedure.")  # noqa
+            accuracy_functions = ['bounded_evaluate_num_array_accuracy']
+            log.info("AccStats will bound the array accuracy for reporting purposes. Check `bounded_evaluate_num_array_accuracy` for a description of the bounding procedure.")  # noqa
         else:
             accuracy_functions = ns.accuracy_functions
 

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -375,7 +375,7 @@ def generate_json_ai(
     elif output_dtype in [dtype.categorical, dtype.tags, dtype.binary]:
         accuracy_functions = ["balanced_accuracy_score"]
     elif output_dtype in (dtype.num_array, dtype.num_tsarray):
-        accuracy_functions = ["bounded_evaluate_num_array_accuracy"]
+        accuracy_functions = ["bounded_ts_accuracy"]
     elif output_dtype in (dtype.cat_array, dtype.cat_tsarray):
         accuracy_functions = ["evaluate_cat_array_accuracy"]
     else:
@@ -385,7 +385,7 @@ def generate_json_ai(
 
     if is_ts:
         if output_dtype in [dtype.integer, dtype.float]:
-            accuracy_functions = ["bounded_evaluate_num_array_accuracy"]  # forces this acc fn for t+1 time series forecasters  # noqa
+            accuracy_functions = ["bounded_ts_accuracy"]  # forces this acc fn for t+1 time series forecasters  # noqa
 
         if output_dtype in (dtype.integer, dtype.float, dtype.num_tsarray):
             imputers.append({"module": "NumericalImputer",

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -375,7 +375,7 @@ def generate_json_ai(
     elif output_dtype in [dtype.categorical, dtype.tags, dtype.binary]:
         accuracy_functions = ["balanced_accuracy_score"]
     elif output_dtype in (dtype.num_array, dtype.num_tsarray):
-        accuracy_functions = ["evaluate_num_array_accuracy"]
+        accuracy_functions = ["bounded_evaluate_num_array_accuracy"]
     elif output_dtype in (dtype.cat_array, dtype.cat_tsarray):
         accuracy_functions = ["evaluate_cat_array_accuracy"]
     else:
@@ -385,7 +385,7 @@ def generate_json_ai(
 
     if is_ts:
         if output_dtype in [dtype.integer, dtype.float]:
-            accuracy_functions = ["evaluate_num_array_accuracy"]  # forces this acc fn for t+1 time series forecasters
+            accuracy_functions = ["bounded_evaluate_num_array_accuracy"]  # forces this acc fn for t+1 time series forecasters  # noqa
 
         if output_dtype in (dtype.integer, dtype.float, dtype.num_tsarray):
             imputers.append({"module": "NumericalImputer",

--- a/lightwood/helpers/__init__.py
+++ b/lightwood/helpers/__init__.py
@@ -2,7 +2,7 @@ from lightwood.helpers.accuracy import to_binary, f1_score, recall_score, precis
 from lightwood.helpers.device import is_cuda_compatible, get_devices
 from lightwood.helpers.general import mase, is_none, evaluate_accuracy, evaluate_num_array_accuracy,\
     evaluate_array_accuracy, evaluate_multilabel_accuracy, evaluate_regression_accuracy, evaluate_cat_array_accuracy, \
-    bounded_evaluate_num_array_accuracy
+    bounded_ts_accuracy
 from lightwood.helpers.ts import get_group_matches, get_ts_groups, get_inferred_timestamps, add_tn_num_conf_bounds, \
     add_tn_cat_conf_bounds
 from lightwood.helpers.io import read_from_path_or_url
@@ -17,7 +17,7 @@ from lightwood.helpers.torch import average_vectors, concat_vectors_and_pad, Lig
 
 __all__ = ['to_binary', 'f1_score', 'recall_score', 'precision_score', 'r2_score', 'is_cuda_compatible', 'get_devices',
            'get_group_matches', 'get_ts_groups', 'mase', 'is_none', 'evaluate_accuracy', 'evaluate_num_array_accuracy',
-           'evaluate_array_accuracy', 'evaluate_cat_array_accuracy', 'bounded_evaluate_num_array_accuracy',
+           'evaluate_array_accuracy', 'evaluate_cat_array_accuracy', 'bounded_ts_accuracy',
            'evaluate_multilabel_accuracy', 'evaluate_regression_accuracy', 'read_from_path_or_url', 'get_nr_procs',
            'mut_method_call', 'run_mut_method', 'tokenize_text', 'analyze_sentences', 'decontracted', 'contains_alnum',
            'get_identifier_description', 'get_identifier_description_mp', 'get_pct_auto_increment',

--- a/lightwood/helpers/__init__.py
+++ b/lightwood/helpers/__init__.py
@@ -2,7 +2,7 @@ from lightwood.helpers.accuracy import to_binary, f1_score, recall_score, precis
 from lightwood.helpers.device import is_cuda_compatible, get_devices
 from lightwood.helpers.general import mase, is_none, evaluate_accuracy, evaluate_num_array_accuracy,\
     evaluate_array_accuracy, evaluate_multilabel_accuracy, evaluate_regression_accuracy, evaluate_cat_array_accuracy, \
-    bounded_evaluate_array_accuracy
+    bounded_evaluate_num_array_accuracy
 from lightwood.helpers.ts import get_group_matches, get_ts_groups, get_inferred_timestamps, add_tn_num_conf_bounds, \
     add_tn_cat_conf_bounds
 from lightwood.helpers.io import read_from_path_or_url
@@ -17,7 +17,7 @@ from lightwood.helpers.torch import average_vectors, concat_vectors_and_pad, Lig
 
 __all__ = ['to_binary', 'f1_score', 'recall_score', 'precision_score', 'r2_score', 'is_cuda_compatible', 'get_devices',
            'get_group_matches', 'get_ts_groups', 'mase', 'is_none', 'evaluate_accuracy', 'evaluate_num_array_accuracy',
-           'evaluate_array_accuracy', 'evaluate_cat_array_accuracy', 'bounded_evaluate_array_accuracy',
+           'evaluate_array_accuracy', 'evaluate_cat_array_accuracy', 'bounded_evaluate_num_array_accuracy',
            'evaluate_multilabel_accuracy', 'evaluate_regression_accuracy', 'read_from_path_or_url', 'get_nr_procs',
            'mut_method_call', 'run_mut_method', 'tokenize_text', 'analyze_sentences', 'decontracted', 'contains_alnum',
            'get_identifier_description', 'get_identifier_description_mp', 'get_pct_auto_increment',

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -1,4 +1,5 @@
 import importlib
+from copy import deepcopy
 from typing import List, Dict, Optional
 import numpy as np
 import pandas as pd
@@ -47,7 +48,7 @@ def evaluate_accuracy(data: pd.DataFrame,
             elif accuracy_function_str == 'evaluate_cat_array_accuracy':
                 acc_fn = evaluate_cat_array_accuracy
             else:
-                acc_fn = bounded_evaluate_array_accuracy
+                acc_fn = bounded_evaluate_num_array_accuracy
             score_dict[accuracy_function_str] = acc_fn(true_values,
                                                        predictions,
                                                        data=data[cols],
@@ -204,7 +205,7 @@ def evaluate_cat_array_accuracy(
                                    base_acc_fn=balanced_accuracy_score)
 
 
-def bounded_evaluate_array_accuracy(
+def bounded_evaluate_num_array_accuracy(
         true_values: pd.Series,
         predictions: pd.Series,
         **kwargs
@@ -216,9 +217,11 @@ def bounded_evaluate_array_accuracy(
     For worse-than-naive, it scales linearly (with a factor).
     For better-than-naive, we fix 10 as 0.99, and scaled-logarithms (with 10 and 1e4 cutoffs as respective bases) are used to squash all remaining preimages to values between 0.5 and 1.0.
     """  # noqa
-    result = evaluate_array_accuracy(np.array(true_values),
-                                     np.array(predictions),
-                                     **kwargs)
+    true_values = deepcopy(true_values)
+    predictions = deepcopy(predictions)
+    result = evaluate_num_array_accuracy(true_values,
+                                         predictions,
+                                         **kwargs)
     if 10 < result <= 1e4:
         step_base = 0.99
         return step_base + (np.log(result) / np.log(1e4)) * (1 - step_base)

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -48,7 +48,7 @@ def evaluate_accuracy(data: pd.DataFrame,
             elif accuracy_function_str == 'evaluate_cat_array_accuracy':
                 acc_fn = evaluate_cat_array_accuracy
             else:
-                acc_fn = bounded_evaluate_num_array_accuracy
+                acc_fn = bounded_ts_accuracy
             score_dict[accuracy_function_str] = acc_fn(true_values,
                                                        predictions,
                                                        data=data[cols],
@@ -205,7 +205,7 @@ def evaluate_cat_array_accuracy(
                                    base_acc_fn=balanced_accuracy_score)
 
 
-def bounded_evaluate_num_array_accuracy(
+def bounded_ts_accuracy(
         true_values: pd.Series,
         predictions: pd.Series,
         **kwargs
@@ -222,12 +222,13 @@ def bounded_evaluate_num_array_accuracy(
     result = evaluate_num_array_accuracy(true_values,
                                          predictions,
                                          **kwargs)
-    if 10 < result <= 1e4:
+    sp = 5
+    if sp < result <= 1e4:
         step_base = 0.99
         return step_base + (np.log(result) / np.log(1e4)) * (1 - step_base)
-    elif 1 <= result <= 10:
+    elif 1 <= result <= sp:
         step_base = 0.5
-        return step_base + (np.log(result) / np.log(10)) * (0.99 - step_base)
+        return step_base + (np.log(result) / np.log(sp)) * (0.99 - step_base)
     else:
         return result / 2  # worse than naive
 

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -29,7 +29,7 @@ def evaluate_accuracy(data: pd.DataFrame,
     score_dict = {}
 
     for accuracy_function_str in accuracy_functions:
-        if 'array_accuracy' in accuracy_function_str:
+        if 'array_accuracy' in accuracy_function_str or accuracy_function_str in ('bounded_ts_accuracy', ):
             if ts_analysis is None or not ts_analysis['tss'].is_timeseries:
                 # normal array, needs to be expanded
                 cols = [target]


### PR DESCRIPTION
# Why

To improve interpretability of reported accuracy for forecasting predictors.

# How

Change default accuracy function in forecasting use cases to `bounded_ts_accuracy`.