### PR TITLE
Replace dill to pickle

### DIFF
--- a/lightwood/analysis/nc/icp.py
+++ b/lightwood/analysis/nc/icp.py
@@ -11,6 +11,10 @@ from lightwood.analysis.nc.base import RegressorMixin, ClassifierMixin, TSMixin
 from types import FunctionType
 
 
+def zerof(x):
+    return 0
+
+
 # -----------------------------------------------------------------------------
 # Base inductive conformal predictor
 # -----------------------------------------------------------------------------
@@ -39,7 +43,7 @@ class BaseIcp(BaseEstimator):
             self.condition = condition
             self.conditional = True
         else:
-            self.condition = lambda x: 0
+            self.condition = zerof
             self.conditional = False
 
     def fit(self, x: np.array, y: np.array) -> None:

--- a/lightwood/api/high_level.py
+++ b/lightwood/api/high_level.py
@@ -1,6 +1,6 @@
 import os
 from typing import Union
-import dill
+import pickle
 import pandas as pd
 from lightwood.api.types import JsonAI, ProblemDefinition
 from dataprep_ml.insights import statistical_analysis
@@ -134,7 +134,7 @@ def predictor_from_state(state_file: str, code: str = None) -> PredictorInterfac
     try:
         module_name = None
         with open(state_file, 'rb') as fp:
-            predictor = dill.load(fp)
+            predictor = pickle.load(fp)
     except Exception as e:
         module_name = str(e).lstrip("No module named '").split("'")[0]
         if code is None:
@@ -149,7 +149,7 @@ def predictor_from_state(state_file: str, code: str = None) -> PredictorInterfac
         gc.collect()
         _module_from_code(code, module_name)
         with open(state_file, 'rb') as fp:
-            predictor = dill.load(fp)
+            predictor = pickle.load(fp)
 
     return predictor
 

--- a/lightwood/api/predictor.py
+++ b/lightwood/api/predictor.py
@@ -1,4 +1,4 @@
-import dill
+import pickle
 from typing import Dict, Optional
 
 import pandas as pd
@@ -143,7 +143,7 @@ class PredictorInterface:
         :returns: Saves Predictor instance.
         """
         with open(file_path, "wb") as fp:
-            dill.dump(self, fp)
+            pickle.dump(self, fp, protocol=5)
 
     def export(self, file_path: str, json_ai_code: str) -> None:
         """
@@ -160,4 +160,4 @@ class PredictorInterface:
         predictor_dict['code'] = json_ai_code
 
         with open(file_path, "wb") as fp:
-            dill.dump(predictor_dict, fp)
+            pickle.dump(predictor_dict, fp, protocol=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ setuptools >=21.2.1
 wheel >=0.32.2
 scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
-dill ==0.3.6
 sktime >=0.21.0,<0.22.0
 statsforecast ==1.4.0
 torch_optimizer ==0.1.0


### PR DESCRIPTION
I noticed that `pickle` works much faster than `dill` when dump model.
Results for model dump (regular home_rentals):
```
def x():
    with open(file_path, "wb") as fp:
        pickle.dump(self, fp, protocol=5)
timeit.timeit(x, number=100)
0.31827622700075153

def y():
    with open(file_path, "wb") as fp:
        dill.dump(self, fp)
timeit.timeit(y, number=100)
2.572783964998962
```

Model load is equal:
```
def x():
    with open(state_file, 'rb') as fp:
        predictor = pickle.load(fp)
timeit.timeit(x, number=100)
0.26572044099884806
        
def y():
    with open(state_file, 'rb') as fp:
        predictor = dill.load(fp)
timeit.timeit(y, number=100)
0.26366778900046484
```

What is the reasons to use `dill`? If there is no reason, then @paxcema can you please confirm results on your pc, and if it also faster, then may be change `dill` to `pickle`?