### PR TITLE
Add support for Python 3.10 & 3.11

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E275,E402,F821,W503,W504,C408,W391
+ignore = E275,E402,F821,W503,W504,C408,W391,E721
 exclude = .git,__pycache__,docs,docssrc

--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8','3.9']
+        python-version: ["3.8","3.9","3.10","3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/lightwood/data/timeseries_transform.py
+++ b/lightwood/data/timeseries_transform.py
@@ -213,7 +213,7 @@ def _ts_infer_next_row(df: pd.DataFrame, ob: str) -> pd.DataFrame:
         delta = 1
 
     last_row[ob] += delta
-    new_df = df.append(last_row)
+    new_df = pd.concat([df, last_row], ignore_index=True)
     new_df.index = pd.DatetimeIndex(new_index)
     return new_df
 

--- a/lightwood/mixer/gluonts.py
+++ b/lightwood/mixer/gluonts.py
@@ -234,14 +234,20 @@ class GluonTSMixer(BaseMixer):
         for col in self.static_features_cat:
             df[col] = self.static_features_cat_encoders[col].transform(df[col].values.reshape(-1, 1))
 
+        static_features = []
+        if self.static_features_real:
+            static_features.extend(self.static_features_real)
+        if self.static_features_cat:
+            static_features.extend(self.static_features_cat)
+        static_features_df = df[static_features]
+
         ds = PandasDataset.from_long_dataframe(
             df,
             target=self.target,
-            item_id=gby,
+            item_id=gby[0],
             freq=freq,
             timestamp=oby_col_name,
-            feat_static_real=self.static_features_real if self.static_features_real else [],
-            feat_static_cat=self.static_features_cat if self.static_features_cat else [],
+            static_features=static_features_df
         )
         return ds
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ type_infer >=0.0.14
 dataprep_ml >=0.0.16
 mindsdb-evaluator >=0.0.10
 numpy
-nltk >=3,<3.6
-python-dateutil >=2.8.1
-pandas >=1.1.5, <1.5.0
+nltk >=3.8, <3.9
+python-dateutil >=2.8.2
+pandas >=2.0.0, <2.1.0
 schema >=0.6.8
 torch >=2.0.0, <2.1
 requests >=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-type_infer >=0.0.14
-dataprep_ml >=0.0.16
-mindsdb-evaluator >=0.0.10
+type_infer >=0.0.15
+dataprep_ml >=0.0.18
+mindsdb-evaluator >=0.0.11
 numpy
 nltk >=3.8, <3.9
 python-dateutil >=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ scipy >=1.5.4
 psutil >=5.7.0
 setuptools >=21.2.1
 wheel >=0.32.2
-scikit-learn >=1.0.0, <=1.0.2
+scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
 dill ==0.3.6
 sktime >=0.14.0,<0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-type_infer >=0.0.13
-dataprep_ml >=0.0.13
-mindsdb-evaluator >=0.0.9
+type_infer >=0.0.14
+dataprep_ml >=0.0.16
+mindsdb-evaluator >=0.0.10
 numpy
 nltk >=3,<3.6
 python-dateutil >=2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wheel >=0.32.2
 scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
 dill ==0.3.6
-sktime >=0.14.0,<0.21.0
+sktime >=0.21.0,<0.22.0
 statsforecast ==1.4.0
 torch_optimizer ==0.1.0
 black ==23.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wheel >=0.32.2
 scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
 dill ==0.3.6
-sktime >=0.14.0,<0.15.0
+sktime >=0.14.0,<0.21.0
 statsforecast ==1.4.0
 torch_optimizer ==0.1.0
 black ==23.3.0

--- a/requirements_extra_ts.txt
+++ b/requirements_extra_ts.txt
@@ -2,4 +2,4 @@ pystan==2.19.1.1
 prophet==1.1
 neuralforecast ==1.5.0
 mxnet >=1.6.0, <2.0.0
-gluonts >= 0.11.0, <0.12.0
+gluonts >= 0.13.2, <0.14.0

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8"
+    python_requires=">=3.8,<3.12"
 )

--- a/tests/integration/advanced/test_timeseries.py
+++ b/tests/integration/advanced/test_timeseries.py
@@ -46,8 +46,8 @@ class TestTimeseries(unittest.TestCase):
             for g in data[group].unique():
                 subframe = data[data[group] == g]
                 length = subframe.shape[0]
-                train = train.append(subframe[:int(length * train_ratio)])
-                test = test.append(subframe[int(length * train_ratio):])
+                train = pd.concat([train, subframe[:int(length * train_ratio)]], ignore_index=True)
+                test = pd.concat([test, subframe[int(length * train_ratio):]], ignore_index=True)
         else:
             train = data[:int(data.shape[0] * train_ratio)]
             test = data[int(data.shape[0] * train_ratio):]
@@ -506,7 +506,7 @@ class TestTimeseries(unittest.TestCase):
         data = pd.read_csv('tests/data/arrivals.csv')
         data = data[data['Country'].isin(['US', 'Japan'])]
         target_len = len(data)
-        data = data.append(data[data['Country'] == 'Japan']).reset_index(drop=True)  # force duplication of one series
+        data = pd.concat([data, data[data['Country'] == 'Japan']], ignore_index=True)  # force duplication of one series
         jai = json_ai_from_problem(data, ProblemDefinition.from_dict({'target': 'Traffic',
                                                                       'time_aim': 30,
                                                                       'timeseries_settings': {


### PR DESCRIPTION
This PR bumps a few packages to enable support for 3.10 and 3.11 (without having to compile any packages for which binaries are available).