### PR TITLE
[ENH] Handle n_classes > 2 in binary encoder as unknowns

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'lightwood'
-__version__ = '23.5.1.1'
+__version__ = '23.6.2.0'
 __description__ = "Lightwood is a toolkit for automatic machine learning model building"
 __email__ = "community@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/encoder/categorical/binary.py
+++ b/lightwood/encoder/categorical/binary.py
@@ -49,7 +49,6 @@ class BinaryEncoder(BaseEncoder):
         self.output_size = 2
         self.encoder_class_type = str
         self.handle_unknown = handle_unknown
-        self.UNK_IDX = 2
 
         # Weight-balance info if encoder represents target
         self.target_weights = None
@@ -115,7 +114,7 @@ class BinaryEncoder(BaseEncoder):
         for idx, word in enumerate(column_data):
             index = self.map.get(word, None)
 
-            if index is None or index == self.UNK_IDX:
+            if index is None or index >= self.output_size:
                 pass  # any unknown value is ignored
             else:
                 ret[idx, index] = 1
@@ -141,7 +140,7 @@ class BinaryEncoder(BaseEncoder):
                 ret.append(_UNCOMMON_WORD)
             else:
                 idx = np.argmax(vector)
-                if idx == self.UNK_IDX:
+                if idx >= self.output_size:
                     ret.append(_UNCOMMON_WORD)  # known, but not either of the supported categories
                 else:
                     ret.append(self.rev_map[idx])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-type_infer ==0.0.9
-dataprep_ml ==0.0.8
-mindsdb-evaluator >=0.0.7
+type_infer >=0.0.10
+dataprep_ml >=0.0.9
+mindsdb-evaluator >=0.0.9
 numpy
 nltk >=3,<3.6
 python-dateutil >=2.8.1

--- a/tests/unit_tests/encoder/categorical/test_binary.py
+++ b/tests/unit_tests/encoder/categorical/test_binary.py
@@ -72,7 +72,7 @@ class TestBinary(unittest.TestCase):
         """ Ensure binary strictly enforces binary typing """
         data = ["apple", "apple", "orange", "banana", "apple", "orange"]
 
-        enc = BinaryEncoder()
+        enc = BinaryEncoder(handle_unknown='error')
         self.assertRaises(ValueError, enc.prepare, data)
 
     def test_check_probabilities(self):


### PR DESCRIPTION
The reason for this: due to sampling, categorical columns with weird distributions can be seen as binary by `type_infer`. This isn't really a bug, it's the nature of using samples for type inference. This happened recently during internal testing with the OpenML "micro mass" dataset.

Anyway, if this edge case triggers, our current implementation of the binary encoder will fail. This PR adds a slight fix so that it doesn't. The new (unseen) classes won't really map out to anything, so the user is still nudged towards overriding and using a multiclass encoder, but at least the predictor is able to finish training successfully.