### PR TITLE
Improved JsonAI templating for analysis blocks

### DIFF
--- a/lightwood/analysis/helpers/feature_importance.py
+++ b/lightwood/analysis/helpers/feature_importance.py
@@ -2,12 +2,10 @@ from copy import deepcopy
 from types import SimpleNamespace
 from typing import Dict
 
-import torch
 import numpy as np
 
 from lightwood.analysis.base import BaseAnalysisBlock
 from lightwood.helpers.general import evaluate_accuracy
-from lightwood.analysis.nc.util import t_softmax
 from lightwood.api.types import PredictionArguments
 
 
@@ -62,7 +60,7 @@ class GlobalFeatureImportance(BaseAnalysisBlock):
             column_importances = {}
             acc_increases = np.zeros((len(ignorable_input_cols),))
             for i, col in enumerate(ignorable_input_cols):
-                accuracy_increase = (info['normal_accuracy'] - empty_input_accuracy[col]) # / info['normal_accuracy']
+                accuracy_increase = (info['normal_accuracy'] - empty_input_accuracy[col]) / info['normal_accuracy']
                 acc_increases[i] = max(0, accuracy_increase)
             acc_increases = (acc_increases / max(acc_increases))
             for col, inc in zip(ignorable_input_cols, acc_increases):

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -28,9 +28,10 @@ class ICP(BaseAnalysisBlock):
     def __init__(self,
                  fixed_significance: float,
                  positive_domain: bool,
-                 confidence_normalizer: bool
+                 confidence_normalizer: bool,
+                 deps: tuple = tuple()
                  ):
-        super().__init__()
+        super().__init__(deps=deps)
         self.fixed_significance = fixed_significance
         self.positive_domain = positive_domain
         self.confidence_normalizer = confidence_normalizer

--- a/lightwood/analysis/nc/calibrate.py
+++ b/lightwood/analysis/nc/calibrate.py
@@ -1,6 +1,6 @@
 import inspect
 from copy import deepcopy
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 from types import SimpleNamespace
 
 import numpy as np
@@ -26,10 +26,10 @@ class ICP(BaseAnalysisBlock):
     """ Confidence estimation block, uses inductive conformal predictors (ICPs) for model agnosticity """
 
     def __init__(self,
-                 fixed_significance: float,
-                 positive_domain: bool,
-                 confidence_normalizer: bool,
-                 deps: tuple = tuple()
+                 positive_domain: Optional[bool] = False,
+                 confidence_normalizer: Optional[bool] = False,
+                 fixed_significance: Optional[float] = None,
+                 deps: Optional[tuple] = tuple()
                  ):
         super().__init__(deps=deps)
         self.fixed_significance = fixed_significance

