### PR TITLE
Remove n-hits & prophet from default mixer list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test.pickle
 AI.json
 AI2.json
 
+# docs
 assert.sh
 docssrc/build
 docssrc/build/*
@@ -67,3 +68,4 @@ docs
 docs/*
 *.zip
 docs/*
+.ipynb_checkpoints

--- a/lightwood/mixer/__init__.py
+++ b/lightwood/mixer/__init__.py
@@ -1,5 +1,5 @@
-from lightwood.mixer.unit import Unit
 from lightwood.mixer.base import BaseMixer
+from lightwood.mixer.unit import Unit
 from lightwood.mixer.neural import Neural
 from lightwood.mixer.neural_ts import NeuralTs
 from lightwood.mixer.lightgbm import LightGBM
@@ -9,14 +9,22 @@ from lightwood.mixer.sktime import SkTime
 from lightwood.mixer.arima import ARIMAMixer
 from lightwood.mixer.ets import ETSMixer
 from lightwood.mixer.gluonts import GluonTSMixer
-from lightwood.mixer.nhits import NHitsMixer
-from lightwood.mixer.prophet import ProphetMixer
 from lightwood.mixer.regression import Regression
 
 try:
     from lightwood.mixer.qclassic import QClassic
 except Exception:
     QClassic = None
+
+try:
+    from lightwood.mixer.nhits import NHitsMixer
+except Exception:
+    NHitsMixer = None
+
+try:
+    from lightwood.mixer.prophet import ProphetMixer
+except Exception:
+    ProphetMixer = None
 
 __all__ = ['BaseMixer', 'Neural', 'NeuralTs', 'LightGBM', 'RandomForest', 'LightGBMArray', 'Unit', 'Regression',
            'SkTime', 'QClassic', 'ProphetMixer', 'ETSMixer', 'ARIMAMixer', 'NHitsMixer', 'GluonTSMixer']

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ black >=21.9b0
 typing_extensions
 colorlog ==6.5.0
 statsmodels >=0.12.0
-neuralforecast ==0.1.0
-pytorch-lightning>=1.6.0, <1.7.0
 langid==1.1.6
 pydateinfer==0.3.0
 shap >= 0.40.0

--- a/requirements_extra_ts.txt
+++ b/requirements_extra_ts.txt
@@ -1,0 +1,4 @@
+pystan==2.19.1.1
+prophet==1.1
+neuralforecast ==0.1.0
+pytorch-lightning>=1.6.0, <1.7.0

--- a/requirements_prophet.txt
+++ b/requirements_prophet.txt
@@ -1,2 +1,0 @@
-pystan==2.19.1.1
-prophet==1.1


### PR DESCRIPTION
## Why
To keep default installation dependencies manageable.

Any users that want to use either of these mixers will have to `pip install lightwood[extra_ts]`.