### PR TITLE
[ENH] Top level cache for Predictor.featurize()

### DIFF
--- a/lightwood/analysis/analyze.py
+++ b/lightwood/analysis/analyze.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Tuple, Optional
 from dataprep_ml import StatisticalAnalysis
 
 from lightwood.helpers.log import log
-from lightwood.helpers.ts import filter_ds
 from type_infer.dtype import dtype
 from lightwood.ensemble import BaseEnsemble
 from lightwood.analysis.base import BaseAnalysisBlock
@@ -60,8 +59,6 @@ def model_analyzer(
     normal_predictions = None
 
     if len(analysis_blocks) > 0:
-        filtered_df = filter_ds(encoded_val_data, tss)
-        encoded_val_data = EncodedDs(encoded_val_data.encoders, filtered_df, encoded_val_data.target)
         normal_predictions = predictor(encoded_val_data, args=PredictionArguments.from_dict(args))
         normal_predictions = normal_predictions.set_index(encoded_val_data.data_frame.index)
 

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1216,13 +1216,14 @@ encoded_data = encoded_ds.get_encoded_data(include_target=False)
 log.info(f'[Predict phase 3/{{n_phases}}] - Calling ensemble')
 df = self.ensemble(encoded_ds, args=self.pred_args)
 
-if self.pred_args.all_mixers:
-    return df
-else:
+if not self.pred_args.all_mixers:
     log.info(f'[Predict phase 4/{{n_phases}}] - Analyzing output')
-    insights, global_insights = {call(json_ai.explainer)}
+    df, global_insights = {call(json_ai.explainer)}
     self.global_insights = {{**self.global_insights, **global_insights}}
-    return insights
+
+self.feature_cache = dict()  # empty feature cache to avoid large predictor objects
+
+return df
 """
 
     predict_body = align(predict_body, 2)

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1004,8 +1004,8 @@ for key, data in split_data.items():
     if key != 'stratified_on':
         if key not in self.feature_cache:
             featurized_split = EncodedDs(self.encoders, filter_ts(data, tss), self.target)
+            self.feature_cache[key] = featurized_split
 
-        self.feature_cache[key] = featurized_split
         feature_data[key] = self.feature_cache[key]
 
 return feature_data

--- a/lightwood/data/encoded_ds.py
+++ b/lightwood/data/encoded_ds.py
@@ -79,7 +79,7 @@ class EncodedDs(Dataset):
                 if col != self.target:
                     X.append(encoded_tensor)
                 else:
-                    Y = encoded_tensor.squeeze()
+                    Y = encoded_tensor.ravel()
 
         if self.cache_encoded:
             X = torch.cat(X, dim=1).float().squeeze()

--- a/lightwood/data/encoded_ds.py
+++ b/lightwood/data/encoded_ds.py
@@ -44,7 +44,7 @@ class EncodedDs(Dataset):
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         The getter yields a tuple (X, y), where:
-          - `X `is a concatenation of all encoded representations of the row
+          - `X `is a concatenation of all encoded representations of the row. Size: (n_features,)
           - `y` is the encoded target
           
         :param idx: index of the row to access.
@@ -56,7 +56,7 @@ class EncodedDs(Dataset):
             if self.cache[idx] is not None:
                 return self.cache[idx]
 
-        X = torch.FloatTensor()
+        X = []
         Y = torch.FloatTensor()
         for col in self.data_frame:
             if self.encoders.get(col, None):
@@ -72,16 +72,17 @@ class EncodedDs(Dataset):
                     cols = [col]
                     data = self.data_frame[cols].iloc[idx].tolist()
 
-                encoded_tensor = self.encoders[col].encode(data, **kwargs)[0]
+                encoded_tensor = self.encoders[col].encode(data, **kwargs)
                 if torch.isnan(encoded_tensor).any() or torch.isinf(encoded_tensor).any():
                     raise Exception(f'Encoded tensor: {encoded_tensor} contains nan or inf values, this tensor is \
                                       the encoding of column {col} using {self.encoders[col].__class__}')
                 if col != self.target:
-                    X = torch.cat([X, encoded_tensor])
+                    X.append(encoded_tensor)
                 else:
-                    Y = encoded_tensor
+                    Y = encoded_tensor.squeeze()
 
         if self.cache_encoded:
+            X = torch.cat(X, dim=1).float().squeeze()
             self.cache[idx] = (X, Y)
 
         return X, Y

--- a/lightwood/helpers/ts.py
+++ b/lightwood/helpers/ts.py
@@ -297,13 +297,12 @@ def max_pacf(data: pd.DataFrame, group_combinations, target, tss):
     return candidate_sps
 
 
-def filter_ds(ds, tss, n_rows=1):
+def filter_ts(df: pd.DataFrame, tss, n_rows=1):
     """
     This method triggers only for timeseries datasets.
 
     It returns a dataframe that filters out all but the first ``n_rows`` per group.
     """  # noqa
-    df = ds.data_frame
     if tss.is_timeseries:
         gby = tss.group_by
         if gby is None:

--- a/lightwood/mixer/random_forest.py
+++ b/lightwood/mixer/random_forest.py
@@ -57,7 +57,7 @@ class RandomForest(BaseMixer):
 
         self.model = None
         self.positive_domain = False
-        self.num_trials = 20
+        self.num_trials = 5
         self.cv = 3
         self.map = {}
 


### PR DESCRIPTION
## Changelog
- `RandomForestMixer`: reduce number of hyperparameter search trials from 20 to 5
- Rename `filter_ds` to `filter_ts`. Change signature and usage so that it directly interacts with `pd.DataFrame`s instead.
- Setting up a cache in the generated `Predictor` code that maintains three `EncodedDs` objects through the `learn()` pipeline, deleting them at the end to avoid bloated binaries. This helps reduce the number of instantiations, as all invocations are done through `featurize()`, which checks (and potentially uses) the cache first.
- Avoid duplicate instantiation of validation `EncodedDs` object inside `analysis`, reverting to use the predictor's cache instead.

## Effect:
This reduces `learn()` runtime anywhere from 15% to 50% depending on the dataset and predictor properties.