### PR TITLE
feat: override inferred types

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -199,12 +199,18 @@ def generate_json_ai(
     exec(IMPORT_EXTERNAL_DIRS, globals())
     target = problem_definition.target
     input_cols = []
+    dependency_dict = {}
     tss = problem_definition.timeseries_settings
+
+    dtype_dict_override = problem_definition.dtype_dict
     dtype_dict = type_information.dtypes
+
     for k in type_information.identifiers:
         if not (tss.is_timeseries and tss.group_by and k in tss.group_by) and k != target:
             del dtype_dict[k]
-    dependency_dict = {}
+
+    for k, v in dtype_dict_override.items():
+        dtype_dict[k] = v
 
     for col_name, col_dtype in dtype_dict.items():
         if (

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -161,6 +161,8 @@ class ProblemDefinition:
          available settings.
     :param anomaly_detection: Whether to conduct unsupervised anomaly detection; currently supported only for time-\
         series.
+    :param dtype_dict: Mapping of features to types (see `mindsdb.type_infer` for all possible values). This will \
+    override the automated type inference results.
     :param ignore_features: The names of the columns the user wishes to ignore in the ML pipeline. Any column name \
         found in this list will be automatically removed from subsequent steps in the ML pipeline.
     :param use_default_analysis: whether default analysis blocks are enabled.
@@ -183,6 +185,7 @@ class ProblemDefinition:
     timeseries_settings: TimeseriesSettings
     anomaly_detection: bool
     use_default_analysis: bool
+    dtype_dict: Optional[dict]
     ignore_features: List[str]
     fit_on_all: bool
     strict_mode: bool
@@ -211,6 +214,7 @@ class ProblemDefinition:
 
         target_weights = obj.get('target_weights', None)
         positive_domain = obj.get('positive_domain', False)
+        dtype_dict = obj.get('dtype_dict', {})
         timeseries_settings = TimeseriesSettings.from_dict(obj.get('timeseries_settings', {}))
         anomaly_detection = obj.get('anomaly_detection', False)
         ignore_features = obj.get('ignore_features', [])
@@ -230,6 +234,7 @@ class ProblemDefinition:
             positive_domain=positive_domain,
             timeseries_settings=timeseries_settings,
             anomaly_detection=anomaly_detection,
+            dtype_dict=dtype_dict,
             ignore_features=ignore_features,
             use_default_analysis=use_default_analysis,
             fit_on_all=fit_on_all,

--- a/tests/integration/basic/test_jsonai.py
+++ b/tests/integration/basic/test_jsonai.py
@@ -8,7 +8,11 @@ class TestJsonAI(unittest.TestCase):
     def test_0_hidden_args_analysis(self):
         df = pd.read_csv('tests/data/concrete_strength.csv')[:500]
         target = 'concrete_strength'
-        pdef = ProblemDefinition.from_dict({'target': target, 'time_aim': 80})
+        pdef = ProblemDefinition.from_dict({
+            'target': target,
+            'time_aim': 80,
+            'dtype_dict': {'age': 'categorical'}  # tests overriding inferred types
+        })
         jai = json_ai_from_problem(df, pdef)
         jai.analysis_blocks = [
             # args not needed (not even deps), they should be injected for default blocks


### PR DESCRIPTION
## Why

The type inference engine is not perfect. And even then, it should be possible for a user to override the inferred type for any reason whatsoever. So far, it wasn't possible, but this PR fixes that.

## How
Adds a `dtype_dict` field to the `ProblemDefinition` class to enable the override. At JsonAI building time, we iterate over the specified keys and replace any inferred types with the user definied ones.