--- a/lightwood/analysis/nn_conf/temp_scale.py
+++ b/lightwood/analysis/nn_conf/temp_scale.py
@@ -16,8 +16,8 @@ class TempScaler(BaseAnalysisBlock):
     Original reference (MIT Licensed): https://github.com/gpleiss/temperature_scaling
     NB: Output of the neural network should be the classification logits, NOT the softmax (or log softmax)! TODO
     """
-    def __init__(self):
-        super().__init__()
+    def __init__(self, deps=tuple()):
+        super().__init__(deps=deps)
         self.temperature = nn.Parameter(torch.ones(1))
         self.ordenc = OrdinalEncoder()
         self._softmax = torch.nn.Softmax(dim=1)

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1,6 +1,7 @@
 # TODO: _add_implicit_values unit test ensures NO changes for a fully specified file.
 from copy import deepcopy
 from lightwood.helpers.templating import call, inline_dict, align
+from lightwood.helpers.templating import _consolidate_analysis_blocks
 from lightwood.api import dtype
 from lightwood.api.types import (
     JsonAI,
@@ -728,6 +729,15 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
 
     for field_name, implicit_value in hidden_fields.items():
         _populate_implicit_field(json_ai, field_name, implicit_value, tss.is_timeseries)
+
+    # further consolidation
+    to_inspect = ['analysis_blocks']
+    consolidation_methods = {
+        'analysis_blocks': _consolidate_analysis_blocks
+    }
+    for k in to_inspect:
+        method = consolidation_methods[k]
+        setattr(json_ai, k, method(json_ai, k))
 
     return json_ai
 

--- a/lightwood/helpers/templating.py
+++ b/lightwood/helpers/templating.py
@@ -132,7 +132,7 @@ def _consolidate_analysis_blocks(jsonai, key):
     blocks = getattr(jsonai, key)
     for i, block in enumerate(blocks):
         if 'args' not in block:
-            blocks[i]['args'] = defaults[block['module']]
+            blocks[i]['args'] = defaults.get(block['module'], {"deps": []})
         elif 'deps' not in block['args']:
             blocks[i]['args']['deps'] = []
 
@@ -146,8 +146,9 @@ def _consolidate_analysis_blocks(jsonai, key):
         for dep in b['args']['deps']:
             adj_M[block_ids[dep]][block_ids[k]] = 1
 
+    # get initial nodes without dependencies
+    frontier = deque(np.where(adj_M.sum(axis=0) == 0)[0].tolist())
     sorted_dag = []
-    frontier = deque(np.where(adj_M.sum(axis=0) == 0)[0].tolist())  # get initial nodes without dependencies
 
     while frontier:
         elt = frontier.pop()

--- a/lightwood/helpers/templating.py
+++ b/lightwood/helpers/templating.py
@@ -107,3 +107,26 @@ def align(code: str, indent: int) -> str:
     code_arr = code.split('\n')
     code = f'\n{add_space}'.join(code_arr)
     return code
+
+
+def _consolidate_analysis_blocks(jsonai, key):
+    """
+    Receives a list of analysis blocks (where applicable, already filed with `hidden` args) and modifies it so that:
+        1. All dependencies are correct
+        2. Execution order is such that all dependencies are met.
+    """
+    defaults = {
+        'ICP': {"deps": []},
+        'AccStats': {"deps": ['ICP']},
+        'ConfStats': {"deps": ['ICP']},
+        'GlobalFeatureImportance': {"disable_column_importance": False, "deps": ['AccStats']}
+    }
+    blocks = getattr(jsonai, key)
+    for i, block in enumerate(blocks):
+        if 'args' not in block:
+            blocks[i]['args'] = defaults[block['module']]
+
+    # dependency solver
+    # TODO: sort DAG based on dependencies
+
+    return blocks

--- a/lightwood/helpers/templating.py
+++ b/lightwood/helpers/templating.py
@@ -122,19 +122,34 @@ def _consolidate_analysis_blocks(jsonai, key):
         2. Execution order is such that all dependencies are met.
             - For this we use a topological sort over the DAG.
     """
-    # 1. all dependencies are correct
-    defaults = {
-        'ICP': {"deps": []},
-        'AccStats': {"deps": ['ICP']},
-        'ConfStats': {"deps": ['ICP']},
-        'GlobalFeatureImportance': {"deps": ['AccStats']}
+    analysis_defaults = {  # non-optional plus dependencies
+        'ICP': {
+            "deps": [],
+        },
+        'AccStats': {
+            "deps": ['ICP']
+        },
+        'ConfStats': {
+            "deps": ['ICP']
+        },
+        'GlobalFeatureImportance': {
+            "deps": ['AccStats']
+        },
+        'ShapleyValues': {
+            "deps": []
+        },
+        'TempScaler': {
+            "deps": []
+        }
     }
+
+    # 1. all dependencies are correct
     blocks = getattr(jsonai, key)
     block_objs = {b['module']: b for b in blocks}
 
     for i, block in enumerate(blocks):
         if 'args' not in block:
-            blocks[i]['args'] = defaults.get(block['module'], {"deps": []})
+            blocks[i]['args'] = analysis_defaults.get(block['module'], {"deps": []})
         elif 'deps' not in block['args']:
             blocks[i]['args']['deps'] = []
         for dep in block['args']['deps']:

--- a/lightwood/helpers/templating.py
+++ b/lightwood/helpers/templating.py
@@ -130,11 +130,16 @@ def _consolidate_analysis_blocks(jsonai, key):
         'GlobalFeatureImportance': {"deps": ['AccStats']}
     }
     blocks = getattr(jsonai, key)
