### PR TITLE
Deduplicate entries in TS transform

### DIFF
--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -50,6 +50,11 @@ def transform_timeseries(
     # infer frequency with get_delta
     oby_col = tss.order_by
     groups = get_ts_groups(data, tss)
+
+    # initial stable sort and per-partition deduplication
+    data = data.sort_values(by=oby_col, kind='mergesort')
+    data = data.drop_duplicates(subset=[tss.order_by, *tss.group_by], keep='first')
+
     if not ts_analysis:
         _, periods, freqs = get_delta(data, dtype_dict, groups, target, tss)
     else:

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -53,7 +53,7 @@ def transform_timeseries(
 
     # initial stable sort and per-partition deduplication
     data = data.sort_values(by=oby_col, kind='mergesort')
-    data = data.drop_duplicates(subset=[tss.order_by, *tss.group_by], keep='first')
+    data = data.drop_duplicates(subset=[oby_col, *gb_arr], keep='first')
 
     if not ts_analysis:
         _, periods, freqs = get_delta(data, dtype_dict, groups, target, tss)

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -316,7 +316,7 @@ class SkTime(BaseMixer):
         try:
             self._fit(train_data)
             y_true = test_data.data_frame[self.target].values[:self.horizon]
-            y_pred = self(test_data)['prediction'].iloc[0][:len(y_true)]
+            y_pred = pd.DataFrame(self(test_data)['prediction'].iloc[0][:len(y_true)])
             error = self.trial_error_fn(y_true, y_pred)
         except Exception as e:
             log.debug(e)

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -257,16 +257,16 @@ class TestTimeseries(unittest.TestCase):
         predictor.learn(train)
         predictor.predict(test)
 
-    def test_5_time_series_sktime_mixer(self):
+    def test_5_time_series_arima_mixer(self):
         """
-        Tests `sktime` mixer individually, as it has a special notion of
-        timestamps that we need to ensure are being used correctly. In
-        particular, given a train-dev-test split, any forecasts coming from a sktime
+        Tests `AutoARIMA` mixer individually, as it has a special notion of
+        timestamps that we need to ensure are being used correctly (along with all other `sktime` mixers). 
+        In particular, given a train-dev-test split, any forecasts coming from any sktime
         mixer should start from the latest observed data in the entire dataset.
         
         This test also compares:
          - correct propagation of offset by K if the special `__mdb_forecast_offset` column is present
-         - results against manual use of sktime to ensure equal results.
+         - results against manual use of AutoARIMA to ensure equal results.
         """  # noqa
 
         # synth square wave
@@ -294,7 +294,7 @@ class TestTimeseries(unittest.TestCase):
 
         json_ai = json_ai_from_problem(df, problem_definition=pdef)
         json_ai.model['args']['submodels'] = [{
-            "module": "SkTime",
+            "module": "ARIMAMixer",
             "args": {
                 "stop_after": "$problem_definition.seconds_per_mixer",
                 "horizon": "$problem_definition.timeseries_settings.horizon",
@@ -350,7 +350,38 @@ class TestTimeseries(unittest.TestCase):
             lw_preds = [p[0] for p in ps['prediction']]
             assert np.allclose(manual_preds, lw_preds, atol=1.5)
 
-    def test_6_irregular_series(self):
+    def test_6_time_series_sktime_mixer(self):
+        """ Sanity check with vanilla sktime mixer using a synthetic square wave """
+        tsteps = 100
+        target = 'Value'
+        horizon = 20
+        df = pd.DataFrame(columns=['Time', target])
+        df['Time'] = np.linspace(0, 100, tsteps, endpoint=False)
+        df[target] = [i + f for i, f in enumerate(signal.sawtooth(2 * np.pi * 5 * df['Time'].values, width=0.5))]
+        df[f'{target}_2x'] = [2 * elt for elt in df[target].values]
+        train = df[:int(len(df) * 0.8)]
+        test = df[int(len(df) * 0.8):]
+        pdef = ProblemDefinition.from_dict({'target': target,
+                                            'time_aim': 200,
+                                            'timeseries_settings': {
+                                                'order_by': 'Time',
+                                                'window': 5,
+                                                'horizon': horizon,
+                                                'historical_columns': [f'{target}_2x']
+                                            }})
+        json_ai = json_ai_from_problem(df, problem_definition=pdef)
+        json_ai.model['args']['submodels'] = [{
+            "module": "SkTime",
+            "args": {
+                "stop_after": "$problem_definition.seconds_per_mixer",
+                "horizon": "$problem_definition.timeseries_settings.horizon",
+            }}]
+        predictor = predictor_from_code(code_from_json_ai(json_ai))
+        train_and_check_time_aim(predictor, train)
+        ps = predictor.predict(test)
+        assert r2_score(test[target].values, ps['prediction'].iloc[0]) >= 0.5
+
+    def test_7_irregular_series(self):
         """
         Even though the suggestion is to feed regularly sampled series into predictors, this test can still help us
         catch undesired behavior when the recommendation is not followed.
@@ -390,7 +421,7 @@ class TestTimeseries(unittest.TestCase):
         test['__mdb_forecast_offset'] = 1
         predictor.predict(test)
 
-    def test_7_time_series_double_grouped_regression(self):
+    def test_8_time_series_double_grouped_regression(self):
         """Test double-grouped numerical predictions, replicates quick start guide in cloud.mindsdb.com """
         data = pd.read_csv('tests/data/house_sales.csv')
         gby = ['bedrooms', 'type']
@@ -423,7 +454,7 @@ class TestTimeseries(unittest.TestCase):
             for timestamp in row[f'order_{order_by}']:
                 assert timestamp > pd.to_datetime(test[order_by]).max().timestamp()
 
-    def test_8_ts_dedupe(self):
+    def test_9_ts_dedupe(self):
         """ Test time series de-duplication procedures """
         data = pd.read_csv('tests/data/arrivals.csv')
         data = data[data['Country'].isin(['US', 'Japan'])]


### PR DESCRIPTION
# Why

Fixes #959.

# How
- Drop duplicate entries for every partition when transforming any time series input.
- Also fixes a small issue computing trial losses inside the `sktime` mixer, plus additional TS tests for coverage.

## Notes
- We may want to do aggregation in the future (see #959 and other issues referenced there). If so, an alternate approach may be better. For now, though, discussions have led to a design where resampling happens in the data layer rather than lightwood, so it's less important to have `resample`/`reduce` for the time being.
