### PR TITLE
[Fix] SHAP block uses original input columns only

### DIFF
--- a/tests/unit_tests/analysis/test_shap.py
+++ b/tests/unit_tests/analysis/test_shap.py
@@ -29,6 +29,9 @@ class TestBasic(unittest.TestCase):
         predictions = predictor.predict(df.head())
 
         self.assertIn('shap_explainer', predictor.runtime_analyzer)
-        self.assertIn('feature_4_impact', predictions.columns)
-        # TODO: once global_insights is exposed, check that all feature impacts
-        # plus base_response sum up to the prediction value
+
+        self.assertIn('shap_base_response', predictions.columns)
+        self.assertIn('shap_final_response', predictions.columns)
+        for input_col in df.columns:
+            if input_col != target:
+                self.assertIn(f'shap_contribution_{input_col}', predictions.columns)


### PR DESCRIPTION
# Why
Fixes #978 

# How
Ensuring the block only uses valid input columns. Additionally, moved base and final response to be additional columns in the output rows.