+    block_objs = {b['module']: b for b in blocks}
+
     for i, block in enumerate(blocks):
         if 'args' not in block:
             blocks[i]['args'] = defaults.get(block['module'], {"deps": []})
         elif 'deps' not in block['args']:
             blocks[i]['args']['deps'] = []
+        for dep in block['args']['deps']:
+            if dep not in block_objs.keys():
+                raise Exception(f'Analysis block "{dep}" not found but necessary for block "{block["module"]}". Please add it and try again.')  # noqa
 
     # 2. correct execution order -- build a DAG out of analysis blocks
     block_objs = {b['module']: b for b in blocks}

--- a/tests/integration/advanced/test_custom_modules.py
+++ b/tests/integration/advanced/test_custom_modules.py
@@ -62,8 +62,8 @@ def throwing_cleaner(data: pd.DataFrame, err_msg: str):
 from lightwood.analysis.base import BaseAnalysisBlock
 
 class {cname}(BaseAnalysisBlock):
-    def __init__(self):
-        super().__init__(deps=None)
+    def __init__(self, deps=tuple()):
+        super().__init__(deps=deps)
 
     def analyze(self, info, **kwargs):
         info['test'] = 'test'

--- a/tests/integration/basic/test_categorical.py
+++ b/tests/integration/basic/test_categorical.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import balanced_accuracy_score
 from lightwood.api.types import ProblemDefinition
-from lightwood.api.high_level import predictor_from_problem, json_ai_from_problem, JsonAI, code_from_json_ai, predictor_from_code  # noqa
+from lightwood.api.high_level import predictor_from_problem  # noqa
 np.random.seed(42)
 
 
@@ -69,23 +69,3 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(balanced_accuracy_score(test['target'], predictions['prediction']) > 0.5)
         self.assertTrue('confidence' not in predictions.columns)
 
-    def test_3_test_tempscale_analysis(self):
-        # Create base json ai
-        df = pd.read_csv('tests/data/hdi.csv').iloc[0:100]
-        pdef = ProblemDefinition.from_dict({'target': 'Development Index',
-                                            'time_aim': 20,
-                                            'use_default_analysis': False
-                                            })
-        json_ai = json_ai_from_problem(df, pdef)
-
-        # modify it
-        json_ai_dump = json_ai.to_dict()
-        json_ai_dump['analysis_blocks'] = [{'module': 'TempScaler', 'args': {}}, {'module': 'ConfStats', 'args': {}}]
-        json_ai = JsonAI.from_dict(json_ai_dump)
-
-        # create a predictor from it
-        code = code_from_json_ai(json_ai)
-        predictor = predictor_from_code(code)
-        predictor.learn(df)
-        row_insights = predictor.predict(df)
-        assert 'confidence' in row_insights.columns

--- a/tests/integration/basic/test_jsonai.py
+++ b/tests/integration/basic/test_jsonai.py
@@ -12,10 +12,7 @@ class TestJsonAI(unittest.TestCase):
         pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 80})
         jai = json_ai_from_problem(df, pdef)
         jai.analysis_blocks = [
-            # args not needed (not even deps) because they are injected for default blocks
-            {"module": "ICP"},
-            {"module": "AccStats"},
-            {"module": "ConfStats"},  # TODO: remove these three, they should always be enabled
+            # args not needed (not even deps), they should be injected for default blocks
             {"module": "GlobalFeatureImportance"}
         ]
 

--- a/tests/integration/basic/test_jsonai.py
+++ b/tests/integration/basic/test_jsonai.py
@@ -1,12 +1,11 @@
 import unittest
 import pandas as pd
 from lightwood.api.types import ProblemDefinition
+from lightwood.api.high_level import json_ai_from_problem, predictor_from_json_ai, JsonAI, code_from_json_ai, predictor_from_code  # noqa
 
 
 class TestJsonAI(unittest.TestCase):
     def test_0_hidden_args_analysis(self):
-        from lightwood.api.high_level import json_ai_from_problem, predictor_from_json_ai
-
         df = pd.read_csv('tests/data/concrete_strength.csv')[:500]
         target = 'concrete_strength'
         pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 80})
@@ -20,3 +19,34 @@ class TestJsonAI(unittest.TestCase):
         predictor.learn(df)
         self.assertTrue(len(predictor.analysis_blocks) == 4)
         self.assertTrue(all([0 <= colimp <= 1 for colimp in predictor.runtime_analyzer['column_importances'].values()]))
