### PR TITLE
[Fix] #910: original format in order column

### DIFF
--- a/lightwood/analysis/explain.py
+++ b/lightwood/analysis/explain.py
@@ -57,7 +57,7 @@ def explain(data: pd.DataFrame,
         row_insights[f'order_{tss.order_by}'] = data[tss.order_by]
         row_insights[f'order_{tss.order_by}'] = get_inferred_timestamps(
             row_insights, tss.order_by, ts_analysis['deltas'], tss, stat_analysis,
-            use_original_format=pred_args.preserve_time_format
+            time_format=pred_args.time_format
         )
 
     kwargs = {

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -673,13 +673,12 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
         "explainer": {
             "module": "explain",
             "args": {
-                "timeseries_settings": "$problem_definition.timeseries_settings",
-                "positive_domain": "$statistical_analysis.positive_domain",
-                "anomaly_detection": "$problem_definition.anomaly_detection",
+                "problem_definition": "$problem_definition",
+                "stat_analysis": "$statistical_analysis",
                 "data": "data",
                 "encoded_data": "encoded_data",
                 "predictions": "df",
-                "analysis": "$runtime_analyzer",
+                "runtime_analysis": "$runtime_analyzer",
                 "ts_analysis": "$ts_analysis" if is_ts else None,
                 "target_name": "$target",
                 "target_dtype": "$dtype_dict[self.target]",

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -504,7 +504,7 @@ class PredictionArguments:
     :param fixed_confidence: Used in the ICP analyzer module, specifies an `alpha` fixed confidence so that predictions, in average, are correct `alpha` percent of the time. For unsupervised anomaly detection, this also translates into the expected error rate. Bounded between 0.01 and 0.99 (respectively implies wider and tighter bounds, all other parameters being equal).
     :param anomaly_cooldown: Sets the minimum amount of timesteps between consecutive firings of the the anomaly \
         detector.
-    :param preserve_time_format: For time series predictors. If set to `infer`, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format. Any other string value will be used as a formatting string, unless empty (''), which disables the feature (this is the default behavior).
+    :param time_format: For time series predictors. If set to `infer`, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format. Any other string value will be used as a formatting string, unless empty (''), which disables the feature (this is the default behavior).
     """  # noqa
 
     predict_proba: bool = True
@@ -512,7 +512,7 @@ class PredictionArguments:
     fixed_confidence: Union[int, float, None] = None
     anomaly_cooldown: int = 1
     forecast_offset: int = 0
-    preserve_time_format: str = ''
+    time_format: str = ''
 
     @staticmethod
     def from_dict(obj: Dict):
@@ -530,7 +530,7 @@ class PredictionArguments:
         fixed_confidence = obj.get('fixed_confidence', PredictionArguments.fixed_confidence)
         anomaly_cooldown = obj.get('anomaly_cooldown', PredictionArguments.anomaly_cooldown)
         forecast_offset = obj.get('forecast_offset', PredictionArguments.forecast_offset)
-        preserve_time_format = obj.get('preserve_time_format', PredictionArguments.preserve_time_format)
+        time_format = obj.get('time_format', PredictionArguments.time_format)
 
         pred_args = PredictionArguments(
             predict_proba=predict_proba,
@@ -538,7 +538,7 @@ class PredictionArguments:
             fixed_confidence=fixed_confidence,
             anomaly_cooldown=anomaly_cooldown,
             forecast_offset=forecast_offset,
-            preserve_time_format=preserve_time_format,
+            time_format=time_format,
         )
 
         return pred_args

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -504,6 +504,7 @@ class PredictionArguments:
     :param fixed_confidence: Used in the ICP analyzer module, specifies an `alpha` fixed confidence so that predictions, in average, are correct `alpha` percent of the time. For unsupervised anomaly detection, this also translates into the expected error rate. Bounded between 0.01 and 0.99 (respectively implies wider and tighter bounds, all other parameters being equal).
     :param anomaly_cooldown: Sets the minimum amount of timesteps between consecutive firings of the the anomaly \
         detector.
+    :param preserve_time_format: For time series predictors. If enabled, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format.
     """  # noqa
 
     predict_proba: bool = True
@@ -511,6 +512,7 @@ class PredictionArguments:
     fixed_confidence: Union[int, float, None] = None
     anomaly_cooldown: int = 1
     forecast_offset: int = 0
+    preserve_time_format: bool = False
 
     @staticmethod
     def from_dict(obj: Dict):
@@ -528,6 +530,7 @@ class PredictionArguments:
         fixed_confidence = obj.get('fixed_confidence', PredictionArguments.fixed_confidence)
         anomaly_cooldown = obj.get('anomaly_cooldown', PredictionArguments.anomaly_cooldown)
         forecast_offset = obj.get('forecast_offset', PredictionArguments.forecast_offset)
+        preserve_time_format = obj.get('preserve_time_format', PredictionArguments.preserve_time_format)
 
         pred_args = PredictionArguments(
             predict_proba=predict_proba,
@@ -535,6 +538,7 @@ class PredictionArguments:
             fixed_confidence=fixed_confidence,
             anomaly_cooldown=anomaly_cooldown,
             forecast_offset=forecast_offset,
+            preserve_time_format=preserve_time_format,
         )
 
         return pred_args

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -504,7 +504,7 @@ class PredictionArguments:
     :param fixed_confidence: Used in the ICP analyzer module, specifies an `alpha` fixed confidence so that predictions, in average, are correct `alpha` percent of the time. For unsupervised anomaly detection, this also translates into the expected error rate. Bounded between 0.01 and 0.99 (respectively implies wider and tighter bounds, all other parameters being equal).
     :param anomaly_cooldown: Sets the minimum amount of timesteps between consecutive firings of the the anomaly \
         detector.
-    :param preserve_time_format: For time series predictors. If enabled, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format.
+    :param preserve_time_format: For time series predictors. If set to `infer`, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format. Any other string value will be used as a formatting string, unless empty (''), which disables the feature (this is the default behavior).
     """  # noqa
 
     predict_proba: bool = True
@@ -512,7 +512,7 @@ class PredictionArguments:
     fixed_confidence: Union[int, float, None] = None
     anomaly_cooldown: int = 1
     forecast_offset: int = 0
-    preserve_time_format: bool = False
+    preserve_time_format: str = ''
 
     @staticmethod
     def from_dict(obj: Dict):

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -94,7 +94,10 @@ def statistical_analysis(data: pd.DataFrame,
     tss = problem_definition.timeseries_settings
     if tss.is_timeseries:
         oby_col = tss.order_by
-        order_format = infer_date_format(data[oby_col])
+        try:
+            order_format = infer_date_format(data[oby_col])
+        except Exception:
+            order_format = None
 
     df = cleaner(data, dtypes, problem_definition.pct_invalid,
                  identifiers, problem_definition.target, 'train', tss,

--- a/lightwood/data/statistical_analysis.py
+++ b/lightwood/data/statistical_analysis.py
@@ -2,6 +2,7 @@ from typing import Dict
 import pandas as pd
 import numpy as np
 import datetime
+import dateinfer
 from dateutil.parser import parse as parse_dt
 from lightwood.api import StatisticalAnalysis, ProblemDefinition
 from lightwood.helpers.numeric import filter_nan_and_none
@@ -74,6 +75,13 @@ def compute_entropy_biased_buckets(histogram):
     return S, biased_buckets
 
 
+def infer_date_format(values: pd.DataFrame, n_samples=50) -> str:
+    """ infer date format based on a small sample """
+    return dateinfer.infer(
+        values.sample(n=min(n_samples, len(values))).tolist()
+    )
+
+
 def statistical_analysis(data: pd.DataFrame,
                          dtypes: Dict[str, str],
                          identifiers: Dict[str, object],
@@ -82,8 +90,14 @@ def statistical_analysis(data: pd.DataFrame,
                          seed_nr: int = 420) -> StatisticalAnalysis:
     seed(seed_nr)
     log.info('Starting statistical analysis')
+
+    tss = problem_definition.timeseries_settings
+    if tss.is_timeseries:
+        oby_col = tss.order_by
+        order_format = infer_date_format(data[oby_col])
+
     df = cleaner(data, dtypes, problem_definition.pct_invalid,
-                 identifiers, problem_definition.target, 'train', problem_definition.timeseries_settings,
+                 identifiers, problem_definition.target, 'train', tss,
                  problem_definition.anomaly_detection)
     columns = [col for col in df.columns if col not in exceptions]
 
@@ -175,9 +189,12 @@ def statistical_analysis(data: pd.DataFrame,
         else:
             avg_words_per_sentence[col] = None
 
-    if problem_definition.timeseries_settings.is_timeseries:
-        groups = get_ts_groups(data, problem_definition.timeseries_settings)
-        ts_stats = {'groups': groups}
+    if tss.is_timeseries:
+        groups = get_ts_groups(data, tss)
+        ts_stats = {
+            'groups': groups,
+            'order_format': order_format
+        }
     else:
         ts_stats = {}
 

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -86,7 +86,7 @@ def get_delta(
 
 
 def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_analysis,
-                            use_original_format=False) -> pd.DataFrame:
+                            use_original_format='') -> pd.DataFrame:
     horizon = tss.horizon
     if tss.group_by:
         gby = [f'group_{g}' for g in tss.group_by]
@@ -108,7 +108,11 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_
 
         # format if needed
         if use_original_format:
-            original_format = stat_analysis.ts_stats['order_format']
+            if use_original_format.lower() == 'infer':
+                original_format = stat_analysis.ts_stats['order_format']
+            else:
+                original_format = use_original_format
+
             if original_format:
                 for i, ts in enumerate(timestamps):
                     timestamps[i] = datetime.utcfromtimestamp(ts).strftime(original_format)

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -1,4 +1,5 @@
 from typing import List, Tuple, Union, Dict
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -84,7 +85,8 @@ def get_delta(
     return deltas, periods, freqs
 
 
-def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss) -> pd.DataFrame:
+def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_analysis,
+                            use_original_format=False) -> pd.DataFrame:
     horizon = tss.horizon
     if tss.group_by:
         gby = [f'group_{g}' for g in tss.group_by]
@@ -103,6 +105,12 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss) -> pd
 
         if tss.horizon == 1:
             timestamps = timestamps[0]  # preserves original input format if horizon == 1
+
+        # format if needed
+        if use_original_format:
+            original_format = stat_analysis.ts_stats['order_format']
+            for i, ts in enumerate(timestamps):
+                timestamps[i] = datetime.utcfromtimestamp(ts).strftime(original_format)
 
         df[f'order_{col}'].iloc[idx] = timestamps
     return df[f'order_{col}']

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -86,7 +86,7 @@ def get_delta(
 
 
 def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_analysis,
-                            use_original_format='') -> pd.DataFrame:
+                            time_format='') -> pd.DataFrame:
     horizon = tss.horizon
     if tss.group_by:
         gby = [f'group_{g}' for g in tss.group_by]
@@ -106,16 +106,15 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_
         if tss.horizon == 1:
             timestamps = timestamps[0]  # preserves original input format if horizon == 1
 
-        # format if needed
-        if use_original_format:
-            if use_original_format.lower() == 'infer':
-                original_format = stat_analysis.ts_stats['order_format']
+        if time_format:
+            if time_format.lower() == 'infer':
+                tformat = stat_analysis.ts_stats['order_format']
             else:
-                original_format = use_original_format
+                tformat = time_format
 
-            if original_format:
+            if tformat:
                 for i, ts in enumerate(timestamps):
-                    timestamps[i] = datetime.utcfromtimestamp(ts).strftime(original_format)
+                    timestamps[i] = datetime.utcfromtimestamp(ts).strftime(tformat)
 
         df[f'order_{col}'].iloc[idx] = timestamps
     return df[f'order_{col}']

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -109,8 +109,9 @@ def get_inferred_timestamps(df: pd.DataFrame, col: str, deltas: dict, tss, stat_
         # format if needed
         if use_original_format:
             original_format = stat_analysis.ts_stats['order_format']
-            for i, ts in enumerate(timestamps):
-                timestamps[i] = datetime.utcfromtimestamp(ts).strftime(original_format)
+            if original_format:
+                for i, ts in enumerate(timestamps):
+                    timestamps[i] = datetime.utcfromtimestamp(ts).strftime(original_format)
 
         df[f'order_{col}'].iloc[idx] = timestamps
     return df[f'order_{col}']

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ statsmodels >=0.12.0
 neuralforecast ==0.1.0
 pytorch-lightning>=1.3.0
 langid==1.1.6
+pydateinfer==0.3.0

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -472,3 +472,21 @@ class TestTimeseries(unittest.TestCase):
         pred = predictor_from_code(code)
         transformed = pred.preprocess(data)
         assert len(transformed) == target_len
+
+    def test_10_output_date_format(self):
+        """ Checks that predicted order_by values are timestamps """
+        np.random.seed(0)
+        data = pd.read_csv('tests/data/arrivals.csv')
+        data = data[data['Country'] == 'US']
+        order_by = 'T'
+        train_df, test_df = self.split_arrivals(data, grouped=False)
+        predictor = predictor_from_problem(train_df, ProblemDefinition.from_dict({'target': 'Traffic',
+                                                                                  'time_aim': 30,
+                                                                                  'timeseries_settings': {
+                                                                                      'order_by': order_by,
+                                                                                      'window': 5,
+                                                                                      'horizon': 2
+                                                                                  }}))
+        predictor.learn(train_df)
+        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': True})
+        self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07', '2012-10'])

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -488,5 +488,8 @@ class TestTimeseries(unittest.TestCase):
                                                                                       'horizon': 2
                                                                                   }}))
         predictor.learn(train_df)
-        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': True})
+        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': 'infer'})
         self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07', '2012-10'])
+
+        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': '%Y-%m-%d'})
+        self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07-16', '2012-10-15'])

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -488,8 +488,8 @@ class TestTimeseries(unittest.TestCase):
                                                                                       'horizon': 2
                                                                                   }}))
         predictor.learn(train_df)
-        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': 'infer'})
+        preds = predictor.predict(test_df.iloc[[-1]], args={'time_format': 'infer'})
         self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07', '2012-10'])
 
-        preds = predictor.predict(test_df.iloc[[-1]], args={'preserve_time_format': '%Y-%m-%d'})
+        preds = predictor.predict(test_df.iloc[[-1]], args={'time_format': '%Y-%m-%d'})
         self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07-16', '2012-10-15'])

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -491,5 +491,5 @@ class TestTimeseries(unittest.TestCase):
         preds = predictor.predict(test_df.iloc[[-1]], args={'time_format': 'infer'})
         self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07', '2012-10'])
 
-        preds = predictor.predict(test_df.iloc[[-1]], args={'time_format': '%Y-%m-%d'})
-        self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012-07-16', '2012-10-15'])
+        preds = predictor.predict(test_df.iloc[[-1]], args={'time_format': '%Y'})
+        self.assertEqual(preds[f'order_{order_by}'].iloc[-1], ['2012', '2012'])


### PR DESCRIPTION
## Why

Fixes #910 

## How

Uses `pydatainfer` to store the originally observed datetime format for the `tss.order_by` column.

User can specify `time_format` inside prediction arguments as follows:
- left unspecified results in unix epoch for timestamps (default behavior)
- `infer` will use the format inferred from a training dataset sample
- any other string can be used as input if a different/custom format is preferred