### PR TITLE
Include extras requirements files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include requirements.txt
+include requirements*.txt


### PR DESCRIPTION
Fixes issues with torchvision missing from mindsdb docker files

Extras requirements files are not included in the lightwood pip package, so setup.py can't enumerate them, and when users install e.g. `lightwood[all_extras]` there are packages missing