### PR TITLE
[feat] add special dispatch for bestof ensemble

### DIFF
--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -12,7 +12,7 @@ from lightwood.api.types import PredictionArguments, SubmodelData
 from lightwood.data.encoded_ds import EncodedDs
 
 # special dispatches
-from lightwood.mixer.gluonts import GluonTSMixer
+from lightwood.mixer import GluonTSMixer  # imported from base mixer folder as it needs optional dependencies
 
 
 class BestOf(BaseEnsemble):

--- a/lightwood/ensemble/best_of.py
+++ b/lightwood/ensemble/best_of.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import numpy as np
 import pandas as pd
+from mindsdb_evaluator import evaluate_accuracies
 
 from lightwood.helpers.log import log
 from type_infer.helpers import is_nan_numeric
@@ -9,7 +10,9 @@ from lightwood.mixer.base import BaseMixer
 from lightwood.ensemble.base import BaseEnsemble
 from lightwood.api.types import PredictionArguments, SubmodelData
 from lightwood.data.encoded_ds import EncodedDs
-from mindsdb_evaluator import evaluate_accuracies
+
+# special dispatches
+from lightwood.mixer.gluonts import GluonTSMixer
 
 
 class BestOf(BaseEnsemble):
@@ -22,19 +25,24 @@ class BestOf(BaseEnsemble):
     def __init__(self, target, mixers: List[BaseMixer], data: EncodedDs, accuracy_functions,
                  args: PredictionArguments, ts_analysis: Optional[dict] = None, fit: bool = True) -> None:
         super().__init__(target, mixers, data, fit=False)
+        self.special_dispatch_list = [GluonTSMixer]
 
         if fit:
             score_list = []
             for _, mixer in enumerate(self.mixers):
-                score_dict = evaluate_accuracies(
-                    data.data_frame,
-                    mixer(data, args)['prediction'],
-                    target,
-                    accuracy_functions,
-                    ts_analysis=ts_analysis
-                )
 
-                avg_score = np.mean(list(score_dict.values()))
+                if type(mixer) in self.special_dispatch_list:
+                    avg_score = self.special_dispatch(mixer, data, args, target, ts_analysis)
+                else:
+                    score_dict = evaluate_accuracies(
+                        data.data_frame,
+                        mixer(data, args)['prediction'],
+                        target,
+                        accuracy_functions,
+                        ts_analysis=ts_analysis
+                    )
+
+                    avg_score = np.mean(list(score_dict.values()))
                 log.info(f'Mixer: {type(mixer).__name__} got accuracy: {avg_score}')
 
                 if is_nan_numeric(avg_score):
@@ -73,3 +81,7 @@ class BestOf(BaseEnsemble):
                     else:
                         log.warning(f'Unstable mixer {type(mixer).__name__} failed with exception: {e}.\
                         Trying next best')
+
+    def special_dispatch(self, mixer, data, args, target, ts_analysis):
+        if isinstance(mixer, GluonTSMixer):
+            return mixer.model_train_stats.loss_history[-1]

--- a/lightwood/mixer/gluonts.py
+++ b/lightwood/mixer/gluonts.py
@@ -87,12 +87,13 @@ class GluonTSMixer(BaseMixer):
         cat_ds = ConcatedEncodedDs([train_data, dev_data])
         fit_groups = list(cat_ds.data_frame[self.grouped_by[0]].unique()) if self.grouped_by != ['__default'] else None
         train_ds = self._make_initial_ds(cat_ds.data_frame, phase='train', groups=fit_groups)
+        self.model_train_stats = TrainingHistory()
 
         self.estimator = DeepAREstimator(
             freq=train_ds.freq,
             prediction_length=self.horizon,
             distr_output=self.distribution,
-            trainer=Trainer(epochs=self.n_epochs, callbacks=[EarlyStop(patience=self.patience)])
+            trainer=Trainer(epochs=self.n_epochs, callbacks=[EarlyStop(patience=self.patience), self.model_train_stats])
         )
         self.model = self.estimator.train(train_ds)
         self.prepared = True


### PR DESCRIPTION
Helps with mixers that are very expensive to run, e.g. GluonTS.

This way, we can override model prediction on a (potentially huge) validation dataset and simply report the validation loss as a proxy, for example. It's up to the provided function that will override the specified mixer within the ensemble.