### PR TITLE
Faster type inference

### DIFF
--- a/lightwood/data/infer_types.py
+++ b/lightwood/data/infer_types.py
@@ -2,6 +2,7 @@ from collections import Counter
 import random
 from typing import List
 import dateutil
+import ciso8601
 from scipy.stats import norm
 import pandas as pd
 import numpy as np
@@ -130,7 +131,8 @@ def type_check_sequence(element: object) -> str:
 
 def type_check_date(element: object) -> str:
     try:
-        dt = dateutil.parser.parse(str(element))
+        # dt = dateutil.parser.parse(str(element))
+        dt = ciso8601.parse_datetime(str(element))
 
         # Not accurate 100% for a single datetime str,
         # but should work in aggregate
@@ -378,7 +380,7 @@ def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420) -> T
         f'from a total population of {population_size}, this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.') # noqa
 
     nr_procs = get_nr_procs(data)
-    if nr_procs > 1:
+    if False: # nr_procs > 1:
         log.info(f'Using {nr_procs} processes to deduct types.')
         pool = mp.Pool(processes=nr_procs)
         # Make type `object` so that dataframe cells can be python lists
@@ -408,7 +410,7 @@ def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420) -> T
             'dtype_dist': data_dtype_dist
         }
 
-    if nr_procs > 1:
+    if False: #nr_procs > 1:
         pool = mp.Pool(processes=nr_procs)
         answer_arr = pool.map(get_identifier_description_mp, [
             (data[x], x, type_information.dtypes[x])

--- a/lightwood/data/infer_types.py
+++ b/lightwood/data/infer_types.py
@@ -1,8 +1,7 @@
 from collections import Counter
 import random
 from typing import List
-import dateutil
-import ciso8601
+import zulu
 from scipy.stats import norm
 import pandas as pd
 import numpy as np
@@ -131,11 +130,9 @@ def type_check_sequence(element: object) -> str:
 
 def type_check_date(element: object) -> str:
     try:
-        # dt = dateutil.parser.parse(str(element))
-        dt = ciso8601.parse_datetime(str(element))
+        dt = zulu.parse(str(element))
 
-        # Not accurate 100% for a single datetime str,
-        # but should work in aggregate
+        # Not accurate 100% for a single datetime str, but should work in aggregate
         if dt.hour == 0 and dt.minute == 0 and dt.second == 0 and len(str(element)) <= 16:
             return dtype.date
         else:
@@ -380,7 +377,7 @@ def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420) -> T
         f'from a total population of {population_size}, this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.') # noqa
 
     nr_procs = get_nr_procs(data)
-    if False: # nr_procs > 1:
+    if nr_procs > 1:
         log.info(f'Using {nr_procs} processes to deduct types.')
         pool = mp.Pool(processes=nr_procs)
         # Make type `object` so that dataframe cells can be python lists
@@ -410,7 +407,7 @@ def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420) -> T
             'dtype_dist': data_dtype_dist
         }
 
-    if False: #nr_procs > 1:
+    if nr_procs > 1:
         pool = mp.Pool(processes=nr_procs)
         answer_arr = pool.map(get_identifier_description_mp, [
             (data[x], x, type_information.dtypes[x])

--- a/lightwood/helpers/text.py
+++ b/lightwood/helpers/text.py
@@ -50,7 +50,7 @@ def get_language_dist(data):
             lang_probs_cache[text] = lang_probs
 
         lang_probs = lang_probs_cache[text]
-        if len(lang_probs) > 0 and lang_probs[1] > 0.90:
+        if len(lang_probs) > 0 and lang_probs[1] > 10 * (1 / len(identifier.nb_classes)):
             lang_dist[lang_probs[0]] += 1
         else:
             lang_dist['Unknown'] += 1

--- a/lightwood/helpers/text.py
+++ b/lightwood/helpers/text.py
@@ -16,7 +16,6 @@ import hashlib
 from typing import Iterable
 import numpy as np
 import scipy.stats as st
-from scipy.special import softmax
 from langid.langid import LanguageIdentifier
 from langid.langid import model as langid_model
 import nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,4 @@ colorlog ==6.5.0
 statsmodels >=0.12.0
 neuralforecast ==0.1.0
 pytorch-lightning>=1.3.0
-zulu==2.0.0
 langid==1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ psutil >=5.7.0
 setuptools >=21.2.1
 wheel >=0.32.2
 scikit-learn <=1.0.2
-langdetect >=1.0.0,<=1.0.9
 dataclasses_json >=0.5.4
 autopep8 >=1.5.7
 dill ==0.3.4
@@ -26,3 +25,4 @@ colorlog ==6.5.0
 statsmodels >=0.12.0
 neuralforecast ==0.1.0
 pytorch-lightning>=1.3.0
+langid<=1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ colorlog ==6.5.0
 statsmodels >=0.12.0
 neuralforecast ==0.1.0
 pytorch-lightning>=1.3.0
-langid<=1.1.6
+zulu==2.0.0
+langid==1.1.6

--- a/tests/unit_tests/data/test_infer_types.py
+++ b/tests/unit_tests/data/test_infer_types.py
@@ -1,0 +1,9 @@
+import unittest
+
+from lightwood.api.dtype import dtype
+from lightwood.data.infer_types import type_check_date
+
+
+class TestTypeInference(unittest.TestCase):
+    def test_0_type_check_dates(self):
+        self.assertEqual(type_check_date('31/12/2010'), dtype.date)


### PR DESCRIPTION
## Why

Fixes #969.

## How

- Replace language detection package: from `langdetect` to `langid`
- Trigger multiprocessing usage only for dataset size bigger than some cutoff (`n_rows * n_cols >= 1e4` by default)

## Some benchmarks

- For the dataframe in the issue above: `0.08 [s]` before, `0.007 [s]` after.
- For [`stack_overflow_survey`](https://github.com/mindsdb/benchmarks/blob/main/benchmarks/datasets/stack_overflow_survey/data.csv) dataset: `84.9 [s]` before, `46.4 [s]` after.