### PR TITLE
[ENH] Offline batching

### DIFF
--- a/lightwood/analysis/helpers/feature_importance.py
+++ b/lightwood/analysis/helpers/feature_importance.py
@@ -81,6 +81,7 @@ class PermutationFeatureImportance(BaseAnalysisBlock):
                 shuffle_data = deepcopy(ref_data)
                 shuffle_data.clear_cache()
                 shuffle_data.data_frame[col] = shuffle(shuffle_data.data_frame[col].values)
+                shuffle_data.build_cache()  # TODO: bottleneck, add a method to build a single column instead!
 
                 shuffled_preds = ns.predictor(shuffle_data, args=PredictionArguments.from_dict(args))
                 shuffled_col_accuracy[col] = np.mean(list(evaluate_accuracies(

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -617,7 +617,6 @@ def _add_implicit_values(json_ai: JsonAI) -> JsonAI:
             mixers[i]["args"]["target_encoder"] = mixers[i]["args"].get(
                 "target_encoder", "$encoders[self.target]"
             )
-            mixers[i]["args"]["use_optuna"] = True
 
         elif mixers[i]["module"] == "LightGBMArray":
             mixers[i]["args"]["input_cols"] = mixers[i]["args"].get(

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -94,7 +94,7 @@ def lookup_encoder(
         dtype.binary: "BinaryEncoder",
         dtype.categorical: "CategoricalAutoEncoder"
         if statistical_analysis is None
-        or len(statistical_analysis.histograms[col_name]) > 100
+        or len(statistical_analysis.histograms[col_name]['x']) > 16
         else "OneHotEncoder",
         dtype.tags: "MultiHotEncoder",
         dtype.date: "DatetimeEncoder",
@@ -943,14 +943,17 @@ prepped_encoders = {{}}
 parallel_encoding = parallel_encoding_check(data['train'], self.encoders)
 
 if parallel_encoding:
+    log.debug('Preparing in parallel...')
     for col_name, encoder in self.encoders.items():
         if col_name != self.target and not encoder.is_trainable_encoder:
             prepped_encoders[col_name] = (encoder, concatenated_train_dev[col_name], 'prepare')
     prepped_encoders = mut_method_call(prepped_encoders)
 
 else:
+    log.debug('Preparing sequentially...')
     for col_name, encoder in self.encoders.items():
         if col_name != self.target and not encoder.is_trainable_encoder:
+            log.debug(f'Preparing encoder for {{col_name}}...')
             encoder.prepare(concatenated_train_dev[col_name])
             prepped_encoders[col_name] = encoder
 

--- a/lightwood/api/json_ai.py
+++ b/lightwood/api/json_ai.py
@@ -1004,8 +1004,8 @@ for key, data in split_data.items():
     if key != 'stratified_on':
         if key not in self.feature_cache:
             featurized_split = EncodedDs(self.encoders, filter_ts(data, tss), self.target)
+            self.feature_cache[key] = featurized_split
 
-        self.feature_cache[key] = featurized_split
         feature_data[key] = self.feature_cache[key]
 
 return feature_data

--- a/lightwood/data/encoded_ds.py
+++ b/lightwood/data/encoded_ds.py
@@ -67,10 +67,10 @@ class EncodedDs(Dataset):
                 if hasattr(self.encoders[col], 'data_window'):
                     cols = [self.target] + [f'{self.target}_timestep_{i}'
                                             for i in range(1, self.encoders[col].data_window)]
-                    data = [self.data_frame[cols].iloc[idx].tolist()]
+                    data = [self.data_frame[cols].iloc[idx].values]
                 else:
                     cols = [col]
-                    data = self.data_frame[cols].iloc[idx].tolist()
+                    data = self.data_frame[cols].iloc[idx].values
 
                 encoded_tensor = self.encoders[col].encode(data, **kwargs)
                 if torch.isnan(encoded_tensor).any() or torch.isinf(encoded_tensor).any():

--- a/lightwood/data/encoded_ds.py
+++ b/lightwood/data/encoded_ds.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 import torch
 import numpy as np
 import pandas as pd
@@ -8,7 +8,7 @@ from lightwood.encoder.base import BaseEncoder
 
 
 class EncodedDs(Dataset):
-    def __init__(self, encoders: List[BaseEncoder], data_frame: pd.DataFrame, target: str) -> None:
+    def __init__(self, encoders: Dict[str, BaseEncoder], data_frame: pd.DataFrame, target: str) -> None:
         """
         Create a Lightwood datasource from a data frame and some encoders. This class inherits from `torch.utils.data.Dataset`.
         
@@ -21,8 +21,6 @@ class EncodedDs(Dataset):
         self.data_frame = data_frame
         self.encoders = encoders
         self.target = target
-        self.use_cache = True
-        self.cache = [None] * len(self.data_frame)
         self.encoder_spans = {}
         self.input_length = 0  # feature tensor dim
 
@@ -34,6 +32,10 @@ class EncodedDs(Dataset):
                 self.input_length += self.encoders[col].output_size
 
         # if cache enabled, we immediately build it
+        self.use_cache = True
+        self.cache_built = False
+        self.X_cache: torch.Tensor = torch.full((len(self.data_frame),), fill_value=torch.nan)
+        self.Y_cache: torch.Tensor = torch.full((len(self.data_frame),), fill_value=torch.nan)
         self.build_cache()
 
     def __len__(self):
@@ -47,20 +49,23 @@ class EncodedDs(Dataset):
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         The getter yields a tuple (X, y), where:
-          - `X `is a concatenation of all encoded representations of the row. Size: (n_features,)
-          - `y` is the encoded target
+          - `X `is a concatenation of all encoded representations of the row. Size: (B, n_features)
+          - `y` is the encoded target. Size: (B, n_features)
           
         :param idx: index of the row to access.
         
         :return: tuple (X, y) with encoded data.
         
         """  # noqa
-        if self.use_cache and self.cache[idx] is not None:
-            X, Y = self.cache[idx]
+        if self.use_cache and self.X_cache[idx] is not torch.nan:
+            X = self.X_cache[idx, :]
+            Y = self.Y_cache[idx]
         else:
             X, Y = self._encode_idxs([idx, ])
             if self.use_cache:
-                self.cache[idx] = [X, Y]
+                self.X_cache[idx, :] = X
+                self.Y_cache[idx, :] = Y
+
         return X, Y
 
     def _encode_idxs(self, idxs: list):
@@ -68,7 +73,7 @@ class EncodedDs(Dataset):
             raise Exception(f"Passed indexes is not an iterable. Check the type! Index: {idxs}")
 
         X = torch.zeros((len(idxs), self.input_length))
-        Y = torch.FloatTensor()
+        Y = torch.zeros((len(idxs),))
         for col in self.data_frame:
             if self.encoders.get(col, None):
                 kwargs = {}
@@ -93,23 +98,18 @@ class EncodedDs(Dataset):
 
                 # target post-processing
                 else:
-                    if len(encoded_tensor.shape) > 1:
+                    Y = encoded_tensor
+
+                    if len(encoded_tensor.shape) > 2:
                         Y = encoded_tensor.squeeze()
-                    else:
-                        Y = encoded_tensor.ravel()
+
+                    if len(encoded_tensor.shape) < 2:
+                        Y = encoded_tensor.unsqueeze(1)
+
+                    # else:
+                    #     Y = encoded_tensor.ravel()
 
         return X, Y
-
-    def build_cache(self):
-        """ This method builds a cache for the entire dataframe provided at initialization. """
-        if not self.use_cache:
-            raise RuntimeError("Cannot build a cache for EncodedDS with `use_cache` set to False.")
-
-        idxs = list(range(len(self.data_frame)))
-        X, Y = self._encode_idxs(idxs)
-
-        for i, (x, y) in enumerate(zip(X, Y)):
-            self.cache[i] = [x, y]
 
     def get_column_original_data(self, column_name: str) -> pd.Series:
         """
@@ -127,20 +127,35 @@ class EncodedDs(Dataset):
         :param column_name: name of the column.
         :return: A `torch.Tensor` with the encoded data of the `column_name` column.
         """
+        if self.use_cache and self.cache_built:
+            if column_name == self.target and self.Y_cache is not None:
+                return self.Y_cache
+            elif self.X_cache is not torch.nan:
+                a, b = self.encoder_spans[column_name]
+                return self.X_cache[:, a:b]
+
         kwargs = {}
         if 'dependency_data' in inspect.signature(self.encoders[column_name].encode).parameters:
             deps = [dep for dep in self.encoders[column_name].dependencies if dep in self.data_frame.columns]
-            kwargs['dependency_data'] = {dep: self.data_frame[dep].tolist() for dep in deps}
+            kwargs['dependency_data'] = {dep: self.data_frame[dep] for dep in deps}
         encoded_data = self.encoders[column_name].encode(self.data_frame[column_name], **kwargs)
         if torch.isnan(encoded_data).any() or torch.isinf(encoded_data).any():
             raise Exception(f'Encoded tensor: {encoded_data} contains nan or inf values')
 
         if not isinstance(encoded_data, torch.Tensor):
             raise Exception(
-                f'The encoder: {self.encoders[column_name]} for column: {column_name} does not return a Tensor !')
+                f'The encoder: {self.encoders[column_name]} for column: {column_name} does not return a Tensor!')
+
+        if self.use_cache and not self.cache_built:
+            if column_name == self.target:
+                self.Y_cache = encoded_data
+            else:
+                a, b = self.encoder_spans[column_name]
+                self.X_cache = self.X_cache[:, a:b]
+
         return encoded_data
 
-    def get_encoded_data(self, include_target=True) -> torch.Tensor:
+    def get_encoded_data(self, include_target: bool = True) -> torch.Tensor:
         """
         Gets all encoded data.
 
@@ -154,11 +169,22 @@ class EncodedDs(Dataset):
 
         return torch.cat(encoded_dfs, 1)
 
+    def build_cache(self):
+        """ This method builds a cache for the entire dataframe provided at initialization. """
+        if not self.use_cache:
+            raise RuntimeError("Cannot build a cache for EncodedDS with `use_cache` set to False.")
+
+        idxs = list(range(len(self.data_frame)))
+        X, Y = self._encode_idxs(idxs)
+        self.X_cache = X
+        self.Y_cache = Y
+        self.cache_built = True
+
     def clear_cache(self):
-        """
-        Clears the `EncodedDs` cache.
-        """
-        self.cache = [None] * len(self.data_frame)
+        """ Clears the `EncodedDs` cache. """
+        self.X_cache = torch.full((len(self.data_frame),), fill_value=torch.nan)
+        self.Y_cache = torch.full((len(self.data_frame),), fill_value=torch.nan)
+        self.cache_built = False
 
 
 class ConcatedEncodedDs(EncodedDs):

--- a/lightwood/data/encoded_ds.py
+++ b/lightwood/data/encoded_ds.py
@@ -83,7 +83,7 @@ class EncodedDs(Dataset):
                 if hasattr(self.encoders[col], 'data_window'):
                     cols = [self.target] + [f'{self.target}_timestep_{i}'
                                             for i in range(1, self.encoders[col].data_window)]
-                    data = [self.data_frame[cols].iloc[idxs].values]  # TODO: this is likely to fail as is
+                    data = self.data_frame[cols].iloc[idxs].values
                 else:
                     cols = [col]
                     data = self.data_frame[cols].iloc[idxs].values.flatten()

--- a/lightwood/encoder/categorical/onehot.py
+++ b/lightwood/encoder/categorical/onehot.py
@@ -68,12 +68,12 @@ class OneHotEncoder(BaseEncoder):
         unq_cats = np.unique([i for i in priming_data if i is not None]).tolist()
 
         if self.use_unknown:
-            log.info("Encoding UNKNOWN categories as index 0")
+            log.debug("Encoding UNKNOWN categories as index 0")
             self.map = {cat: indx + 1 for indx, cat in enumerate(unq_cats)}
             self.map.update({_UNCOMMON_WORD: 0})
             self.rev_map = {indx: cat for cat, indx in self.map.items()}
         else:
-            log.info("Encoding UNKNOWN categories as vector of all 0s")
+            log.debug("Encoding UNKNOWN categories as vector of all 0s")
             self.map = {cat: indx for indx, cat in enumerate(unq_cats)}
             self.rev_map = {indx: cat for cat, indx in self.map.items()}
 

--- a/lightwood/encoder/numeric/numeric.py
+++ b/lightwood/encoder/numeric/numeric.py
@@ -1,12 +1,15 @@
 import math
-from typing import Iterable, List, Union
+from typing import List, Union
+
 import torch
 import numpy as np
+import pandas as pd
 from torch.types import Number
+from type_infer.dtype import dtype
+
 from lightwood.encoder.base import BaseEncoder
 from lightwood.helpers.log import log
 from lightwood.helpers.general import is_none
-from type_infer.dtype import dtype
 
 
 class NumericEncoder(BaseEncoder):
@@ -28,13 +31,12 @@ class NumericEncoder(BaseEncoder):
         :param positive_domain: Forces the encoder to always output positive values
         """
         super().__init__(is_target)
-        self._type = data_type
         self._abs_mean = None
         self.positive_domain = positive_domain
         self.decode_log = False
         self.output_size = 4 if not self.is_target else 3
 
-    def prepare(self, priming_data: Iterable):
+    def prepare(self, priming_data: pd.Series):
         """
         "NumericalEncoder" uses a rule-based form to prepare results on training (priming) data. The averages etc. are taken from this distribution.
 
@@ -43,55 +45,36 @@ class NumericEncoder(BaseEncoder):
         if self.is_prepared:
             raise Exception('You can only call "prepare" once for a given encoder.')
 
-        value_type = 'int'
-        for number in priming_data:
-            if not is_none(number):
-                if int(number) != number:
-                    value_type = 'float'
-
-        self._type = value_type if self._type is None else self._type
-        non_null_priming_data = [x for x in priming_data if not is_none(x)]
-        self._abs_mean = np.mean(np.abs(non_null_priming_data))
+        self._abs_mean = priming_data.abs().mean()
         self.is_prepared = True
 
-    def encode(self, data: Iterable):
+    def encode(self, data: pd.Series):
         """
-        :param data: An iterable data structure containing the numbers to be encoded
-
+        :param data: A pandas series containing the numbers to be encoded
         :returns: A torch tensor with the representations of each number
         """
         if not self.is_prepared:
             raise Exception('You need to call "prepare" before calling "encode" or "decode".')
 
-        ret = []
-        for real in data:
-            try:
-                real = float(real)
-            except Exception:
-                real = None
-            if self.is_target:
-                # Will crash if ``real`` is not a float, this is fine, targets should always have a value
-                vector = [0] * 3
-                vector[0] = 1 if real < 0 and not self.positive_domain else 0
-                vector[1] = math.log(abs(real)) if abs(real) > 0 else -20
-                vector[2] = real / self._abs_mean
+        # todo: wrap with try/except to cover non-real edge cases
+        if not self.positive_domain:
+            sign = np.vectorize(lambda x: 0 if x < 0 else 1)(data)
+        else:
+            sign = np.zeros(len(data))
+        log_value = np.vectorize(lambda x: math.log(abs(x)) if abs(x) > 0 else -20)(data)
+        log_value = np.nan_to_num(log_value, nan=0, posinf=20, neginf=-20)
 
-            else:
-                vector = [0] * 4
-                try:
-                    if is_none(real):
-                        vector[0] = 0
-                    else:
-                        vector[0] = 1
-                        vector[1] = math.log(abs(real)) if abs(real) > 0 else -20
-                        vector[2] = 1 if real < 0 and not self.positive_domain else 0
-                        vector[3] = real / self._abs_mean
-                except Exception as e:
-                    vector = [0] * 4
-                    log.error(f'Can\'t encode input value: {real}, exception: {e}')
+        exp = np.vectorize(lambda x: x / self._abs_mean)(data)
+        exp = np.nan_to_num(exp, nan=0, posinf=20, neginf=-20)
 
-            ret.append(vector)
+        if self.is_target:
+            components = [sign, log_value, exp]
+        else:
+            # todo: if can't encode return 0s and log.error(f'Can\'t encode input value: {real}, exception: {e}')
+            nones = np.vectorize(lambda x: 1 if is_none(x) else 0)(data)
+            components = [sign, log_value, exp, nones]
 
+        ret = torch.Tensor(np.array(components)).T
         return torch.Tensor(ret)
 
     def decode(self, encoded_values: Union[List[Number], torch.Tensor], decode_log: bool = None) -> list:
@@ -112,40 +95,32 @@ class NumericEncoder(BaseEncoder):
             encoded_values = encoded_values.tolist()
 
         for vector in encoded_values:
-            if self.is_target:
-                if np.isnan(
-                        vector[0]) or vector[0] == float('inf') or np.isnan(
-                        vector[1]) or vector[1] == float('inf') or np.isnan(
-                        vector[2]) or vector[2] == float('inf'):
-                    log.error(f'Got weird target value to decode: {vector}')
-                    real_value = pow(10, 63)
-                else:
-                    if decode_log:
-                        sign = -1 if vector[0] > 0.5 else 1
-                        try:
-                            real_value = math.exp(vector[1]) * sign
-                        except OverflowError:
-                            real_value = pow(10, 63) * sign
-                    else:
-                        real_value = vector[2] * self._abs_mean
+            # check for none
+            if len(vector) == 4 and vector[-1] == 1:
+                ret.append(None)
+                continue
 
-                    if self.positive_domain:
-                        real_value = abs(real_value)
+            # edge case: divergence
+            elif np.isnan(vector[0]) or vector[0] == float('inf') or \
+                    np.isnan(vector[1]) or vector[1] == float('inf') or \
+                    np.isnan(vector[2]) or vector[2] == float('inf'):
 
-                    if self._type == 'int':
-                        real_value = int(real_value)
+                log.error(f'Got weird target value to decode: {vector}')
+                real_value = pow(10, 63)
 
+            elif decode_log:
+                sign = -1 if vector[0] < 0.5 else 1
+                try:
+                    real_value = math.exp(vector[1]) * sign
+                except OverflowError:
+                    real_value = pow(10, 63) * sign
             else:
-                if vector[0] < 0.5:
-                    ret.append(None)
-                    continue
+                real_value = vector[2] * self._abs_mean
 
-                real_value = vector[3] * self._abs_mean
+            if self.positive_domain:
+                real_value = abs(real_value)
 
-                if self._type == 'int':
-                    real_value = round(real_value)
-
-            if isinstance(real_value, torch.Tensor):
-                real_value = real_value.item()
+            # if isinstance(real_value, torch.Tensor):
+            #     real_value = real_value.item()
             ret.append(real_value)
         return ret

--- a/lightwood/encoder/numeric/numeric.py
+++ b/lightwood/encoder/numeric/numeric.py
@@ -73,8 +73,7 @@ class NumericEncoder(BaseEncoder):
             nones = np.vectorize(self._none_fn, otypes=[float])(data)
             components = [sign, log_value, norm, nones]
 
-        ret = torch.Tensor(np.asarray(components)).T
-        return torch.Tensor(ret)
+        return torch.Tensor(np.asarray(components)).T
 
     @staticmethod
     def _sign_fn(x: float) -> float:

--- a/lightwood/encoder/numeric/numeric.py
+++ b/lightwood/encoder/numeric/numeric.py
@@ -74,7 +74,7 @@ class NumericEncoder(BaseEncoder):
             nones = np.vectorize(lambda x: 1 if is_none(x) else 0)(data)
             components = [sign, log_value, exp, nones]
 
-        ret = torch.Tensor(np.array(components)).T
+        ret = torch.Tensor(np.asarray(components)).T
         return torch.Tensor(ret)
 
     def decode(self, encoded_values: Union[List[Number], torch.Tensor], decode_log: bool = None) -> list:

--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -54,8 +54,11 @@ class TsNumericEncoder(NumericEncoder):
                     return self.normalizers['__default'].abs_mean
 
             for i, group in enumerate(list(zip(*dependency_data.values()))):  # TODO: support multigroup
-                if group is not None:
-                    means = np.vectorize(_get_group_mean, otypes=[float])(group[0].values)
+                if group[0] is not None:
+                    try:
+                        means = np.vectorize(_get_group_mean, otypes=[float])(group[0].values)
+                    except Exception:
+                        print("!")
 
         def _norm_fn(x: float, mean: float) -> float:
             return x / mean

--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -54,6 +54,11 @@ class TsNumericEncoder(NumericEncoder):
                 if group[0] is not None:
                     means = np.vectorize(_get_group_mean, otypes=[float])(group[0].values)
 
+        if len(data.shape) > 1 and data.shape[1] > 1:
+            if len(means.shape) == 1:
+                means = np.expand_dims(means, 1)
+            means = np.repeat(means, data.shape[1], axis=1)
+
         def _norm_fn(x: float, mean: float) -> float:
             return x / mean
 

--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -107,14 +107,8 @@ class TsNumericEncoder(NumericEncoder):
                     if self.positive_domain:
                         real_value = abs(real_value)
 
-                    if self._type == 'int':
-                        real_value = int(round(real_value, 0))
-
             else:
                 real_value = vector[0] * self._abs_mean
-
-                if self._type == 'int':
-                    real_value = round(real_value)
 
             ret.append(real_value)
         return ret

--- a/lightwood/encoder/numeric/ts_numeric.py
+++ b/lightwood/encoder/numeric/ts_numeric.py
@@ -42,10 +42,7 @@ class TsNumericEncoder(NumericEncoder):
             means = np.full((len(data)), fill_value=self._abs_mean)
         else:
             # use global mean as default for novel series
-            try:
-                means = np.full((len(data)), fill_value=self.normalizers['__default'].abs_mean)
-            except Exception:
-                print('!')
+            means = np.full((len(data)), fill_value=self.normalizers['__default'].abs_mean)
 
             def _get_group_mean(group) -> float:
                 if (group, ) in self.normalizers:
@@ -55,10 +52,7 @@ class TsNumericEncoder(NumericEncoder):
 
             for i, group in enumerate(list(zip(*dependency_data.values()))):  # TODO: support multigroup
                 if group[0] is not None:
-                    try:
-                        means = np.vectorize(_get_group_mean, otypes=[float])(group[0].values)
-                    except Exception:
-                        print("!")
+                    means = np.vectorize(_get_group_mean, otypes=[float])(group[0].values)
 
         def _norm_fn(x: float, mean: float) -> float:
             return x / mean

--- a/lightwood/encoder/text/short.py
+++ b/lightwood/encoder/text/short.py
@@ -55,7 +55,7 @@ class ShortTextEncoder(BaseEncoder):
         unique_tokens = set()
         max_words_per_sent = 0
         for sent in no_null_sentences:
-            tokens = tokenize_text(sent)
+            tokens = list(tokenize_text(sent))
             max_words_per_sent = max(max_words_per_sent, len(tokens))
             for tok in tokens:
                 unique_tokens.add(tok)
@@ -78,7 +78,7 @@ class ShortTextEncoder(BaseEncoder):
         no_null_sentences = (x if x is not None else '' for x in column_data)
         output = []
         for sent in no_null_sentences:
-            tokens = tokenize_text(sent)
+            tokens = list(tokenize_text(sent))
             encoded_words = self.cae.encode(tokens)
             encoded_sent = self._combine_fn(encoded_words)
             output.append(torch.Tensor(encoded_sent))

--- a/lightwood/mixer/neural.py
+++ b/lightwood/mixer/neural.py
@@ -223,8 +223,8 @@ class Neural(BaseMixer):
             else:
                 if len(running_errors) >= self.loss_hist_len:
                     delta_mean = np.average([
-                        running_errors[-i - 1] - running_errors[-i] for i in range(len(running_errors)-1)],
-                        weights=[(1 / 2)**i for i in range(len(running_errors)-1)])
+                        running_errors[-i - 1] - running_errors[-i] for i in range(len(running_errors) - 1)],
+                        weights=[(1 / 2)**i for i in range(len(running_errors) - 1)])
                     if delta_mean >= 0:
                         break
                 elif (time.time() - self.started) > stop_after:

--- a/lightwood/mixer/neural.py
+++ b/lightwood/mixer/neural.py
@@ -166,7 +166,7 @@ class Neural(BaseMixer):
             else:
                 stop = True
 
-        best_loss_lr = lr_log[np.argmin(running_losses)]
+        best_loss_lr = lr_log[np.nanargmin(running_losses)]  # nanargmin ignores nans that may arise
         lr = best_loss_lr
         log.info(f'Found learning rate of: {lr}')
         return lr, best_model

--- a/lightwood/mixer/neural.py
+++ b/lightwood/mixer/neural.py
@@ -128,8 +128,8 @@ class Neural(BaseMixer):
         best_model = self.model
         stop = False
 
-        _, test_batch = next(enumerate(dl))
-        X, Y = test_batch
+        dl_iter = iter(dl)
+        X, Y = next(dl_iter)
         n_steps = 10
         cum_loss = 0
 

--- a/lightwood/mixer/neural.py
+++ b/lightwood/mixer/neural.py
@@ -250,8 +250,9 @@ class Neural(BaseMixer):
     def _init_net(self, ds: EncodedDs):
         self.net_class = DefaultNet if self.net_name == 'DefaultNet' else ArNet
 
-        net_kwargs = {'input_size': len(ds[0][0]),
-                      'output_size': len(ds[0][1]),
+        X, Y = ds[0]
+        net_kwargs = {'input_size': len(X),
+                      'output_size': len(Y),
                       'num_hidden': self.num_hidden,
                       'dropout': 0}
 

--- a/lightwood/mixer/neural.py
+++ b/lightwood/mixer/neural.py
@@ -142,7 +142,12 @@ class Neural(BaseMixer):
             optimizer = self._select_optimizer(self.model, lr=lr)
 
             for i in range(n_steps):
-                X, Y = next(dl_iter)
+                try:
+                    X, Y = next(dl_iter)
+                except StopIteration:
+                    dl_iter = iter(dl)
+                    X, Y = next(dl_iter)
+
                 X = X.to(self.model.device)
                 Y = Y.to(self.model.device)
 

--- a/lightwood/mixer/neural_ts.py
+++ b/lightwood/mixer/neural_ts.py
@@ -7,10 +7,8 @@ import pandas as pd
 
 import torch
 from torch import nn
-import torch_optimizer as ad_optim
 from torch.cuda.amp import GradScaler
 from torch.utils.data import DataLoader
-from torch.optim.optimizer import Optimizer
 
 from type_infer.dtype import dtype
 from lightwood.api.types import PredictionArguments
@@ -76,10 +74,6 @@ class NeuralTs(Neural):
 
         return criterion
 
-    def _select_optimizer(self) -> Optimizer:
-        optimizer = ad_optim.Ranger(self.model.parameters(), lr=self.lr)
-        return optimizer
-
     def _fit(self, train_data: EncodedDs, dev_data: EncodedDs) -> None:
         """
         :param train_data: The network is fit/trained on this
@@ -109,7 +103,7 @@ class NeuralTs(Neural):
         self.lr, self.model = self._find_lr(train_dl)
 
         # Keep on training
-        optimizer = self._select_optimizer()
+        optimizer = self._select_optimizer(lr=self.lr)
         criterion = self._select_criterion()
         scaler = GradScaler()
 

--- a/lightwood/mixer/neural_ts.py
+++ b/lightwood/mixer/neural_ts.py
@@ -100,10 +100,10 @@ class NeuralTs(Neural):
         # Find learning rate
         # keep the weights
         self._init_net(train_data)
-        self.lr, self.model = self._find_lr(train_dl)
+        self.lr, self.model = self._find_lr(train_data)
 
         # Keep on training
-        optimizer = self._select_optimizer(lr=self.lr)
+        optimizer = self._select_optimizer(self.model, lr=self.lr)
         criterion = self._select_criterion()
         scaler = GradScaler()
 

--- a/lightwood/mixer/random_forest.py
+++ b/lightwood/mixer/random_forest.py
@@ -14,7 +14,7 @@ from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 from type_infer.dtype import dtype
 from lightwood.helpers.log import log
 from lightwood.encoder.base import BaseEncoder
-from lightwood.data.encoded_ds import ConcatedEncodedDs, EncodedDs
+from lightwood.data.encoded_ds import EncodedDs, ConcatedEncodedDs
 from lightwood.mixer.base import BaseMixer
 from lightwood.api.types import PredictionArguments
 
@@ -203,7 +203,7 @@ class RandomForest(BaseMixer):
 
         :return: dataframe with predictions.
         """
-        data = ds.get_encoded_data(include_target=False)
+        data = ds.get_encoded_data(include_target=False).numpy()
 
         if self.is_classifier:
             predictions = self.model.predict_proba(data)

--- a/lightwood/mixer/random_forest.py
+++ b/lightwood/mixer/random_forest.py
@@ -33,8 +33,8 @@ class RandomForest(BaseMixer):
             target: str,
             dtype_dict: Dict[str, str],
             fit_on_dev: bool,
-            use_optuna: bool,
-            target_encoder: BaseEncoder
+            target_encoder: BaseEncoder,
+            use_optuna: bool = False,
     ):
         """
         The `RandomForest` mixer supports both regression and classification tasks. 
@@ -100,7 +100,6 @@ class RandomForest(BaseMixer):
         init_params = {
             'n_estimators': 50,
             'max_depth': 5,
-            'max_features': 1.,
             'bootstrap': True,
             'n_jobs': -1,
             'random_state': 0
@@ -128,15 +127,10 @@ class RandomForest(BaseMixer):
             else (mean_squared_error, 'predict')
 
         def objective(trial: trial_module.Trial):
-            criterion = trial.suggest_categorical("criterion",
-                                                  ["gini", "entropy"]) if self.is_classifier else 'squared_error'
+            criterion = trial.suggest_categorical("criterion", "gini") if self.is_classifier else 'squared_error'
 
             params = {
                 'n_estimators': trial.suggest_int('n_estimators', 2, 512),
-                'max_depth': trial.suggest_int('max_depth', 2, 15),
-                'min_samples_split': trial.suggest_int("min_samples_split", 2, 20),
-                'min_samples_leaf': trial.suggest_int("min_samples_leaf", 1, 20),
-                'max_features': trial.suggest_float("max_features", 0.1, 1),
                 'criterion': criterion,
             }
 

--- a/lightwood/mixer/regression.py
+++ b/lightwood/mixer/regression.py
@@ -89,7 +89,10 @@ class Regression(BaseMixer):
         """ # noqa
         X = []
         for x, _ in ds:
-            X.append(x.tolist())
+            entry = x.numpy()
+            if len(entry.shape) > 1:
+                entry = entry[0]
+            X.append(entry)
 
         Yh = self.model.predict(X)
 

--- a/lightwood/mixer/regression.py
+++ b/lightwood/mixer/regression.py
@@ -87,13 +87,7 @@ class Regression(BaseMixer):
 
         :returns: A dataframe cotaining the decoded predictions and (depending on the args) additional information such as the probabilites for each target class
         """ # noqa
-        X = []
-        for x, _ in ds:
-            entry = x.numpy()
-            if len(entry.shape) > 1:
-                entry = entry[0]
-            X.append(entry)
-
+        X = ds.get_encoded_data(include_target=False)
         Yh = self.model.predict(X)
 
         decoded_predictions = self.target_encoder.decode(torch.Tensor(Yh))

--- a/requirements_image.txt
+++ b/requirements_image.txt
@@ -1,2 +1,2 @@
-torchvision >=0.10.0,<0.11.0
+torchvision
 pillow >8.3.1

--- a/tests/unit_tests/encoder/numeric/test_numeric.py
+++ b/tests/unit_tests/encoder/numeric/test_numeric.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import pandas as pd
 import torch
 from lightwood.encoder.numeric import NumericEncoder
 from lightwood.encoder.numeric import TsNumericEncoder
@@ -16,31 +17,38 @@ def _pollute(array):
 
 class TestNumericEncoder(unittest.TestCase):
     def test_encode_and_decode(self):
-        data = [1, 1.1, 2, -8.6, None, 0]
+        data = pd.Series([1, 1.1, 2, -8.6, None, 0])
 
         encoder = NumericEncoder()
-
         encoder.prepare(data)
         encoded_vals = encoder.encode(data)
 
-        self.assertTrue(encoded_vals[1][1] > 0)
-        self.assertTrue(encoded_vals[2][1] > 0)
-        self.assertTrue(encoded_vals[3][1] > 0)
-        for i in range(0, 3):
-            self.assertTrue(encoded_vals[i][2] == 0)
-        self.assertTrue(encoded_vals[3][2] == 1)
-        self.assertTrue(encoded_vals[4][3] == 0)
+        # sign component check
+        self.assertTrue(encoded_vals[0][0] > 0)
+        self.assertTrue(encoded_vals[1][0] > 0)
+        self.assertTrue(encoded_vals[2][0] > 0)
+        self.assertTrue(encoded_vals[3][0] == 0)
 
-        decoded_vals = encoder.decode(encoded_vals)
-
-        for i in range(len(encoded_vals)):
-            if decoded_vals[i] is None:
-                self.assertTrue(decoded_vals[i] == data[i])
+        # none component check
+        for i in range(0, len(encoded_vals)):
+            if i != 4:
+                self.assertTrue(encoded_vals[i][-1] == 0)
             else:
-                np.testing.assert_almost_equal(round(decoded_vals[i], 10), round(data[i], 10))
+                self.assertTrue(encoded_vals[i][-1] == 1)
+
+        # exp component nan edge case check
+        self.assertTrue(encoded_vals[4][2] == 0)
+
+        # compare decoded v/s real
+        decoded_vals = encoder.decode(encoded_vals)
+        for decoded, real in zip(decoded_vals, data.tolist()):
+            if decoded is None:
+                self.assertTrue((real is None) or (real != real))
+            else:
+                np.testing.assert_almost_equal(round(decoded, 10), round(real, 10))
 
     def test_positive_domain(self):
-        data = [-1, -2, -100, 5, 10, 15]
+        data = pd.Series([-1, -2, -100, 5, 10, 15])
         for encoder in [NumericEncoder(), TsNumericEncoder()]:
             encoder.is_target = True        # only affects target values
             encoder.positive_domain = True
@@ -51,7 +59,7 @@ class TestNumericEncoder(unittest.TestCase):
                 self.assertTrue(val >= 0)
 
     def test_log_overflow_and_none(self):
-        data = list(range(-2000, 2000, 66))
+        data = pd.Series(list(range(-2000, 2000, 66)))
         encoder = NumericEncoder()
 
         encoder.is_target = True
@@ -72,10 +80,10 @@ class TestNumericEncoder(unittest.TestCase):
 
         # Prepare with the correct data and decode invalid data
         encoder = NumericEncoder()
-        encoder.prepare(data)
+        encoder.prepare(pd.Series(data))
         for array in invalid_data:
             # Make sure the encoding has no nans or infs
-            encoded_repr = encoder.encode(array)
+            encoded_repr = encoder.encode(pd.Series(array))
             assert not torch.isnan(encoded_repr).any()
             assert not torch.isinf(encoded_repr).any()
 
@@ -88,29 +96,17 @@ class TestNumericEncoder(unittest.TestCase):
         # Prepare with the invalid data and decode the valid data
         for array in invalid_data:
             encoder = NumericEncoder()
-            encoder.prepare(array)
+            encoder.prepare(pd.Series(array))
 
             # Make sure the encoding has no nans or infs
-            encoded_repr = encoder.encode(data)
+            encoded_repr = encoder.encode(pd.Series(array))
             assert not torch.isnan(encoded_repr).any()
             assert not torch.isinf(encoded_repr).any()
 
             # Make sure the invalid value is decoded as `None` and the rest as numbers
             decoded_repr = encoder.decode(encoded_repr)
-            for x in decoded_repr:
-                assert not is_none(x)
-
-        # Prepare with the invalid data and decode invalid data
-        for array in invalid_data:
-            encoder = NumericEncoder()
-            encoder.prepare(array)
-            # Make sure the encoding has no nans or infs
-            encoded_repr = encoder.encode(array)
-            assert not torch.isnan(encoded_repr).any()
-            assert not torch.isinf(encoded_repr).any()
-
-            # Make sure the invalid value is decoded as `None` and the rest as numbers
-            decoded_repr = encoder.decode(encoded_repr)
-            for x in decoded_repr[:-1]:
-                assert not is_none(x)
-            assert decoded_repr[-1] is None
+            for dec, real in zip(decoded_repr, array):
+                if is_none(real):
+                    assert is_none(dec)
+                else:
+                    assert not is_none(x) or x != 0.0

--- a/tests/unit_tests/encoder/numeric/test_numeric.py
+++ b/tests/unit_tests/encoder/numeric/test_numeric.py
@@ -45,7 +45,7 @@ class TestNumericEncoder(unittest.TestCase):
             if decoded is None:
                 self.assertTrue((real is None) or (real != real))
             else:
-                np.testing.assert_almost_equal(round(decoded, 10), round(real, 10))
+                np.testing.assert_almost_equal(round(decoded, 6), round(real, 6))
 
     def test_positive_domain(self):
         data = pd.Series([-1, -2, -100, 5, 10, 15])
@@ -69,7 +69,7 @@ class TestNumericEncoder(unittest.TestCase):
         encoder.decode(encoder.encode(data))
 
         for i in range(0, 70, 10):
-            encoder.decode([[0, pow(2, i), 0]])
+            encoder.decode(torch.Tensor([[0, pow(2, i), 0]]))
 
     def test_nan_encoding(self):
         # Generate some numbers


### PR DESCRIPTION
## Changelog
1. `EncodedDs.__getitem__` now retrieves rows from an "offline" cache that is populated at the end of the initialization method, instead of just-in-time. This enables encoders (which are assumed to be optimized, mostly there but some exceptions we're working on at the moment) to do batch encoding at a much faster rate.
2. Optimized some encoders with vectorized operations (see point 1): `NumericalEncoder`, `TsNumericEncoder`, `TsArrayNumericEncoder`
3. Reactivated Neural mixer's early stopping with a patience-based mechanism, and a learning rate search procedure with a standard range of options.
4. Deactivated RandomForest mixer's hyperparam optimization by default due to small loss in accuracy traded by a large speedup in training runtime.

## Effects
Lightwood becomes an order of magnitude faster across all ~50 benchmarked datasets (average speedup is ~7.5x, median is ~16.5x)