### PR TITLE
Simpler TS evaluation

### DIFF
--- a/lightwood/analysis/analyze.py
+++ b/lightwood/analysis/analyze.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple, Optional
 
 from lightwood.helpers.log import log
+from lightwood.helpers.ts import filter_ds
 from lightwood.api import dtype
 from lightwood.ensemble import BaseEnsemble
 from lightwood.analysis.base import BaseAnalysisBlock
@@ -53,8 +54,10 @@ def model_analyzer(
 
     # raw predictions for validation dataset
     args = {} if not is_classification else {"predict_proba": True}
+    filtered_df = filter_ds(encoded_val_data, tss)
+    encoded_val_data = EncodedDs(encoded_val_data.encoders, filtered_df, encoded_val_data.target)
     normal_predictions = predictor(encoded_val_data, args=PredictionArguments.from_dict(args))
-    normal_predictions = normal_predictions.set_index(data.index)
+    normal_predictions = normal_predictions.set_index(encoded_val_data.data_frame.index)
 
     # ------------------------- #
     # Run analysis blocks, both core and user-defined
@@ -65,7 +68,7 @@ def model_analyzer(
         'input_cols': input_cols,
         'dtype_dict': dtype_dict,
         'normal_predictions': normal_predictions,
-        'data': data,
+        'data': filtered_df,
         'train_data': train_data,
         'encoded_val_data': encoded_val_data,
         'is_classification': is_classification,

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -381,8 +381,10 @@ def generate_json_ai(
         accuracy_functions = ["r2_score"]
     elif output_dtype in [dtype.categorical, dtype.tags, dtype.binary]:
         accuracy_functions = ["balanced_accuracy_score"]
-    elif output_dtype in (dtype.num_array, dtype.num_tsarray):
+    elif output_dtype in (dtype.num_tsarray, ):
         accuracy_functions = ["complementary_smape_array_accuracy"]
+    elif output_dtype in (dtype.num_array, ):
+        accuracy_functions = ["evaluate_num_array_accuracy"]
     elif output_dtype in (dtype.cat_array, dtype.cat_tsarray):
         accuracy_functions = ["evaluate_cat_array_accuracy"]
     else:

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -40,6 +40,7 @@ from lightwood.encoder import *
 from lightwood.ensemble import *
 from lightwood.helpers.device import *
 from lightwood.helpers.general import *
+from lightwood.helpers.ts import *
 from lightwood.helpers.log import *
 from lightwood.helpers.numeric import *
 from lightwood.helpers.imputers import *
@@ -995,6 +996,8 @@ self.mode = 'train'
 encoded_train_data = enc_data['train']
 encoded_dev_data = enc_data['dev']
 encoded_test_data = enc_data['test']
+filtered_df = filter_ds(encoded_test_data, self.problem_definition.timeseries_settings)
+encoded_test_data = EncodedDs(encoded_test_data.encoders, filtered_df, encoded_test_data.target)
 
 log.info('Training the mixers')
 

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -381,7 +381,7 @@ def generate_json_ai(
     elif output_dtype in [dtype.categorical, dtype.tags, dtype.binary]:
         accuracy_functions = ["balanced_accuracy_score"]
     elif output_dtype in (dtype.num_array, dtype.num_tsarray):
-        accuracy_functions = ["bounded_ts_accuracy"]
+        accuracy_functions = ["complementary_smape_array_accuracy"]
     elif output_dtype in (dtype.cat_array, dtype.cat_tsarray):
         accuracy_functions = ["evaluate_cat_array_accuracy"]
     else:

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -391,7 +391,8 @@ def generate_json_ai(
 
     if is_ts:
         if output_dtype in [dtype.integer, dtype.float]:
-            accuracy_functions = ["bounded_ts_accuracy"]  # forces this acc fn for t+1 time series forecasters  # noqa
+            # forces this acc fn for t+1 time series forecasters
+            accuracy_functions = ["complementary_smape_array_accuracy"]
 
         if output_dtype in (dtype.integer, dtype.float, dtype.num_tsarray):
             imputers.append({"module": "NumericalImputer",

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -125,7 +125,7 @@ class TimeseriesSettings:
     :param target_type: Automatically inferred dtype of the target (e.g. `dtype.integer`, `dtype.float`).
     :param use_previous_target: Use the previous values of the target column to generate predictions. Defaults to True.
     :param allow_incomplete_history: whether predictions can be made for rows with incomplete historical context (i.e. less than `window` rows have been observed for the datetime that has to be forecasted).
-    :param eval_cold_start: whether to include predictions with incomplete history (thus part of the cold start region for certain mixers) when evaluating mixer scores with the validation dataset.
+    :param eval_incomplete: whether to consider predictions with incomplete history or target information when evaluating mixer accuracy with the validation dataset.
     :param interval_periods: tuple of tuples with user-provided period lengths for time intervals. Default values will be added for intervals left unspecified. For interval options, check the `timeseries_analyzer.detect_period()` method documentation. e.g.: (('daily', 7),).
     """  # noqa
 
@@ -141,7 +141,7 @@ class TimeseriesSettings:
         # @TODO: George: No, I don't think it is, we need to pass this some other way
     )
     allow_incomplete_history: bool = True
-    eval_cold_start: bool = True
+    eval_incomplete: bool = False
     interval_periods: tuple = tuple()
 
     @staticmethod
@@ -172,7 +172,7 @@ class TimeseriesSettings:
                 historical_columns=[],
                 horizon=obj.get("horizon", 1),
                 allow_incomplete_history=obj.get('allow_incomplete_history', True),
-                eval_cold_start=obj.get('eval_cold_start', True),
+                eval_incomplete=obj.get('eval_incomplete', False),
                 interval_periods=obj.get('interval_periods', tuple(tuple()))
             )
             for setting in obj:

--- a/lightwood/helpers/general.py
+++ b/lightwood/helpers/general.py
@@ -256,7 +256,9 @@ def complementary_smape_array_accuracy(
     """  # noqa
     y_true = deepcopy(true_values)
     y_pred = deepcopy(predictions)
-    smape_score = mean_absolute_percentage_error(y_true, y_pred, symmetric=True)
+    if kwargs['ts_analysis']['tss'].group_by:
+        [y_true.pop(gby_col) for gby_col in kwargs['ts_analysis']['tss'].group_by]
+    smape_score = mean_absolute_percentage_error(y_true.values, y_pred.values, symmetric=True)
     return 1 - smape_score / 2
 
 

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -286,3 +286,24 @@ def max_pacf(data: pd.DataFrame, group_combinations, target, tss):
                 candidate_sps[group] = [1]
 
     return candidate_sps
+
+
+def filter_ds(ds, tss, n_rows=1):
+    """
+    This method triggers only for timeseries datasets.
+
+    It returns a dataframe that filters out all but the first ``n_rows`` per group.
+    """  # noqa
+    df = ds.data_frame
+    if tss.is_timeseries:
+        gby = tss.group_by
+        if gby is None:
+            df = df.iloc[[0]]
+        else:
+            ndf = pd.DataFrame(columns=df.columns)
+            for group in get_ts_groups(df, tss):
+                if group != '__default':
+                    _, subdf = get_group_matches(df, group, tss.group_by)
+                    ndf = pd.concat([ndf, subdf.iloc[:n_rows]])
+            df = ndf
+    return df


### PR DESCRIPTION
## Why
Improves UX in forecasting scenarios by using a more streamlined accuracy function and mixer evaluation procedure.

## How
- New evaluation protocol for TS predictors: now only the first forecast horizon is considered for accuracy computation. If there are multiple series (i.e. groups), the first data point for each is used.
- New complementary sMAPE metric is now the default metric in forecasting use cases.