### PR TITLE
[fix] Update statsforecast & sktime

### DIFF
--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -69,7 +69,7 @@ class SkTime(BaseMixer):
         :param use_stl: Whether to use de-trenders and de-seasonalizers fitted in the timeseries analysis phase.
         """  # noqa
         super().__init__(stop_after)
-        self.stable = True  # TODO remove, debug
+        self.stable = False
         self.prepared = False
         self.supports_proba = False
         self.target = target

--- a/lightwood/mixer/sktime.py
+++ b/lightwood/mixer/sktime.py
@@ -69,7 +69,7 @@ class SkTime(BaseMixer):
         :param use_stl: Whether to use de-trenders and de-seasonalizers fitted in the timeseries analysis phase.
         """  # noqa
         super().__init__(stop_after)
-        self.stable = False
+        self.stable = True  # TODO remove, debug
         self.prepared = False
         self.supports_proba = False
         self.target = target

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ wheel >=0.32.2
 scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
 dill ==0.3.6
-sktime >=0.21.0,<0.22.0
-statsforecast ==1.4.0
+sktime >=0.24.0,<0.25 .0
+statsforecast ~=1.6.0
 torch_optimizer ==0.1.0
 black ==23.3.0
 typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wheel >=0.32.2
 scikit-learn >=1.0.0
 dataclasses_json >=0.5.4
 dill ==0.3.6
-sktime >=0.24.0,<0.25 .0
+sktime >=0.24.0,<0.25.0
 statsforecast ~=1.6.0
 torch_optimizer ==0.1.0
 black ==23.3.0


### PR DESCRIPTION
Migrate to latest versions for compatibility with the rest of the MindsDB default ML engines.