### PR TITLE
Deprecate support for Python 3.7

### DIFF
--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7,3.8,3.9]
+        python-version: ['3.8','3.9','3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8','3.9','3.10']
+        python-version: ['3.8','3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ pip3 install lightwood
 However, we recommend creating a python virtual environment.
 
 #### Setting up a dev environment
-- Python version should be in the range >=3.7, < 3.10
+- Python version should be in the range >=3.8, < 3.11
 - Clone lightwood
 - `cd lightwood && pip install -r requirements.txt && pip install -r requirements_image.txt`
 - Add it to your python path (e.g. by adding `export PYTHONPATH='/where/you/cloned/lightwood':$PYTHONPATH` as a newline at the end of your `~/.bashrc` file)

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7"
+    python_requires=">=3.8"
 )


### PR DESCRIPTION
Needed as we move towards PyTorch 2.0 (see #1130).