### PR TITLE
Fixed the AdamW Import Error

### DIFF
--- a/lightwood/__about__.py
+++ b/lightwood/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'lightwood'
 __package_name__ = 'lightwood'
-__version__ = '25.2.2.0'
+__version__ = '25.3.3.0'
 __description__ = "Lightwood is a toolkit for automatic machine learning model building"
 __email__ = "community@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/lightwood/encoder/text/pretrained.py
+++ b/lightwood/encoder/text/pretrained.py
@@ -12,9 +12,9 @@ from transformers import (
     DistilBertModel,
     DistilBertForSequenceClassification,
     DistilBertTokenizerFast,
-    AdamW,
     get_linear_schedule_with_warmup,
 )
+from torch.optim import AdamW
 from sklearn.model_selection import train_test_split
 
 from lightwood.encoder.text.helpers.pretrained_helpers import TextEmbed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "lightwood"
-version = "25.2.2.0"
+version = "25.3.3.0"
 description = "Lightwood is Legos for Machine Learning."
 authors = ["MindsDB Inc."]
 license = "GPL-3.0-only"


### PR DESCRIPTION
This [PR](https://github.com/huggingface/transformers/pull/36177) from the `transformers` package removes their own implementation of `AdamW` and suggests the use of the version from `torch`.

Fixes https://linear.app/mindsdb/issue/BE-822/fix-broken-lightwood

This PR updates the import in `lightwood` to come from `torch`.