+
+    def test_1_incorrect_chain(self):
+        df = pd.read_csv('tests/data/concrete_strength.csv')[:500]
+        target = 'concrete_strength'
+        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 80})
+        jai = json_ai_from_problem(df, pdef)
+        jai.analysis_blocks = [{'module': 'TempScaler', 'args': {'deps': ['Some other block']}}]
+        with self.assertRaises(Exception) as context:
+            predictor_from_json_ai(jai)
+        self.assertTrue('not found but necessary for block' in str(context.exception))
+
+    def test_2_tempscale_analysis(self):
+        # Create base json ai
+        df = pd.read_csv('tests/data/hdi.csv').iloc[0:100]
+        pdef = ProblemDefinition.from_dict({'target': 'Development Index',
+                                            'time_aim': 20,
+                                            'use_default_analysis': False
+                                            })
+        json_ai = json_ai_from_problem(df, pdef)
+
+        # modify it
+        json_ai_dump = json_ai.to_dict()
+        json_ai_dump['analysis_blocks'] = [{'module': 'TempScaler'}]
+        json_ai = JsonAI.from_dict(json_ai_dump)
+
+        # create a predictor from it
+        code = code_from_json_ai(json_ai)
+        predictor = predictor_from_code(code)
+        predictor.learn(df)
+        row_insights = predictor.predict(df)
+        assert 'confidence' in row_insights.columns

--- a/tests/integration/basic/test_jsonai.py
+++ b/tests/integration/basic/test_jsonai.py
@@ -1,0 +1,25 @@
+import unittest
+import pandas as pd
+from lightwood.api.types import ProblemDefinition
+
+
+class TestJsonAI(unittest.TestCase):
+    def test_0_hidden_args_analysis(self):
+        from lightwood.api.high_level import json_ai_from_problem, predictor_from_json_ai
+
+        df = pd.read_csv('tests/data/concrete_strength.csv')[:500]
+        target = 'concrete_strength'
+        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 80})
+        jai = json_ai_from_problem(df, pdef)
+        jai.analysis_blocks = [
+            # args not needed (not even deps) because they are injected for default blocks
+            {"module": "ICP"},
+            {"module": "AccStats"},
+            {"module": "ConfStats"},  # TODO: remove these three, they should always be enabled
+            {"module": "GlobalFeatureImportance"}
+        ]
+
+        predictor = predictor_from_json_ai(jai)
+        predictor.learn(df)
+        self.assertTrue(len(predictor.analysis_blocks) == 4)
+        self.assertTrue(all([0 <= colimp <= 1 for colimp in predictor.runtime_analyzer['column_importances'].values()]))


### PR DESCRIPTION
# Why 
For a simpler, better, streamlined UX with analysis blocks.

# How
- Added a topological sorting procedure to determine valid execution order in case that inputs are incorrectly ordered.
- Improved missing params insertion for default blocks
- Minor modifications to some blocks, in particular `GlobalFeatureImportance` normalization is now based on the obtained accuracy rather than passing through a low-temp softmax.

## Example

In practice, this implies a substantial change in the amount of boilerplate needed to specify an analysis chain.

From:

```python
[...]
jai = json_ai_from_problem(df, pdef)
jai.analysis_blocks = [
        {
            "module": "ICP",
            "args": {
                "fixed_significance": None,
                "confidence_normalizer": False,
                "positive_domain": "$statistical_analysis.positive_domain",
            },
        },
        {
            "module": "AccStats",
            "args": {"deps": ["ICP"]},
        },
        {
            "module": "ConfStats",
            "args": {"deps": ["ICP"]}
        },
        {
            "module": "lightwood.analysis.GlobalFeatureImportance",
            "args": {"disable_column_importance": False}
        }
      ]
```

To:

```python
jai = json_ai_from_problem(df, pdef)
jai.analysis_blocks = [
    {"module": "GlobalFeatureImportance"}
]
```
- `ICP`, `AccStats` and `ConfStats` are now appended to any chain if missing.
- Args are not needed for default blocks (e.g. `GlobalFeatureImportance`).
