### PR TITLE
fix type hint

### DIFF
--- a/lightwood/api/types.py
+++ b/lightwood/api/types.py
@@ -313,7 +313,7 @@ class JsonAI:
     analysis_blocks: Optional[List[Module]] = None
     timeseries_transformer: Optional[Module] = None
     timeseries_analyzer: Optional[Module] = None
-    accuracy_functions: Optional[List[str]] = None
+    accuracy_functions: Optional[List[Union[str, Module]]] = None
 
     @staticmethod
     def from_dict(obj: Dict):


### PR DESCRIPTION
In response to [mdb_evaluator#32](https://github.com/mindsdb/mindsdb_evaluator/pull/32).

Users can now do:

```python
jai = json_ai_from_problem(train_df,
                           ProblemDefinition.from_dict({'target': TARGET}))
jai.accuracy_functions = [{'module': 'precision_score', 'args': {'average': 'macro'}}]
```

To control the arguments passed into sklearn metrics.