### PR TITLE
Force infer_row in bulk ts predictions

### DIFF
--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -753,7 +753,8 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
                 "dtype_dict": "$dtype_dict",
                 "target": "$target",
                 "mode": "$mode",
-                "ts_analysis": "$ts_analysis"
+                "ts_analysis": "$ts_analysis",
+                "pred_args": "$pred_args",
             },
         },
         "timeseries_analyzer": {
@@ -1050,7 +1051,6 @@ self.mixers = trained_mixers
 # --------------- #
 log.info('Ensembling the mixer')
 # Create an ensemble of mixers to identify best performing model
-self.pred_args = PredictionArguments()
 # Dirty hack
 self.ensemble = {call(json_ai.model)}
 self.supports_proba = self.ensemble.supports_proba
@@ -1183,6 +1183,8 @@ n_phases = 3 if self.pred_args.all_mixers else 4
 if len(data) == 0:
     raise Exception("Empty input, aborting prediction. Please try again with some input data.")
 
+self.pred_args = PredictionArguments.from_dict(args)
+
 log.info(f'[Predict phase 1/{{n_phases}}] - Data preprocessing')
 if self.problem_definition.ignore_features:
     log.info(f'Dropping features: {{self.problem_definition.ignore_features}}')
@@ -1200,7 +1202,6 @@ encoded_ds = self.featurize({{"predict_data": data}})["predict_data"]
 encoded_data = encoded_ds.get_encoded_data(include_target=False)
 
 log.info(f'[Predict phase 3/{{n_phases}}] - Calling ensemble')
-self.pred_args = PredictionArguments.from_dict(args)
 df = self.ensemble(encoded_ds, args=self.pred_args)
 
 if self.pred_args.all_mixers:
@@ -1233,6 +1234,7 @@ class Predictor(PredictorInterface):
         self.identifiers = {json_ai.identifiers}
         self.dtype_dict = {inline_dict(dtype_dict)}
         self.lightwood_version = '{lightwood_version}'
+        self.pred_args = PredictionArguments()
 
         # Any feature-column dependencies
         self.dependencies = {inline_dict(json_ai.dependency_dict)}

--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -440,6 +440,7 @@ class PredictionArguments:
     :param anomaly_cooldown: Sets the minimum amount of timesteps between consecutive firings of the the anomaly \
         detector.
     :param time_format: For time series predictors. If set to `infer`, predicted `order_by` timestamps will be formatted back to the original dataset's `order_by` format. Any other string value will be used as a formatting string, unless empty (''), which disables the feature (this is the default behavior).
+    :param force_ts_infer: For time series predictors. If set to `true`, an additional row will be produced per each group in the input DF, corresponding to an out-of-sample forecast w.r.t. to the input timestamps.
     """  # noqa
 
     predict_proba: bool = True
@@ -449,6 +450,7 @@ class PredictionArguments:
     forecast_offset: int = 0
     simple_ts_bounds: bool = False
     time_format: str = ''
+    force_ts_infer: bool = False
 
     @staticmethod
     def from_dict(obj: Dict):
@@ -468,6 +470,7 @@ class PredictionArguments:
         forecast_offset = obj.get('forecast_offset', PredictionArguments.forecast_offset)
         simple_ts_bounds = obj.get('simple_ts_bounds', PredictionArguments.simple_ts_bounds)
         time_format = obj.get('time_format', PredictionArguments.time_format)
+        force_ts_infer = obj.get('force_ts_infer', PredictionArguments.force_ts_infer)
 
         pred_args = PredictionArguments(
             predict_proba=predict_proba,
@@ -477,6 +480,7 @@ class PredictionArguments:
             forecast_offset=forecast_offset,
             simple_ts_bounds=simple_ts_bounds,
             time_format=time_format,
+            force_ts_infer=force_ts_infer,
         )
 
         return pred_args

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -412,7 +412,8 @@ class TestTimeseries(unittest.TestCase):
         for idx in [1, None]:
             # Last row yields predictions starting one period after the most recent timestamp seen at training time
             train['__mdb_forecast_offset'] = idx
-            ps = predictor.predict(train)
+            args = {} if idx == 1 else {'force_ts_infer': True}
+            ps = predictor.predict(train, args=args)
             if idx == 1:
                 assert len(ps) == 1
             else:
@@ -422,6 +423,10 @@ class TestTimeseries(unittest.TestCase):
             start_predtime = datetime.utcfromtimestamp(ps.iloc[-1][f'order_{oby}'][0])
             start_test = datetime.utcfromtimestamp(pd.to_datetime(test.iloc[0][oby]).value // 1e9)
             assert start_test - start_predtime <= timedelta(days=2)
+
+            if idx is None:
+                ps = predictor.predict(train, args={})  # ensure without `force_ts_infer` flag it behaves normally
+                assert len(ps) == len(train)
 
     def test_7_irregular_series(self):
         """


### PR DESCRIPTION
This PR adds a prediction argument (`force_ts_infer`) that modifies the behavior of predict calls in time series models so that an additional row is provided in the returned data frame, corresponding to the first out of sample forecast w.r.t. the passed input.

Fixes #990 and #1055.