### PR TITLE
Add lightwood library version to predictor

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1186,6 +1186,7 @@ class Predictor(PredictorInterface):
         self.accuracy_functions = {json_ai.accuracy_functions}
         self.identifiers = {json_ai.identifiers}
         self.dtype_dict = {inline_dict(dtype_dict)}
+        self.lightwood_version = lightwood_version
 
         # Any feature-column dependencies
         self.dependencies = {inline_dict(json_ai.dependency_dict)}

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -11,7 +11,7 @@ from lightwood.api.types import (
 )
 import inspect
 from lightwood.helpers.log import log
-from lightwood import __version__ as lightwood_version
+from lightwood.__about__ import __version__ as lightwood_version
 
 
 # For custom modules, we create a module loader with necessary imports below

--- a/tests/integration/basic/test_regression.py
+++ b/tests/integration/basic/test_regression.py
@@ -4,6 +4,7 @@ import pandas as pd
 from sklearn.metrics import r2_score
 from lightwood.api.types import ProblemDefinition
 from lightwood.api.high_level import json_ai_from_problem, predictor_from_json_ai
+from lightwood import __version__ as lightwood_version
 
 
 class TestBasic(unittest.TestCase):
@@ -38,6 +39,8 @@ class TestBasic(unittest.TestCase):
         predictor.learn(df)
 
         assert predictor.model_analysis.dtypes[target] == dtype.quantity
+
+        assert predictor.lightwood_version == lightwood_version
 
         predictions = predictor.predict(df)
 

--- a/tests/integration/basic/test_regression.py
+++ b/tests/integration/basic/test_regression.py
@@ -40,7 +40,7 @@ class TestBasic(unittest.TestCase):
 
         assert predictor.model_analysis.dtypes[target] == dtype.quantity
 
-        assert predictor.lightwood_version == lightwood_version
+        assert predictor.lightwood_version == str(lightwood_version)
 
         predictions = predictor.predict(df)
 


### PR DESCRIPTION
fixes #1010 

As explained in #1011 the versioning logic will be added in code generation phase.