### PR TITLE
Merged lightwood & release.yml

### DIFF
--- a/.github/workflows/ligthtwood.yml
+++ b/.github/workflows/ligthtwood.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - stable
       - staging
+  release:
+    types: [ published ]
 
 
 jobs:
@@ -46,7 +48,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/stable'
+    if: github.ref == 'refs/heads/stable' || github.event_name == 'release'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python


### PR DESCRIPTION
Merged the lightwood & release.yml, now deploy job in the lightwood yaml will also be executed if the release is published from any other branch.